### PR TITLE
avoid updating node_engine state

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -55,11 +55,10 @@ warn_node_modules "$modules_source"
 
 head "Installing binaries"
 if [ "$iojs_engine" == "" ]; then
-  install_node
+  install_node "$node_engine"
 else
-  install_iojs
+  install_iojs "$iojs_engine"
 fi
-node_engine=`node --version`
 install_npm
 
 ####### Build the project's dependencies


### PR DESCRIPTION
Instead of changing state, let's leave as much state constant as possible and just read from `node --version` for the caching mechanism.