### PR TITLE
use pipefail to force exit when `npm install` fails.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# fail fast
-set -e
-
-# enable debugging
-# set -x
+set -e            # fail fast
+set -o pipefail   # don't ignore piped exit codes
+# set -x          # enable debugging
 
 # Configure directories
 build_dir=$1

--- a/bin/test
+++ b/bin/test
@@ -66,6 +66,11 @@ testProfileCreated() {
   assertCapturedSuccess
 }
 
+testInvalidDependency() {
+  compile "invalid-dependency"
+  assertCapturedError 1 "not in the npm registry"
+}
+
 testNodeModulesCached() {
   cache=$(mktmpdir)
   compile "caching" $cache


### PR DESCRIPTION
Ensures pipey commands like `npm install` and `npm rebuild` are checked for error codes. Fixes https://github.com/heroku/heroku-buildpack-nodejs/pull/46
