### PR TITLE
README.md had typo for buildpacks documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Heroku buildpack: Node.js
 =========================
 
-This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpack) for Node.js apps.
+This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for Node.js apps.
 It uses [NPM](http://npmjs.org/) and [SCons](http://www.scons.org/).
 
 Usage


### PR DESCRIPTION
The link to the documentation was incorrect, it caused me a little confusion.
