### PR TITLE
Make bin/release comply with published Buildpack API

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
-echo "{}"
+cat << EOF
+addons: []
+default_process_types: {}
+EOF


### PR DESCRIPTION
From https://devcenter.heroku.com/articles/buildpack-api#bin-release:

```
This script returns a YAML formatted hash with two keys:
addons is a list of default addons to install.
default_process_types is a hash of default Procfile entries.
```

This pull request makes the buildpack's bin/release script comply with this specification by having it emit a hash with an empty list for 'addons' and an empty hash for 'default_process_types'.
