### PR TITLE
Bypass semver.io and s3pository when not necessary to complete build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,25 +23,31 @@ trap cat_npm_debug_log ERR
 # Look in package.json's engines.node field for a semver range
 semver_range=$(cat $build_dir/package.json | $bp_dir/vendor/jq -r .engines.node)
 
-# Resolve node version using semver.io
-node_version=$(curl --silent --get --data-urlencode "range=${semver_range}" https://semver.io/node/resolve)
-
-# Recommend using semver ranges in a safe manner
-if [ "$semver_range" == "null" ]; then
-  protip "Specify a node version in package.json"
-  semver_range=""
-elif [ "$semver_range" == "*" ]; then
-  protip "Avoid using semver ranges like '*' in engines.node"
-elif [ ${semver_range:0:1} == ">" ]; then
-  protip "Avoid using semver ranges starting with '>' in engines.node"
-fi
-
-# Output info about requested range and resolved node version
-if [ "$semver_range" == "" ]; then
-  status "Defaulting to latest stable node: $node_version"
+if [[ "$semver_range" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+  # Use specified Node version, bypass HTTP request to semver.io
+  node_version=$semver_range
+  status "Requested node version:  $node_version"
 else
-  status "Requested node range:  $semver_range"
-  status "Resolved node version: $node_version"
+  # Resolve node version using semver.io
+  node_version=$(curl --silent --get --data-urlencode "range=${semver_range}" https://semver.io/node/resolve)
+
+  # Recommend using semver ranges in a safe manner
+  if [ "$semver_range" == "null" ]; then
+    protip "Specify a node version in package.json"
+    semver_range=""
+  elif [ "$semver_range" == "*" ]; then
+    protip "Avoid using semver ranges like '*' in engines.node"
+  elif [ ${semver_range:0:1} == ">" ]; then
+    protip "Avoid using semver ranges starting with '>' in engines.node"
+  fi
+
+  # Output info about requested range and resolved node version
+  if [ "$semver_range" == "" ]; then
+    status "Defaulting to latest stable node: $node_version"
+  else
+    status "Requested node range:  $semver_range"
+    status "Resolved node version: $node_version"
+  fi
 fi
 
 


### PR DESCRIPTION
For context see: https://github.com/heroku/heroku-buildpack-nodejs/issues/129
1.   If `package.json` specifies the exact Node version number, use that version number, do not make HTTP request to `semver.io`. All other version specs are resolved against `semver.io`.
   
   The idea is to allow builds that target specific version the extra reliability of not depending on a separate service, so for the sake of simplicity, not extending this feature to unstable releases. Pre-release, RC, etc will all get resolved via `semver.io`.
2.  If the requested version of Node already available in `/vendor`, use that version, otherwise download the requested version.
   
   Determine if the previous build successfully installed Node, by checking that both the binary exist, and that it's executable.  If you're running in VM/container that already has the correct version of Node deployed, this eliminates dependency on `s3pository.heroku.com`.
