### PR TITLE
Run `npm start` if no Procfile is present

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,12 @@
+#!/bin/sh
+# bin/release <build-dir>
+
+build_dir=$1
+
+if [ ! -e $build_dir/Procfile ]; then
+  cat << EOF
+---
+default_process_types:
+  web: npm start
+EOF
+fi


### PR DESCRIPTION
Fixes #49.
