### PR TITLE
Cat npm-debug.log on exit

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -101,6 +101,14 @@ function package_download() {
   curl $package -s -o - | tar xzf - -C $location
 }
 
+function cat_npm_debug_log() {
+  if [ -f $BUILD_DIR/npm-debug.log ]; then
+    cat $BUILD_DIR/npm-debug.log
+  fi
+}
+
+trap cat_npm_debug_log EXIT
+
 bootstrap_node=$(mktmpdir bootstrap_node)
 package_download "nodejs" "0.4.7" $bootstrap_node
 


### PR DESCRIPTION
This was a quick change I made in response to a user trying to get to the NPM debug output. It might need some work to improve how its stylized, but seems like it would be generally helpful to have in the default buildpack. Here's the related Stackoverflow question that prompted this:

http://stackoverflow.com/questions/15560037/heroku-troubleshooting-npm-errors-during-deploy-reading-a-tmp-file
