### PR TITLE
Ensure npm scripts are run after restoring cache

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -63,21 +63,27 @@ if test -d $cache_dir; then
   status "package.json unchanged since last build"
   status "Restoring node_modules from cache"
   test -d $cache_dir/node_modules && cp -r $cache_dir/node_modules $build_dir/
-  # cp -r $cache_dir/vendor/node $build_dir/vendor/
-else
 
-  status "Installing dependencies"
-  npm install --production | indent
+  # If any scripts are defined in package.json, trigger them.
+  # https://npmjs.org/doc/misc/npm-scripts.html
+  hook_scripts=$(cat $build_dir/package.json | $bp_dir/vendor/jq -r .scripts)
+  if [ "$hook_scripts" != "null" ]; then
+    status "Running npm install to trigger script hooks"
+    npm install --production | indent
+  fi
+
+else
 
   status "Rebuilding dependencies"
   npm rebuild | indent
 
+  status "Installing dependencies"
+  npm install --production | indent
+
   status "Caching node_modules for future builds"
   rm -rf $cache_dir
   mkdir -p $cache_dir
-  # mkdir -p $cache_dir/vendor
   test -d $build_dir/node_modules && cp -r $build_dir/node_modules $cache_dir/
-  # cp -r $build_dir/vendor/node $cache_dir/vendor/
 fi
 
 # Update the PATH

--- a/bin/test
+++ b/bin/test
@@ -49,16 +49,6 @@ testUnstableVersion() {
   assertCapturedSuccess
 }
 
-# testInvalidVersion() {
-#   compile "invalid-node-version"
-#   assertCapturedError 1 "not found among available versions"
-# }
-
-# testInvalidVersion() {
-#   compile "invalid-dependency"
-#   assertCapturedError 1 "not in the npm registry"
-# }
-
 testProfileCreated() {
   compile "stable-node"
   assertCaptured "Building runtime environment"
@@ -78,7 +68,7 @@ testNodeModulesCached() {
   assertEquals "1" "$(ls -1 $cache/ | wc -l)"
 }
 
-# Pending
+# Pending Tests
 
 # testNodeBinariesAddedToPath() {
 # }
@@ -86,13 +76,35 @@ testNodeModulesCached() {
 # testNodeModulesRestoredFromCache() {
 # }
 
-## utils ########################################
+# TODO: Figure out how to test stuff like script hooks
+# when restoring node_modules from cache
+# testScriptHooks() {
+#   compile "script-hooks"
+#   assertCaptured "trigger script hooks"
+#   assertCaptured "preinstall hook message"
+#   assertCapturedSuccess
+# }
+
+# testWithoutScriptHooks() {
+#   compile "no-script-hooks"
+#   assertNotCaptured "trigger script hooks"
+#   assertCapturedSuccess
+# }
+
+# testInvalidVersion() {
+#   compile "invalid-node-version"
+#   assertCapturedError 1 "not found among available versions"
+# }
+
+
+
+# Utils
 
 pushd $(dirname 0) >/dev/null
-BASE=$(pwd)
+bp_dir=$(pwd)
 popd >/dev/null
 
-source ${BASE}/vendor/test-utils/test-utils
+source ${bp_dir}/vendor/test-utils/test-utils
 
 mktmpdir() {
   dir=$(mktemp -t testXXXXX)
@@ -102,19 +114,19 @@ mktmpdir() {
 }
 
 detect() {
-  capture ${BASE}/bin/detect ${BASE}/test/$1
+  capture ${bp_dir}/bin/detect ${bp_dir}/test/$1
 }
 
-COMPILE_DIR=""
+compile_dir=""
 
 compile() {
-  COMPILE_DIR=$(mktmpdir)
-  cp -r ${BASE}/test/$1/* ${COMPILE_DIR}/
-  capture ${BASE}/bin/compile ${COMPILE_DIR} ${2:-$(mktmpdir)}
+  compile_dir=$(mktmpdir)
+  cp -r ${bp_dir}/test/$1/* ${compile_dir}/
+  capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)}
 }
 
 assertFile() {
-  assertEquals "$1" "$(cat ${COMPILE_DIR}/$2)"
+  assertEquals "$1" "$(cat ${compile_dir}/$2)"
 }
 
-source ${BASE}/vendor/shunit2/shunit2
+source ${bp_dir}/vendor/shunit2/shunit2

--- a/test/no-script-hooks/README.md
+++ b/test/no-script-hooks/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/no-script-hooks/package.json
+++ b/test/no-script-hooks/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "~0.10.0"
+  }
+}

--- a/test/script-hooks/README.md
+++ b/test/script-hooks/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/script-hooks/package.json
+++ b/test/script-hooks/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "~0.10.0"
+  },
+  "scripts" : {
+    "preinstall" : "echo preinstall hook message"
+  }
+}


### PR DESCRIPTION
After the `node_modules` directory is restored from cache, `npm install --production` will be run if anything is present in package.json's `scripts` field.
