### PR TITLE
clear caches before slug compilation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -86,6 +86,10 @@ else
   test -d $build_dir/node_modules && cp -r $build_dir/node_modules $cache_dir/
 fi
 
+status "Cleaning up node-gyp and npm artifacts"
+rm -rf "$build_dir/.node-gyp"
+rm -rf "$build_dir/.npm"
+
 # Update the PATH
 status "Building runtime environment"
 mkdir -p $build_dir/.profile.d


### PR DESCRIPTION
This commit was stolen verbatim from @mojodna:

> node-gyp and NPM both cache resources required during `npm install`. They're not necessary at runtime and only increase the size of the slug, so let's clear them.
