### PR TITLE
npm install and rebuild steps aren't checked for error codes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# fail fast
+set -e
+set -o pipefail
+
 build_dir=$1
 cache_basedir=$2
 bp_dir=$(cd $(dirname $0); cd ..; pwd)


### PR DESCRIPTION
If `npm install` fails (because a module could not be found or built), the buildpack will continue merrily on its way and build (and deploy) an invalid slug.

The previous version of the buildpack ran `npm` commands via a function that looked like:

``` bash
function run_npm() {
  command="$1"

  cd $BUILD_DIR
  HOME="$BUILD_DIR" $VENDORED_NODE/bin/node $VENDORED_NPM/cli.js $command 2>&1 | indent

  if [ "${PIPESTATUS[*]}" != "0 0" ]; then
    echo " !     Failed to $command dependencies with npm"
    exit 1
  fi
}
```

Checking for `$?` would be simpler, but `indent` complicates things (`$?` ends up being `indent`'s return code).  Instead, `${PIPESTATUS[*]` is a space-delimited list of return codes for each command in the pipeline.  If `npm` fails, it will be `1 0` (or perhaps something other than `1`).
