### PR TITLE
test and implementation to invalidate cache on runtime signature changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+- Fix runtime signature cache invalidation
+
 ## v77
 
 - Skip npm bootstrapping with iojs
@@ -15,8 +19,8 @@
 
 ## v73 (24/4/2015)
 
-- Patch for caching to disable cache restoration if node_modules already exists (eg from being git submoduled or checked into git)
+- Disable cache restoration if node_modules already exists (eg from being git submoduled or checked into git)
 
 ## v72 (23/4/2015)
 
-* Accepts `cacheDirectories` array in package.json to override default `node_modules` caching
+* Accept `cacheDirectories` array in package.json to override default `node_modules` caching

--- a/bin/compile
+++ b/bin/compile
@@ -89,13 +89,9 @@ header "Installing binaries"
 install_bins | indent
 
 restore_cache() {
-  local cache_status=$(get_cache_status)
+  local cache_status="$(get_cache_status)"
 
-  if [ "$cache_status" == "disabled" ]; then
-    echo "Skipping (cache disabled)"
-  elif [ "$cache_status" == "invalidated" ]; then
-    echo "Skipping (cache invalidated)"
-  else
+  if [ "$cache_status" == "valid" ]; then
     local cache_directories=$(get_cache_directories)
     if [ "$cache_directories" == "" ]; then
       echo "Loading 1 from cacheDirectories (default):"
@@ -104,6 +100,8 @@ restore_cache() {
       echo "Loading $(echo $cache_directories | wc -w | xargs) from cacheDirectories (package.json):"
       restore_cache_directories "$BUILD_DIR" "$CACHE_DIR" $cache_directories
     fi
+  else
+    echo "Skipping cache ($cache_status)"
   fi
 }
 
@@ -124,6 +122,7 @@ build_dependencies | indent
 
 cache_build() {
   local cache_directories=$(get_cache_directories)
+  
   echo "Clearing previous node cache"
   clear_cache
   if [ "$cache_directories" == "" ]; then
@@ -133,6 +132,7 @@ cache_build() {
     echo "Saving $(echo $cache_directories | wc -w | xargs) cacheDirectories (package.json):"
     save_cache_directories "$BUILD_DIR" "$CACHE_DIR" $cache_directories
   fi
+  save_signature
 }
 
 header "Caching build"

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -5,7 +5,7 @@ create_signature() {
 }
 
 save_signature() {
-  echo "$(get_signature)" > $CACHE_DIR/node/signature
+  echo "$(create_signature)" > $CACHE_DIR/node/signature
 }
 
 load_signature() {
@@ -16,19 +16,11 @@ load_signature() {
   fi
 }
 
-signature_changed() {
-  if ! [ "$(create_signature)" == "$(load_signature)" ]; then
-    return 1
-  else
-    return 0
-  fi
-}
-
 get_cache_status() {
   if ! ${NODE_MODULES_CACHE:-true}; then
-    echo "disabled"
-  elif signature_changed; then
-    echo "invalidated"
+    echo "disabled by config"
+  elif [ "$(create_signature)" != "$(load_signature)" ]; then
+    echo "new runtime signature"
   else
     echo "valid"
   fi
@@ -66,6 +58,7 @@ restore_cache_directories() {
 
 clear_cache() {
   rm -rf $CACHE_DIR/node
+  mkdir -p $CACHE_DIR/node
 }
 
 save_cache_directories() {

--- a/test/fixtures/node-0.12.6/README.md
+++ b/test/fixtures/node-0.12.6/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/node-0.12.6/package.json
+++ b/test/fixtures/node-0.12.6/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+  },
+  "engines": {
+    "node": "0.12.6"
+  }
+}

--- a/test/fixtures/node-0.12.7/README.md
+++ b/test/fixtures/node-0.12.7/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/node-0.12.7/package.json
+++ b/test/fixtures/node-0.12.7/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+  },
+  "engines": {
+    "node": "0.12.7"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -1,6 +1,38 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testBuildWithCache() {
+  cache=$(mktmpdir)
+
+  compile "stable-node" $cache
+  assertCaptured "Skipping cache (new runtime"
+  assertEquals "1" "$(ls -1 $cache/node | grep node_modules | wc -l | tr -d ' ')"
+  assertCapturedSuccess
+
+  compile "stable-node" $cache
+  assertNotCaptured "- node_modules (not cached - skipping)"
+  assertCapturedSuccess
+
+  rm -rf "$cache/node/node_modules"
+  compile "stable-node" $cache
+  assertCaptured "- node_modules (not cached - skipping)"
+  assertCapturedSuccess
+}
+
+testSignatureInvalidation() {
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  compile "node-0.12.6" $cache
+  assertCaptured "Downloading and installing node 0.12.6"
+  assertCapturedSuccess
+
+  compile "node-0.12.7" $cache
+  assertCaptured "Downloading and installing node 0.12.7"
+  assertCaptured "Skipping cache (new runtime"
+  assertCapturedSuccess
+}
+
 testModulesCheckedIn() {
   cache=$(mktmpdir)
   compile "modules-checked-in" $cache
@@ -202,19 +234,6 @@ testNodeModulesCached() {
   assertCaptured "Saving 1 cacheDirectories (default)"
   assertCaptured "- node_modules"
   assertEquals "1" "$(ls -1 $cache/node | grep node_modules | wc -l | tr -d ' ')"
-  assertCapturedSuccess
-}
-
-testBuildWithCache() {
-  cache=$(mktmpdir)
-
-  compile "stable-node" $cache
-  assertCaptured "- node_modules (not cached - skipping)"
-  assertEquals "1" "$(ls -1 $cache/node | grep node_modules | wc -l | tr -d ' ')"
-  assertCapturedSuccess
-
-  compile "stable-node" $cache
-  assertNotCaptured "- node_modules (not cached - skipping)"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Resolves https://github.com/heroku/heroku-buildpack-nodejs/issues/249

Whenever the runtime signature (`node --version; npm --version`) changes, we should invalidate the cache so that dependencies are rebuilt with the new binaries.