### PR TITLE
Clear caches before slug compilation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -180,6 +180,10 @@ run_npm "install --production"
 run_npm "rebuild"
 echo "Dependencies installed" | indent
 
+echo "-----> Cleaning up"
+rm -rf "$BUILD_DIR/.node-gyp"
+rm -rf "$BUILD_DIR/.npm"
+
 echo "-----> Building runtime environment"
 mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\"\$HOME/bin:\$HOME/node_modules/.bin:\$PATH\"" > $BUILD_DIR/.profile.d/nodejs.sh


### PR DESCRIPTION
node-gyp and NPM both cache resources required during `npm install`. They're not necessary at runtime and only increase the size of the slug, so let's clear them.
