### PR TITLE
Use `npm start` if Procfile is absent

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,6 +89,17 @@ status "Cleaning up node-gyp and npm artifacts"
 rm -rf "$build_dir/.node-gyp"
 rm -rf "$build_dir/.npm"
 
+# Add npm start to Procfile if necessary
+if [ ! -e $build_dir/Procfile ]; then
+  npm_start=$(cat $build_dir/package.json | $bp_dir/vendor/jq -r .scripts.start)
+
+  # If a start script is declared, add it to a Procfile
+  if [ "$npm_start" != "null" ]; then
+    status "No Procfile present; adding npm start script to Procfile"
+    echo "web: $npm_start" > $build_dir/Procfile
+  fi
+fi
+
 # Update the PATH
 status "Building runtime environment"
 mkdir -p $build_dir/.profile.d


### PR DESCRIPTION
This recent feedback from customer @aseemk echoes my sentiment:

> Procfile: you guys require this currently, which makes sense when you want to have multiple processes or tweak the command, etc. But I'm building an open-source project w/folks that we want to work across multiple PaaSes, and most other Node.js PaaSes support just defaulting to the common Node convention of `npm start`. It'd be nice if you guys defaulted to this also, if a Procfile wasn't present, for the simple/typical case of just one web process. (This'd lift the requirement for a Procfile for Node.js apps, just like is the case on Heroku for PHP apps.)
