### PR TITLE
Add --no-bin-links to npm install to avoid deploy error

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -168,7 +168,7 @@ export CPPPATH="$INCLUDE_PATH"
 
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
-run_npm "install --production"
+run_npm "install --production --no-bin-links"
 run_npm "rebuild"
 echo "Dependencies installed" | indent
 


### PR DESCRIPTION
Please see http://stackoverflow.com/questions/13321231/fail-to-deploy-node-js-application-to-heroku for more context.
