### PR TITLE
npm reverted to a backwards compatible cert

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -75,13 +75,6 @@ elif test -d $cache_dir/node/node_modules; then
 
 fi
 
-# Handle npm's new cert bug
-# http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
-if [ ! -f "$build_dir/.npmrc" ]; then
-  status "Writing a custom .npmrc to circumvent npm bugs"
-  echo "ca=" > "$build_dir/.npmrc"
-fi
-
 # Scope config var availability only to `npm install`
 (
   if [ -d "$env_dir" ]; then


### PR DESCRIPTION
This PR removes the npm cert bugfix from two months ago.

From http://blog.npmjs.org/post/78165272245/more-help-with-self-signed-cert-in-chain-and-npm

> We are rolling back to the older cert now, but since the registry is distributed by a global CDN this process is slower than we’d like, and we don’t want to break things (further) by rushing the process.

@rockbot @ceejbot @izs @seldo it should be safe to remove this workaround by now, right?
