### PR TITLE
use bin/release instead of Procfile

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
+default_process_types() {
+  local bp_dir=$(cd $(dirname $0); cd ..; pwd)
+  local file="$bp_dir/default_process_types"
+  local result="default_process_types: {}"
+  if [ -f $file ]; then
+    result="default_process_types:\n  $(cat $bp_dir/default_process_types)"
+    rm $file
+  fi
+  echo -e "$result"
+}
+
 cat << EOF
 addons: []
-default_process_types: {}
+$(default_process_types)
 EOF

--- a/bin/release
+++ b/bin/release
@@ -2,10 +2,10 @@
 # bin/release <build-dir>
 default_process_types() {
   local bp_dir=$(cd $(dirname $0); cd ..; pwd)
-  local file="$bp_dir/default_process_types"
+  local file="/tmp/default_process_types"
   local result="default_process_types: {}"
   if [ -f $file ]; then
-    result="default_process_types:\n  $(cat $bp_dir/default_process_types)"
+    result="default_process_types:\n  $(cat $file)"
     rm $file
   fi
   echo -e "$result"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -198,10 +198,10 @@ ensure_procfile() {
     info "Procfile created during build"
   elif [ "$start_method" == "npm start" ]; then
     info "No Procfile; Adding default process type 'web: npm start'"
-    echo "web: npm start" > $bp_dir/default_process_types
+    echo "web: npm start" > /tmp/default_process_types
   elif [ "$start_method" == "server.js" ]; then
     info "No Procfile; Adding default process type 'web: node server.js'"
-    echo "web: node server.js" > $bp_dir/default_process_types
+    echo "web: node server.js" > /tmp/default_process_types
   else
     info "None found"
   fi

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -197,11 +197,11 @@ ensure_procfile() {
   elif test -f $build_dir/Procfile; then
     info "Procfile created during build"
   elif [ "$start_method" == "npm start" ]; then
-    info "No Procfile; Adding 'web: npm start' to new Procfile"
-    echo "web: npm start" > $build_dir/Procfile
+    info "No Procfile; Adding default process type 'web: npm start'"
+    echo "web: npm start" > $bp_dir/default_process_types
   elif [ "$start_method" == "server.js" ]; then
-    info "No Procfile; Adding 'web: node server.js' to new Procfile"
-    echo "web: node server.js" > $build_dir/Procfile
+    info "No Procfile; Adding default process type 'web: node server.js'"
+    echo "web: node server.js" > $bp_dir/default_process_types
   else
     info "None found"
   fi

--- a/test/run
+++ b/test/run
@@ -244,15 +244,20 @@ testUserConfig() {
 testProcfile() {
   compile "procfile-present-only"
   assertCaptured "Start mechanism:     Procfile"
-  assertNotCaptured "new Procfile"
+  assertNotCaptured "Adding default process type"
+  assertCapturedSuccess
+  release "procfile-present-only"
+  assertCaptured "default_process_types: {}"
   assertCapturedSuccess
 }
 
 testProcfileAbsentNpmStartPresent() {
   compile "procfile-absent-npm-start-present"
   assertCaptured "Start mechanism:     npm start"
-  assertCaptured "Adding 'web: npm start' to new Procfile"
-  assertFile "web: npm start" "Procfile"
+  assertCaptured "Adding default process type 'web: npm start'"
+  assertCapturedSuccess
+  release "procfile-absent-npm-start-present"
+  assertCaptured "web: npm start"
   assertCapturedSuccess
 }
 
@@ -262,6 +267,9 @@ testProcfileAbsentNpmStartAbsent() {
   assertCaptured "None found"
   assertNotCaptured "new Procfile"
   assertCapturedSuccess
+  release "procfile-absent-npm-start-absent"
+  assertCaptured "default_process_types: {}"
+  assertCapturedSuccess
 }
 
 testDynamicProcfile() {
@@ -269,21 +277,28 @@ testDynamicProcfile() {
   assertCaptured "Procfile created during build"
   assertFileContains "web: node index.js customArg" "${compile_dir}/Procfile"
   assertCapturedSuccess
+  release "dynamic-procfile"
+  assertCaptured "default_process_types: {}"
+  assertCapturedSuccess
 }
 
 testProcfileAbsentServerPresent() {
   compile "procfile-absent-server-present"
   assertCaptured "Start mechanism:     server.js"
-  assertCaptured "'web: node server.js' to new Procfile"
-  assertFile "web: node server.js" "Procfile"
+  assertCaptured "Adding default process type 'web: node server.js'"
+  assertCapturedSuccess
+  release "procfile-absent-server-present"
+  assertCaptured "web: node server.js"
   assertCapturedSuccess
 }
 
 testServerPresentOnly() {
   compile "server-present-only"
   assertCaptured "Skipping dependencies"
-  assertCaptured "'web: node server.js' to new Procfile"
-  assertFile "web: node server.js" "Procfile"
+  assertCaptured "Adding default process type 'web: node server.js'"
+  assertCapturedSuccess
+  release "server-present-only"
+  assertCaptured "web: node server.js"
   assertCapturedSuccess
 }
 
@@ -464,10 +479,22 @@ detect() {
 
 compile_dir=""
 
+default_process_types_cleanup() {
+  file="${bp_dir}/default_process_types"
+  if [ -f "$file" ]; then
+    rm "$file"
+  fi
+}
+
 compile() {
+  default_process_types_cleanup
   compile_dir=$(mktmpdir)
   cp -r ${bp_dir}/test/fixtures/$1/. ${compile_dir}
   capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
+}
+
+release() {
+  capture ${bp_dir}/bin/release ${bp_dir}/test/fixtures/$1
 }
 
 assertFile() {

--- a/test/run
+++ b/test/run
@@ -480,7 +480,7 @@ detect() {
 compile_dir=""
 
 default_process_types_cleanup() {
-  file="${bp_dir}/default_process_types"
+  file="/tmp/default_process_types"
   if [ -f "$file" ]; then
     rm "$file"
   fi


### PR DESCRIPTION
This is the patch @ojacobson and I were talking about. This change removes the generation of the `Procfile`, so if a `Procfile` exists we know it's created by the user. Instead the buildpack will use the `default_process_types` in `bin/release`. I needed a place to store the file to be read in b/t `bin/compile` and `bin/release`. I'm currently storing it in the buildpack dir and cleaning it up in `bin/release`. I couldn't think of a better spot.