### PR TITLE
Add processes from package.json to Procfile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,6 +89,13 @@ status "Cleaning up node-gyp and npm artifacts"
 rm -rf "$build_dir/.node-gyp"
 rm -rf "$build_dir/.npm"
 
+# Add package.json processes to Procfile
+processes=$(cat $build_dir/package.json | $bp_dir/vendor/jq '.processes.production')
+if [[ $processes != "null" ]]; then
+  status "Adding processes from package.json to Procfile"
+  echo $processes | $bp_dir/vendor/jq -r '. as $in | keys[] | "\(.): \($in[.])"' >> Procfile
+fi
+
 # Update the PATH
 status "Building runtime environment"
 mkdir -p $build_dir/.profile.d


### PR DESCRIPTION
If in my package.json I define processes for the production environment, add them to a `Procfile`.

``` js
{
  "name": "proc-pkg",
  "version": "0.0.0",
  "description": "Proof of concept for package.json process manifest",
  "main": "index.js",
  "author": "Jonathan Clem",
  "license": "MIT",
  "processes": {
    "production": {
      "web": "node web.js",
      "worker": "node worker.js"
    },
    "development": {
      "web": "node web.js",
      "worker": "node worker.js"
    }
  },
  "engines": {
    "node": "0.10.x"
  }
}
```
