### PR TITLE
Fix prebuild should skip prune

### DIFF
--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -75,8 +75,8 @@ save_cache_directories() {
   for cachepath in ${@:3}; do
     if [ -e "$build_dir/$cachepath" ]; then
       echo "- $cachepath"
-      mkdir -p $(dirname "$cache_dir/node/$cachepath")
-      ln -s "$build_dir/$cachepath" "$cache_dir/node/$cachepath"
+      mkdir -p "$cache_dir/node/$cachepath"
+      cp -a "$build_dir/$cachepath" $(dirname "$cache_dir/node/$cachepath")
     else
       echo "- $cachepath (nothing to cache)"
     fi

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -21,8 +21,6 @@ rebuild_node_modules() {
 
   if [ -e $build_dir/package.json ]; then
     cd $build_dir
-    echo "Pruning any extraneous modules"
-    npm prune --unsafe-perm --userconfig $build_dir/.npmrc 2>&1
     echo "Rebuilding any native modules"
     npm rebuild 2>&1
     if [ -e $build_dir/npm-shrinkwrap.json ]; then

--- a/test/run
+++ b/test/run
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testModulesCheckedIn() {
+  cache=$(mktmpdir)
+  compile "modules-checked-in" $cache
+  assertCapturedSuccess
+
+  compile "modules-checked-in" $cache
+  assertCaptured "Prebuild detected"
+  assertCaptured "Rebuilding any native modules"
+  assertCaptured "(preinstall script)"
+  assertCaptured "Installing any new modules"
+  assertCaptured "(postinstall script)"
+  assertNotCaptured "Pruning any extraneous modules"
+  assertCapturedSuccess
+}
+
 testDisableCache() {
   cache=$(mktmpdir)
   env_dir=$(mktmpdir)
@@ -232,20 +247,6 @@ testBuildWithUserCacheDirectoriesCamel() {
   assertCaptured "- server/node_modules"
   assertCaptured "- client/node_modules"
   assertCaptured "- non/existent (not cached - skipping)"
-  assertCapturedSuccess
-}
-
-testModulesCheckedIn() {
-  cache=$(mktmpdir)
-  compile "modules-checked-in" $cache
-  assertCapturedSuccess
-
-  compile "modules-checked-in" $cache
-  assertCaptured "Prebuild detected"
-  assertCaptured "Rebuilding any native modules"
-  assertCaptured "(preinstall script)"
-  assertCaptured "Installing any new modules"
-  assertCaptured "(postinstall script)"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
- remove `npm prune` from prebuilt dependencies
- use `cp` instead of `ln` (`ln` works in test environment, but apparently not on codon)