### PR TITLE
Adding support for the N|Solid runtime

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -63,10 +63,13 @@ list_node_config | indent
 install_bins() {
   local node_engine=$(read_json "$BUILD_DIR/package.json" ".engines.node")
   local iojs_engine=$(read_json "$BUILD_DIR/package.json" ".engines.iojs")
+  local nsolid_engine=$(read_json "$BUILD_DIR/package.json" ".engines.nsolid")
   local npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
 
   if [ -n "$iojs_engine" ]; then
     echo "engines.iojs (package.json):  $iojs_engine (iojs)"
+  elif [ -n "$nsolid_engine" ]; then
+    echo "engines.nsolid (package.json):  $nsolid_engine (nsolid)"
   else
     echo "engines.node (package.json):  ${node_engine:-unspecified}"
   fi
@@ -77,6 +80,10 @@ install_bins() {
     warn_node_engine "$iojs_engine"
     install_iojs "$iojs_engine" "$BUILD_DIR/.heroku/node"
     echo "Using bundled npm version for iojs compatibility: `npm --version`"
+  elif [ -n "$nsolid_engine" ]; then
+    warn_node_engine "$nsolid_engine"
+    install_nsolid "$nsolid_engine" "$BUILD_DIR/.heroku/node"
+    echo "Using bundled npm version for nsolid compatibility: `npm --version`"
   else
     warn_node_engine "$node_engine"
     install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -41,6 +41,18 @@ install_iojs() {
   chmod +x $dir/bin/*
 }
 
+install_nsolid() {
+  local version="$1"
+  local dir="$2"
+
+  echo "Downloading and installing nsolid $version..."
+  local download_url="https://nsolid-download.nodesource.com/download/nsolid-node/release/v$version/nsolid-v$version-$os-$cpu.tar.gz"
+  curl "$download_url" --silent --fail -o /tmp/node.tar.gz || (echo "Unable to download nsolid $version; does it exist?" && false)
+  tar xzf /tmp/node.tar.gz -C /tmp
+  mv /tmp/nsolid-v$version-$os-$cpu/* $dir
+  chmod +x $dir/bin/*
+}
+
 install_npm() {
   local version="$1"
 

--- a/test/fixtures/nsolid-1.0.0/README.md
+++ b/test/fixtures/nsolid-1.0.0/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/nsolid-1.0.0/package.json
+++ b/test/fixtures/nsolid-1.0.0/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+  },
+  "engines": {
+    "node": "1.0.0"
+  }
+}

--- a/test/fixtures/nsolid-1.0.0/package.json
+++ b/test/fixtures/nsolid-1.0.0/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
   },
   "engines": {
-    "node": "1.0.0"
+    "nsolid": "1.0.0"
   }
 }

--- a/test/run
+++ b/test/run
@@ -104,6 +104,11 @@ testSignatureInvalidation() {
   assertCaptured "Downloading and installing node 0.12.7"
   assertCaptured "Skipping cache (new runtime"
   assertCapturedSuccess
+
+  compile "nsolid-1.0.0" $cache
+  assertCaptured "Downloading and installing nsolid 1.0.0"
+  assertCaptured "Skipping cache (new runtime"
+  assertCapturedSuccess
 }
 
 testModulesCheckedIn() {


### PR DESCRIPTION
Adding support for the  N|Solid runtime to the buildpack.

Changes:

* Adds `install_nsolid` function to `/lib/binaries.sh`
* Adds `nsolid_engine` and accompanying `elif` commands to `/bin/compile`
* Adds test with `nsolid` as an engine in package.json