### PR TITLE
run npm install even with prebuild node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ This is the official [Heroku buildpack](http://devcenter.heroku.com/articles/bui
 
 Apps are built via one of four paths:
 
-1. A regular `npm install` (default scenario)
+1. A regular `npm install` (first build; default scenario)
 2. Copy existing `node_modules` from cache, then `npm prune`, then `npm install` (subsequent builds)
-3. No build (if package.json doesn't exist but server.js does)
-4. Run `npm run preinstall`, `npm rebuild`, `npm run postinstall` (`node_modules` are checked into source control)
+3. Skip dependencies (if package.json doesn't exist but server.js does)
+4. Skip cache, run `npm rebuild` before `npm install` (`node_modules` are checked into source control)
 
 You should only use #3 (omitting package.json) for quick tests or experiments.
 
 You should never use #4 - it's included for backwards-compatibility and will generate warnings.
-Checking in `node_modules` is an antipattern.
+**Checking in `node_modules` is an antipattern.**
 For more information, see [the npm docs](https://docs.npmjs.com/misc/faq#should-i-check-my-node_modules-folder-into-git-)
 
 For technical details, check out the [heavily-commented compile script](https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/compile).

--- a/bin/compile
+++ b/bin/compile
@@ -129,9 +129,9 @@ if [ "$modules_source" == "" ]; then
 
 elif [ $modules_source == "prebuilt" ]; then
   info "Rebuilding any native modules for this architecture"
-  npm run preinstall 2>&1 | indent
   npm rebuild 2>&1 | indent
-  npm run postinstall 2>&1 | indent
+  info "Installing any new modules"
+  npm install --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
 
 elif $use_cache; then
   info "Restoring node modules from cache"

--- a/bin/test
+++ b/bin/test
@@ -105,14 +105,12 @@ testBuildWithCache() {
 testModulesCheckedIn() {
   compile "modules-checked-in"
   assertCaptured "node_modules source: prebuilt"
-  assertCaptured "(preinstall script)"
   assertCaptured "Rebuilding any native modules for this architecture"
+  assertCaptured "(preinstall script)"
+  assertCaptured "Installing any new modules"
   assertCaptured "(postinstall script)"
   assertNotCaptured "Restoring node modules"
   assertNotCaptured "Pruning unused dependencies"
-  assertNotCaptured "Installing any new modules"
-  assertNotCaptured "Installing node modules"
-  assertNotCaptured "Deduping dependency tree"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
For backwards compatibility. Some users don't realize they're checking in node_modules so they rely on the `npm install` step to update their dependency tree with current dependencies. Needs more warnings, this is a huge cause of problems.