### PR TITLE
npm cert bug

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -78,6 +78,7 @@ fi
 # Handle npm's new cert bug
 # http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
 if [ ! -f "$build_dir/.npmrc" ]; then
+  status "Writing a custom .npmrc to circumvent npm bugs"
   echo "ca=" > "$build_dir/.npmrc"
 fi
 


### PR DESCRIPTION
Fix this: http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
