### PR TITLE
Add version to the sample package.json shown in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can specify the versions of Node.js and npm your application requires using 
 
     {
       "name": "myapp",
+      "version": "0.0.1",
       "engines": {
         "node": ">=0.4.7 <0.7.0",
         "npm": ">=1.0.0"


### PR DESCRIPTION
Without this `myapp` throws the following when deployed to Heroku:

```
-----> Installing dependencies with npm
       npm ERR! Error: 'version' field missing
       npm ERR! 'version' Must be X.Y.Z, with an optional trailing tag.
       ...
       npm not ok
 !     Failed to install dependencies with npm
 !     Heroku push rejected, failed to compile Node.js app
```
