### PR TITLE
Allow overriding `$build_dir`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,11 +10,17 @@ set -o posix      # more strict failures in subshells
 
 # Configure directories
 build_dir=$1
+
+if ! [ -z "$NODE_DIRECTORY" ]; then
+  build_dir="$1/$NODE_DIRECTORY"
+fi
+
 cache_dir=$2
 env_dir=$3
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/node
+
 warnings=$(mktemp)
 
 # Load dependencies

--- a/bin/detect
+++ b/bin/detect
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-if [ -f $1/package.json ]; then
+build_dir=$1
+
+if ! [ -z "$NODE_DIRECTORY" ]; then
+  build_dir="$1/$NODE_DIRECTORY"
+fi
+
+if [ -f $build_dir/package.json ]; then
   echo "Node.js" && exit 0
-elif [ -f $1/server.js ]; then
+elif [ -f $build_dir/server.js ]; then
   echo "Node.js" && exit 0
 else
   echo "no" && exit 1


### PR DESCRIPTION
While [deploying `ember-cli-rails` projects to heroku][readme] (https://github.com/rwz/ember-cli-rails/issues/33#issuecomment-73264887) , we've felt the pain of lengthy deploys and a lack of caching.

This can be attributed to the fact that we're using a workaround root `package.json`.

This `package.json` is usually blank, and is simply in place to make the buildpacke `bin/detect` as node. By leaving it blank and having custom tasks to handle installs from a `package.json` in a sub directory (e.g. `./app/frontend/package.json`), we seem to be forfeiting caching.

This PR would enable projects to specify the sub-directory to treat as the node root. This could be declared by the`NODE_DIRECTORY` environment variable (e.g. `NODE_DIRECTORY=app/frontend`).

This is currently impossbile, as the `bin/detect` script doesn't have access to the `env_dir`, so `bin/detect` can't alter the location of its `$build_dir`.

Outside of checking for `**/package.json` in `bin/detect`, is there anything we can do?

[readme]: https://github.com/rwz/ember-cli-rails/blob/8a857fc60d7df1bf5e07750b7be353b99cf07eae/README.md#heroku