### PR TITLE
only prune when node_modules directory is restored from cache. Fixes #75

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,14 +62,14 @@ if test -d $build_dir/node_modules; then
 elif test -d $cache_dir/node_modules; then
   status "Restoring node_modules directory from cache"
   cp -r $cache_dir/node_modules $build_dir/
+
+  status "Pruning cached dependencies not specified in package.json"
+  npm prune 2>&1 | indent
 fi
 
 # Make npm output to STDOUT instead of its default STDERR
 status "Installing dependencies"
 npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
-
-status "Pruning dependencies not specified in package.json"
-npm prune 2>&1 | indent
 
 status "Caching node_modules directory for future builds"
 rm -rf $cache_dir


### PR DESCRIPTION
This change is intended to account for apps that:
- have `node_modules` checked into source control
- have dependencies in the `node_modules` directory that aren't specified in `package.json`

In short, checking in node_modules means no caching and no pruning.
