### PR TITLE
Reset GIT_DIR when calling npm

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -69,7 +69,7 @@ fi
 # install dependencies with npm
 echo "-----> Installing dependencies with npm $NPM_VERSION"
 cd $BUILD_DIR
-HOME="$BUILD_DIR" $VENDORED_NODE/bin/node $VENDORED_NPM/cli.js install 2>&1 | indent
+HOME="$BUILD_DIR" GIT_DIR=".git" $VENDORED_NODE/bin/node $VENDORED_NPM/cli.js install 2>&1 | indent
 if [ "${PIPESTATUS[*]}" != "0 0" ]; then
   echo " !     Failed to install dependencies with npm"
   exit 1


### PR DESCRIPTION
The GIT_DIR="." environment is leaking down into NPM.  This resets it to ".git" for NPM.

This issue affects specifying "git:" URIs for npm modules in package.json, and has been discussed here:
http://stackoverflow.com/questions/8243527/use-git-dependencies-in-with-npm-and-node-on-heroku
