### PR TITLE
Performance L

### DIFF
--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -20,10 +20,10 @@ detect_memory() {
   local limit=$(ulimit -u)
 
   case $limit in
-    256) echo "512";;     # Standard-1X
-    512) echo "1024";;    # Standard-2X
-    16384) echo "2560";;  # Performance-M
-    32768) echo "6144";;  # Performance-L
+    256) echo "512";;      # Standard-1X
+    512) echo "1024";;     # Standard-2X
+    16384) echo "2560";;   # Performance-M
+    32768) echo "14336";;  # Performance-L
     *) echo "$default";;
   esac
 }

--- a/test/run
+++ b/test/run
@@ -39,11 +39,11 @@ testConcurrencyPerformanceM() {
   assertCapturedSuccess
 }
 
-testConcurrencyPX() {
-  LOG_CONCURRENCY=true MEMORY_AVAILABLE=6144 capture $(pwd)/profile/nodejs.sh
-  assertCaptured "Detected 6144 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=12"
-  assertCapturedSuccess
+testConcurrencyPerformanceL() {
+   LOG_CONCURRENCY=true MEMORY_AVAILABLE=14336 capture $(pwd)/profile/nodejs.sh
+   assertCaptured "Detected 14336 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+   assertCaptured "Recommending WEB_CONCURRENCY=28"
+   assertCapturedSuccess
 }
 
 testConcurrencyCustomLimit() {

--- a/test/run
+++ b/test/run
@@ -171,7 +171,7 @@ testNoVersion() {
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
   assertCaptured "Resolving node version (latest stable) via semver.io"
-  assertCaptured "Downloading and installing node 0.12."
+  assertCaptured "Downloading and installing node 4."
   assertCapturedSuccess
 }
 
@@ -199,7 +199,7 @@ testUnstableVersion() {
 
 testOldNpm() {
   compile "old-npm"
-  assertCaptured "This version of npm (1.2.8000) has several known issues - consider upgrading to the latest release (2."
+  assertCaptured "This version of npm (1.2.8000) has several known issues - consider upgrading to the latest release (3."
   assertNotCaptured "integer expression expected"
   assertCapturedError
 }
@@ -275,7 +275,7 @@ testDangerousRangeStar() {
   compile "dangerous-range-star"
   assertCaptured "Dangerous semver range"
   assertCaptured "Resolving node version * via semver.io"
-  assertCaptured "Downloading and installing node 0.12."
+  assertCaptured "Downloading and installing node 4."
   assertCapturedError
 }
 
@@ -283,14 +283,14 @@ testDangerousRangeGreaterThan() {
   compile "dangerous-range-greater-than"
   assertCaptured "Dangerous semver range"
   assertCaptured "Resolving node version >0.4 via semver.io"
-  assertCaptured "Downloading and installing node 0.12"
+  assertCaptured "Downloading and installing node 4."
   assertCapturedError
 }
 
 testRangeWithSpace() {
   compile "range-with-space"
   assertCaptured "Resolving node version >= 0.8.x via semver.io"
-  assertCaptured "Downloading and installing node 0.12"
+  assertCaptured "Downloading and installing node 4."
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Adds support for the newer, more powerful Performance-L dynos.

Caveat: if apps are not memory-bound (but rather cpu or io bound), or if they have external requirements for fewer worker processes (like limited connections to a database, queue, etc), then this quite-high 28 process concurrency level might overload them. Note this in the docs.