### PR TITLE
how to not persist cached node_modules across builds?

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,7 +62,7 @@ if test -d $build_dir/node_modules; then
   npm rebuild 2>&1 | indent
 
 elif test -f $build_dir/.no-cache; then
-  status "Found .no-cache file; purging cache"
+  status "Found .no-cache file; ignoring cache"
 
   # Purge node/ directory instead of the entire cache,
   # for the sake of apps using multiple buildpacks
@@ -106,6 +106,11 @@ mkdir -p $build_dir/.heroku
 
 # Save resolved node version in the slug for later reference
 echo $node_version > $build_dir/.heroku/node-version
+
+# If an old build cache exists, explicitly let the user know it's being purged.
+if test -d $cache_dir/node; then
+  status "Purging cache from previous build"
+fi
 
 # Purge node-related cached content, being careful not to purge the top-level
 # cache, for the sake of heroku-buildpack-multi apps.


### PR DESCRIPTION
it's really annoying when nested deps aren't upgraded. at least don't use partial caches.
