### PR TITLE
Preserve ENV vars CPATH and CPPPATH (composable buildpacks)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -164,8 +164,8 @@ cp "$VENDORED_NODE/bin/node" "$BUILD_DIR/bin/node"
 # setting up paths for building
 PATH="$VENDORED_SCONS:$VENDORED_NODE/bin:$PATH"
 INCLUDE_PATH="$VENDORED_NODE/include"
-export CPATH="$INCLUDE_PATH"
-export CPPPATH="$INCLUDE_PATH"
+export CPATH="$INCLUDE_PATH:$CPATH"
+export CPPPATH="$INCLUDE_PATH:$CPPPATH"
 
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"


### PR DESCRIPTION
Not overriding these variables entirely in the nodejs buildpack allows for it to be easily composable with others that provide dependencies not specifiable in an npm `package.json` using the **heroku-buildpack-multi** without having to hack the nodejs buildpack itself.
