### PR TITLE
Update URL for "node_modules checked into source control"

### DIFF
--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -49,7 +49,7 @@ warn_node_engine() {
 warn_prebuilt_modules() {
   local build_dir=${1:-}
   if [ -e "$build_dir/node_modules" ]; then
-    warning "node_modules checked into source control" "https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-"
+    warning "node_modules checked into source control" "https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git"
   fi
 }
 


### PR DESCRIPTION
I noticed that
- there is an additional hyphen, and
- www.npmjs.org redirected to docs.npmjs.com

while working on the support ticket #285287