### PR TITLE
Set $NPM_REBUILD to rebuild cached deps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -65,6 +65,11 @@ elif test -d $cache_dir/node_modules; then
 
   status "Pruning cached dependencies not specified in package.json"
   npm prune 2>&1 | indent
+
+  if test $NPM_REBUILD; then
+    status "npm rebuild requested"
+    npm rebuild 2>&1 | indent
+  fi
 fi
 
 # Make npm output to STDOUT instead of its default STDERR


### PR DESCRIPTION
When composed with other buildpacks, underlying dependencies (e.g. [mapnik](https://github.com/mojodna/heroku-buildpack-mapnik) may have changed causing the cached binaries to link to incorrect versions. If prior buildpacks (or users) set `$NPM_REBUILD`, cached modules will be rebuilt.
