### PR TITLE
default to NODE_ENV=production for build and runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix runtime signature cache invalidation
 - Provide error messaging for un-downloadable binaries
+- Default to NODE_ENV=production for both build and runtime
 
 ## v77
 

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -2,12 +2,19 @@ create_default_env() {
   export NPM_CONFIG_PRODUCTION=${NPM_CONFIG_PRODUCTION:-true}
   export NPM_CONFIG_LOGLEVEL=${NPM_CONFIG_LOGLEVEL:-error}
   export NODE_MODULES_CACHE=${NODE_MODULES_CACHE:-true}
+  export NODE_ENV=${NODE_ENV:-production}
 }
 
 list_node_config() {
   echo ""
   printenv | grep ^NPM_CONFIG_ || true
   printenv | grep ^NODE_ || true
+
+  if [ "$NPM_CONFIG_PRODUCTION" = "true" ] && [ "$NODE_ENV" != "production" ]; then
+    echo ""
+    echo "npm scripts will see NODE_ENV=production (not '${NODE_ENV}')"
+    echo "https://docs.npmjs.com/misc/config#production"
+  fi
 }
 
 export_env_dir() {

--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -10,11 +10,6 @@ calculate_concurrency() {
   WEB_CONCURRENCY=$WEB_CONCURRENCY
 }
 
-log_concurrency() {
-  echo "Detected $MEMORY_AVAILABLE MB available memory, $WEB_MEMORY MB limit per process (WEB_MEMORY)"
-  echo "Recommending WEB_CONCURRENCY=$WEB_CONCURRENCY"
-}
-
 detect_memory() {
   local default=$1
   local limit=$(ulimit -u)
@@ -29,9 +24,9 @@ detect_memory() {
 
 export PATH="$HOME/.heroku/node/bin:$HOME/bin:$HOME/node_modules/.bin:$PATH"
 export NODE_HOME="$HOME/.heroku/node"
+export NODE_ENV=${NODE_ENV:-production}
 
 calculate_concurrency
-log_concurrency
 
 export MEMORY_AVAILABLE=$MEMORY_AVAILABLE
 export WEB_MEMORY=$WEB_MEMORY


### PR DESCRIPTION
Resolves https://github.com/heroku/heroku-buildpack-nodejs/issues/60

Addresses the previous need to rollback by setting equivalent environments in both the build and run stages. This also shows `NODE_ENV` during build without needing to echo during startup.

A common source of confusion is that npm sets `NODE_ENV=production` anytime `NPM_CONFIG_PRODUCTION=true` or `npm install` is run with the `--production` flag. However, it only sets this for subshells (lifecycle scripts), so outside of npm `NODE_ENV` appears untouched. This PR adds a warning for such scenarios.

This also removes the `WEB_CONCURRENCY` logs from startup, leaving the environment variables set.