### PR TITLE
broken link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ heroku config:set BUILDPACK_URL=<your-github-url>
 heroku config:set BUILDPACK_URL=<your-github-url>#your-branch
 ```
 
-For more detailed information about testing buildpacks, see [CONTRIBUTING.md](CONTRIBUTING.md)
-
 
 Testing
 -------


### PR DESCRIPTION
not saying this line should be removed necessarily, but it is broken. Is there a good `CONTRIBUTING.md` file we could add in here? Maybe from another buildpack?
