### PR TITLE
Blow away the cached node_modules directory instead of the entire cache.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -72,7 +72,7 @@ status "Installing dependencies"
 npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
 
 status "Caching node_modules directory for future builds"
-rm -rf $cache_dir
+rm -rf $cache_dir/node_modules
 mkdir -p $cache_dir
 test -d $build_dir/node_modules && cp -r $build_dir/node_modules $cache_dir/
 


### PR DESCRIPTION
Blow away the cached node_modules directory instead of the entire cache.

:boom: node_modules :boom:
