### PR TITLE
Persist npm's cache between builds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,9 @@ bp_dir=$(cd $(dirname $0); cd ..; pwd)
 # Load some convenience functions like status(), echo(), and indent()
 source $bp_dir/bin/common.sh
 
+# persist npm cache
+export npm_config_cache="$cache_dir/npm"
+
 # Output npm debug info on error
 trap cat_npm_debug_log ERR
 
@@ -75,9 +78,8 @@ status "Caching node_modules directory for future builds"
 rm -rf $cache_dir/node_modules
 test -d $build_dir/node_modules && cp -r $build_dir/node_modules $cache_dir/
 
-status "Cleaning up node-gyp and npm artifacts"
+status "Cleaning up node-gyp artifacts"
 rm -rf "$build_dir/.node-gyp"
-rm -rf "$build_dir/.npm"
 
 # If Procfile is absent, try to create one using `npm start`
 if [ ! -e $build_dir/Procfile ]; then


### PR DESCRIPTION
`$npm_config_cache` allows npm's cache to be location somewhere other than `$HOME/.npm`

This also changes cache operations to explicitly deal with `$cache_dir/node_modules` to allow composed buildpacks to effectively use the cache (otherwise the "Caching node_modules" step would stomp on other users of the cache).
