### PR TITLE
Install packages from clean slate when Node.js or NPM versions change

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -179,7 +179,6 @@ fi
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
 run_npm "install"
-run_npm "rebuild"
 echo "Dependencies installed" | indent
 
 # repack cache with new assets


### PR DESCRIPTION
I realize that this has been fixed already. Should have checked master again before spending more time on testing. Nevertheless, I thought I'd still send the pull request because there's another change too that might be useful.

That other change removes the now unnecessary `npm rebuild` step. I imagine it's original purpose was to resolve some issues with upgrading node while having native packages.
### How I tested

I created an app on Heroku called [warm-meadow-5745](http://warm-meadow-5745.herokuapp.com). It depends on the `redis` and `hiredis` packages. On each request it increments a counter in Redis and reports its new value back in the response.

Then I started changing package and engine versions around while checking whether the build process and the app works. It worked without any issues. Here's the commit log for the test application:

```
* b7ea885 (HEAD, heroku/master, master) Both Node.js and NPM versions change to latest supported
* f0ed90d Hiredis 0.1.13
* 3262fd8 Major Node.js upgrade
* fbdee6c Innocent change
* aa4a7d9 Both Node.js and NPM versions change
* be9265c NPM downgrade to 1.0.94
* 2e4d968 Added engines section
* 3ad972d Hiredis 0.1.12
* 128dd43 Hiredis 0.1.10
* fe41f0c Added Procfile
* aea47ae Visit counter
```

Sorry it took so long.
