### PR TITLE
Default to NODE_ENV=production during runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Node.js Buildpack Changelog
 
+## Upcoming
+
+- Fix not defaulting to `NODE_ENV=production` during runtime
+
 ## v79 (2015-08-10)
 
 Supports WEB_CONCURRENCY for Performance-M dynos

--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -30,6 +30,7 @@ detect_memory() {
 
 export PATH="$HOME/.heroku/node/bin:$HOME/bin:$HOME/node_modules/.bin:$PATH"
 export NODE_HOME="$HOME/.heroku/node"
+export NODE_ENV=${NODE_ENV:-production}
 
 calculate_concurrency
 


### PR DESCRIPTION
This was added in 459ebb67baff09c62fe10d24d9b530915b1da722 and, by the looks of it, mistakenly removed in 043067eb8cc30cfd05115e105c0678c859c12c28.