### PR TITLE
refactor(test): Make sure the cache contains a node folder

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -74,7 +74,7 @@ testNodeModulesCached() {
   cache=$(mktmpdir)
   compile "caching" $cache
   assertCaptured "Caching node"
-  assertEquals "1" "$(ls -1 $cache/ | wc -l)"
+  assertEquals "1" "$(ls -1 $cache/ | grep node | wc -l)"
 }
 
 testModulesCheckedIn() {


### PR DESCRIPTION
The `testNodeModulesCached` passes as long as there is one item in the `$cache` folder. Make sure it is the node folder. 