### PR TITLE
fix(README): heroku buildpack:set not config:set

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For most Node.js apps this buildpack should work just fine.
 If, however, you're unable to deploy using this new version of the buildpack, you can get your app working again by locking it to the previous version:
 
 ```
-heroku config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-nodejs#v63 -a my-app
+heroku buildpack:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-nodejs#v63 -a my-app
 git commit -am "empty" --allow-empty
 git push heroku master
 ```


### PR DESCRIPTION
`heroku config:set` wasn't enough to change the buildpack if you already had one set. Changed it to `heroku buildpack:set` to match the docs here: https://devcenter.heroku.com/articles/buildpacks