### PR TITLE
Namespaced caching and node runtime version tracking

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -61,12 +61,18 @@ if test -d $build_dir/node_modules; then
   status "Found existing node_modules directory; skipping cache"
   status "Rebuilding any native dependencies"
   npm rebuild 2>&1 | indent
-elif test -d $cache_dir/node_modules; then
+elif test -d $cache_dir/node/node_modules; then
   status "Restoring node_modules directory from cache"
-  cp -r $cache_dir/node_modules $build_dir/
+  cp -r $cache_dir/node/node_modules $build_dir/
 
   status "Pruning cached dependencies not specified in package.json"
   npm prune 2>&1 | indent
+
+  if test -f $cache_dir/node/.heroku/node-version && [ $(cat $cache_dir/node/.heroku/node-version) != "$node_version" ]; then
+    status "Node version changed since last build; rebuilding dependencies"
+    npm rebuild 2>&1 | indent
+  fi
+
 fi
 
 # Scope config var availability only to `npm install`
@@ -81,10 +87,26 @@ fi
   npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
 )
 
-status "Caching node_modules directory for future builds"
-rm -rf $cache_dir/node_modules
-mkdir -p $cache_dir
-test -d $build_dir/node_modules && cp -r $build_dir/node_modules $cache_dir/
+# Persist goodies like node-version in the slug
+mkdir -p $build_dir/.heroku
+
+# Save resolved node version in the slug for later reference
+echo $node_version > $build_dir/.heroku/node-version
+
+# Purge node-related cached content, being careful not to purge the top-level
+# cache, for the sake of heroku-buildpack-multi apps.
+rm -rf $cache_dir/node_modules # (for apps still on the older caching strategy)
+rm -rf $cache_dir/node
+mkdir -p $cache_dir/node
+
+# If app has a node_modules directory, cache it.
+if test -d $build_dir/node_modules; then
+  status "Caching node_modules directory for future builds"
+  cp -r $build_dir/node_modules $cache_dir/node
+fi
+
+# Copy goodies to the cache
+cp -r $build_dir/.heroku $cache_dir/node
 
 status "Cleaning up node-gyp and npm artifacts"
 rm -rf "$build_dir/.node-gyp"


### PR DESCRIPTION
Changes are as follows:
- Cache everything one level deeper (inside `$cache_dir/node`) to avoid clobbering cached artifacts from other buildpacks.
-  Store `node-version` file in new `.heroku` directory, in both the slug _and_ the cache.
- Run `npm rebuild` after restoring node_modules when current node version differs from last-deployed node version.

Sample build output:

```
-----> Pruning cached dependencies not specified in package.json
-----> Node version changed since last build; rebuilding dependencies
       express@3.3.8 /tmp/build_f2d52764-e024-458a-b842-267760370fa6/node_modules/express
       connect@2.8.8 /tmp/build_f2d52764-e024-458a-b842-267760370fa6/node_modules/express/node_modules/connect
       qs@0.6.5 /tmp/build_f2d52764-e024-458a-b842-267760370fa6/node_modules/express/node_modules/connect/node_modules/qs
       formidable@1.0.14 /tmp/build_f2d52764-e024-458a-b842-267760370fa6/node_modules/express/node_modules/connect/node_modules/formidable
       ...
```
