### PR TITLE
Remove the default `ca` setting (now that npm's SSL cert is rolled back)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -75,13 +75,6 @@ elif test -d $cache_dir/node/node_modules; then
 
 fi
 
-# Handle npm's new cert bug
-# http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
-if [ ! -f "$build_dir/.npmrc" ]; then
-  status "Writing a custom .npmrc to circumvent npm bugs"
-  echo "ca=" > "$build_dir/.npmrc"
-fi
-
 # Scope config var availability only to `npm install`
 (
   if [ -d "$env_dir" ]; then


### PR DESCRIPTION
for #101, reverts #98

might be good to get rid of https://devcenter.heroku.com/changelog-items/432 as well as this seems to work fine under node 0.10.25 as well

demo app: https://github.com/dickeyxxx/heroku-test-1
