### PR TITLE
don’t limit config vars to a subprocess

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,12 @@ source $bp_dir/bin/common.sh
 # Output npm debug info on error
 trap cat_npm_debug_log ERR
 
+# Make config vars avaiable to the build
+if [ -d "$env_dir" ]; then
+  status "Exporting config vars to environment"
+  export_env_dir $env_dir
+fi
+
 # Look in package.json's engines.node field for a semver range
 semver_range=$(cat $build_dir/package.json | $bp_dir/vendor/jq -r .engines.node)
 
@@ -82,17 +88,9 @@ if [ ! -f "$build_dir/.npmrc" ]; then
   echo "ca=" > "$build_dir/.npmrc"
 fi
 
-# Scope config var availability only to `npm install`
-(
-  if [ -d "$env_dir" ]; then
-    status "Exporting config vars to environment"
-    export_env_dir $env_dir
-  fi
-
-  status "Installing dependencies"
-  # Make npm output to STDOUT instead of its default STDERR
-  npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
-)
+status "Installing dependencies"
+# Make npm output to STDOUT instead of its default STDERR
+npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
 
 # Persist goodies like node-version in the slug
 mkdir -p $build_dir/.heroku


### PR DESCRIPTION
The current `compile` script limits config vars to a subprocess around `npm install`, but there are other commands in the `compile` script (such as npm prune) that are [executed outside of that context](https://github.com/heroku/heroku-buildpack-nodejs/blob/539550a90181c18c897a5208a31cf6509ba369f6/bin/compile#L69). This patch makes the more broadly available in the `compile` script.
