### PR TITLE
Optionally split src_dir to build_dir

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,11 +9,14 @@ set -o posix      # more strict failures in subshells
 set -x          # enable debugging
 
 # Configure directories
-build_dir=$PWD
-src_dir=$1
+build_dir=$1
 cache_dir=$2
 env_dir=$3
-subdir_dir=$4
+if [[ ! -z $4 ]]; then
+    src_dir=$4
+else
+    src_dir=$build_dir
+fi
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/node
@@ -42,7 +45,7 @@ cd $src_dir
 read_current_state
 show_current_state
 
-cd $old_pwd
+cd $build_dir
 
 if [ "$iojs_engine" == "" ]; then
   warn_node_engine "$node_engine"

--- a/bin/compile
+++ b/bin/compile
@@ -19,6 +19,11 @@ heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/node
 warnings=$(mktemp)
 
+echo "build_dir=$build_dir"
+echo "src_dir=$src_dir"
+echo "cache_dir=$cache_dir"
+echo "env_dir=$env_dir"
+
 # Load dependencies
 source $bp_dir/lib/common.sh
 source $bp_dir/lib/build.sh
@@ -59,7 +64,7 @@ install_npm
 ####### Build the project's dependencies
 
 head "Building dependencies"
-cd $build_dir
+cd $src_dir
 build_dependencies
 
 ####### Create a Procfile if possible

--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,8 @@ set -o posix      # more strict failures in subshells
 set -x          # enable debugging
 
 # Configure directories
-build_dir=$1
+build_dir=$PWD
+src_dir=$1
 cache_dir=$2
 env_dir=$3
 subdir_dir=$4
@@ -32,10 +33,7 @@ trap build_failed ERR
 ####### Determine current state
 
 head "Reading application state"
-old_pwd=$PWD
-if [[ ! -z $subdir_dir ]]; then
-    cd $subdir_dir
-fi
+cd $src_dir
 read_current_state
 show_current_state
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,9 +13,9 @@ build_dir=$1
 cache_dir=$2
 env_dir=$3
 if [[ ! -z $4 ]]; then
-    sub_dir=""
-else
     sub_dir=$4
+else
+    sub_dir=""
 fi
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku

--- a/bin/compile
+++ b/bin/compile
@@ -70,8 +70,9 @@ install_npm
 
 head "Building dependencies"
 cd $src_dir
-build_dependencies
 install_gulp
+build_dependencies
+
 
 ####### Create a Procfile if possible
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,10 +13,11 @@ build_dir=$1
 cache_dir=$2
 env_dir=$3
 if [[ ! -z $4 ]]; then
-    sub_dir=$4
+    sub_dir=/$4
 else
     sub_dir=""
 fi
+src_dir=$build_dir$sub_dir
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/node
@@ -24,6 +25,7 @@ warnings=$(mktemp)
 
 echo "-----> build_dir=$build_dir"
 echo "-----> sub_dir=$sub_dir"
+echo "-----> src_dir=$src_dir"
 echo "-----> cache_dir=$cache_dir"
 echo "-----> env_dir=$env_dir"
 
@@ -41,7 +43,7 @@ trap build_failed ERR
 ####### Determine current state
 
 head "Reading application state"
-cd $build_dir/$sub_dir
+cd $src_dir
 read_current_state
 show_current_state
 
@@ -67,13 +69,13 @@ install_npm
 ####### Build the project's dependencies
 
 head "Building dependencies"
-cd $build_dir/$sub_dir
+cd $src_dir
 build_dependencies
 
 ####### Create a Procfile if possible
 
 head "Checking startup method"
-ensure_procfile "$start_method" "$build_dir"
+ensure_procfile "$start_method" "$src_dir"
 warn_start "$start_method"
 
 ####### Finalize the build

--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,7 @@ set -x          # enable debugging
 build_dir=$1
 cache_dir=$2
 env_dir=$3
+subdir_dir=$4
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/node
@@ -31,8 +32,14 @@ trap build_failed ERR
 ####### Determine current state
 
 head "Reading application state"
+old_pwd=$PWD
+if [[ ! -z $subdir_dir ]]; then
+    cd $subdir_dir
+fi
 read_current_state
 show_current_state
+
+cd $old_pwd
 
 if [ "$iojs_engine" == "" ]; then
   warn_node_engine "$node_engine"

--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ env_dir=$3
 if [[ ! -z $4 ]]; then
     sub_dir=$4
 else
-    sub_dir=$build_dir
+    sub_dir=""
 fi
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku

--- a/bin/compile
+++ b/bin/compile
@@ -71,6 +71,7 @@ install_npm
 head "Building dependencies"
 cd $src_dir
 build_dependencies
+install_gulp
 
 ####### Create a Procfile if possible
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,9 +13,9 @@ build_dir=$1
 cache_dir=$2
 env_dir=$3
 if [[ ! -z $4 ]]; then
-    src_dir=$4
+    sub_dir=$4
 else
-    src_dir=$build_dir
+    sub_dir=$build_dir
 fi
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku
@@ -23,7 +23,7 @@ mkdir -p $heroku_dir/node
 warnings=$(mktemp)
 
 echo "build_dir=$build_dir"
-echo "src_dir=$src_dir"
+echo "sub_dir=$sub_dir"
 echo "cache_dir=$cache_dir"
 echo "env_dir=$env_dir"
 
@@ -41,7 +41,7 @@ trap build_failed ERR
 ####### Determine current state
 
 head "Reading application state"
-cd $src_dir
+cd $build_dir$sub_dir
 read_current_state
 show_current_state
 
@@ -67,7 +67,7 @@ install_npm
 ####### Build the project's dependencies
 
 head "Building dependencies"
-cd $src_dir
+cd $build_dir$sub_dir
 build_dependencies
 
 ####### Create a Procfile if possible

--- a/bin/compile
+++ b/bin/compile
@@ -13,9 +13,9 @@ build_dir=$1
 cache_dir=$2
 env_dir=$3
 if [[ ! -z $4 ]]; then
-    sub_dir=$4
-else
     sub_dir=""
+else
+    sub_dir=$4
 fi
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 heroku_dir=$build_dir/.heroku

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ trap build_failed ERR
 ####### Determine current state
 
 head "Reading application state"
-cd $build_dir$sub_dir
+cd $build_dir/$sub_dir
 read_current_state
 show_current_state
 

--- a/bin/compile
+++ b/bin/compile
@@ -22,10 +22,10 @@ heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/node
 warnings=$(mktemp)
 
-echo "build_dir=$build_dir"
-echo "sub_dir=$sub_dir"
-echo "cache_dir=$cache_dir"
-echo "env_dir=$env_dir"
+echo "-----> build_dir=$build_dir"
+echo "-----> sub_dir=$sub_dir"
+echo "-----> cache_dir=$cache_dir"
+echo "-----> env_dir=$env_dir"
 
 # Load dependencies
 source $bp_dir/lib/common.sh
@@ -67,7 +67,7 @@ install_npm
 ####### Build the project's dependencies
 
 head "Building dependencies"
-cd $build_dir$sub_dir
+cd $build_dir/$sub_dir
 build_dependencies
 
 ####### Create a Procfile if possible

--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ set -o errexit    # always exit on error
 set -o errtrace   # trap errors in functions as well
 set -o pipefail   # don't ignore exit codes when piping output
 set -o posix      # more strict failures in subshells
-# set -x          # enable debugging
+set -x          # enable debugging
 
 # Configure directories
 build_dir=$1

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -121,6 +121,7 @@ install_node() {
   # Move node (and npm) into .heroku/node and make them executable
   echo "remove $heroku_dir/node"
   rm -rfv $heroku_dir/node
+  mkdir -p $heroku_dir/node
   mv /tmp/node-v$node_engine-linux-x64/* $heroku_dir/node
   chmod +x $heroku_dir/node/bin/*
   PATH=$heroku_dir/node/bin:$PATH

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -176,10 +176,12 @@ function build_dependencies() {
     info "Rebuilding any native modules for this architecture"
     npm rebuild 2>&1 | indent
     info "Installing any new modules"
+    cd $src_dir
     npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
 
   else
     info "Installing node modules"
+    cd $src_dir
     npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
   fi
 }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -183,7 +183,7 @@ function build_dependencies() {
     info "Installing node modules"
     cd $src_dir
     # npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
-    npm install --unsafe-perm 2>&1 | indent
+    npm install --dev 2>&1 | indent
   fi
 }
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -337,7 +337,7 @@ install_gulp() {
   # Check and run gulp
   if [ -f $src_dir/gulpfile.js ]; then
     # Install gulp locally
-    echo "-----> Found gulpfile, installing heroku"
+    echo "-----> Found gulpfile, installing gulp"
     npm install gulp
   else
     echo "-----> No gulpfile found"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -119,6 +119,7 @@ install_node() {
   curl $node_url -s -o - | tar xzf - -C /tmp
 
   # Move node (and npm) into .heroku/node and make them executable
+  rm -rfv $heroku_dir/node
   mv /tmp/node-v$node_engine-linux-x64/* $heroku_dir/node
   chmod +x $heroku_dir/node/bin/*
   PATH=$heroku_dir/node/bin:$PATH

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -335,19 +335,11 @@ write_user_cache() {
 install_gulp() {
   #https://github.com/appstack/heroku-buildpack-nodejs-gulp/blob/master/bin/compile
   # Check and run gulp
-  (
-    if [ -f $src_dir/gulpfile.js ]; then
-      # get the env vars
-      if [ -d "$env_dir" ]; then
-        status "Exporting config vars to environment"
-        export_env_dir $env_dir
-      fi
-
-      # Install gulp locally
-      echo "-----> Found gulpfile, installing heroku"
-      npm install gulp
-    else
-      echo "-----> No gulpfile found"
-    fi
-  )
+  if [ -f $src_dir/gulpfile.js ]; then
+    # Install gulp locally
+    echo "-----> Found gulpfile, installing heroku"
+    npm install gulp
+  else
+    echo "-----> No gulpfile found"
+  fi
 }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -182,7 +182,8 @@ function build_dependencies() {
   else
     info "Installing node modules"
     cd $src_dir
-    npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+    # npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
+    npm install --unsafe-perm 2>&1 | indent
   fi
 }
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -119,6 +119,7 @@ install_node() {
   curl $node_url -s -o - | tar xzf - -C /tmp
 
   # Move node (and npm) into .heroku/node and make them executable
+  echo "remove $heroku_dir/node"
   rm -rfv $heroku_dir/node
   mv /tmp/node-v$node_engine-linux-x64/* $heroku_dir/node
   chmod +x $heroku_dir/node/bin/*

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -183,7 +183,7 @@ function build_dependencies() {
     info "Installing node modules"
     cd $src_dir
     # npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
-    npm install --dev 2>&1 | indent
+    npm install --quiet 2>&1 | indent
   fi
 }
 
@@ -338,7 +338,7 @@ install_gulp() {
   if [ -f $src_dir/gulpfile.js ]; then
     # Install gulp locally
     echo "-----> Found gulpfile, installing gulp"
-    npm install gulp
+    npm install gulp  --quiet
   else
     echo "-----> No gulpfile found"
   fi

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -330,3 +330,24 @@ write_user_cache() {
     done
   fi
 }
+
+
+install_gulp() {
+  #https://github.com/appstack/heroku-buildpack-nodejs-gulp/blob/master/bin/compile
+  # Check and run gulp
+  (
+    if [ -f $src_dir/gulpfile.js ]; then
+      # get the env vars
+      if [ -d "$env_dir" ]; then
+        status "Exporting config vars to environment"
+        export_env_dir $env_dir
+      fi
+
+      # Install gulp locally
+      echo "-----> Found gulpfile, installing heroku"
+      npm install gulp
+    else
+      echo "-----> No gulpfile found"
+    fi
+  )
+}


### PR DESCRIPTION
Hello

Here is the modification I have done to node buildpack in order to build my project. I use a modified version of heroku-buildpack-multi that support building projects that are in sub folders to the build directory (https://github.com/Stibbons/heroku-buildpack-multi-subdir).

In other word, I simply allow to build outside of the source directory. build_dir is where the .heroku directory will be generated. src_dir is where the package.json file is. Of course, this is optional, the default is still build_dir = src_dir.
