### PR TITLE
Prune devDependencies after running `npm install` in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ To install *dependencies and devDependencies:*
 heroku config:set NPM_CONFIG_PRODUCTION=false
 ```
 
+If `NODE_ENV` is set to `production`, your devDependencies will be pruned after running `npm install`.
+
 Default: `NPM_CONFIG_PRODUCTION` defaults to true on Heroku
 
 ### Configure npm with .npmrc

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -11,6 +11,10 @@ install_node_modules() {
       echo "Installing node modules (package.json)"
     fi
     npm install --unsafe-perm --userconfig $build_dir/.npmrc 2>&1
+    if [ "$NPM_CONFIG_PRODUCTION" = "false" ] && [ "$NODE_ENV" = "production" ]; then
+      echo "Pruning devDependencies"
+      npm prune --unsafe-perm --userconfig $build_dir/.npmrc --production 2>&1
+    fi
   else
     echo "Skipping (no package.json)"
   fi
@@ -29,6 +33,10 @@ rebuild_node_modules() {
       echo "Installing any new modules (package.json)"
     fi
     npm install --unsafe-perm --userconfig $build_dir/.npmrc 2>&1
+    if [ "$NPM_CONFIG_PRODUCTION" = "false" ] && [ "$NODE_ENV" = "production" ]; then
+      echo "Pruning devDependencies"
+      npm prune --unsafe-perm --userconfig $build_dir/.npmrc --production 2>&1
+    fi
   else
     echo "Skipping (no package.json)"
   fi


### PR DESCRIPTION
This would allow for applications where you need devDependencies during build time but don’t need them during runtime. For example, [devDependencies are often used for Grunt tasks](https://github.com/mbuchetics/heroku-buildpack-nodejs-grunt/issues/5) and [only need to be available during `postinstall`](https://devcenter.heroku.com/articles/node-with-grunt#specify-your-grunt-task-in-a-postinstall-script).

If desired, I can wrap this in a separate environment variable, e.g. `NPM_PRUNE_PRODUCTION`. However, it’s arguable that if you really want to run your Node.js application with `NODE_ENV=production` *and* use devDependencies during runtime, you should either change your `NODE_ENV` or promote those devDependencies to runtime dependencies.