### PR TITLE
Replace sed with awk

### DIFF
--- a/lib/output.sh
+++ b/lib/output.sh
@@ -2,15 +2,15 @@ info() {
   echo "       $*"
 }
 
-# sed's buffer can't hold some of the huge build output from JS asset builders
-# try awk next? awk  '{ print "       " $0 }'
+# sed has a problem with the huge build output from npm 3
+# try awk? awk  '{ print "       " $0 }'
 output() {
   local logfile="$1"
   local c='s/^/       /'
 
   case $(uname) in
-    Darwin) tee -a "$logfile";;
-    *)      tee -a "$logfile";;
+    Darwin) tee -a "$logfile" | awk '{ print "       " $0 }';;
+    *)      tee -a "$logfile" | awk -W interactive '{ print "       " $0 }';;
   esac
 }
 

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -2,16 +2,15 @@ info() {
   echo "       $*"
 }
 
-# sed -l basically makes sed replace and buffer through stdin to stdout
-# so you get updates while the command runs and dont wait for the end
-# e.g. npm install | indent
+# sed's buffer can't hold some of the huge build output from JS asset builders
+# try awk next? awk  '{ print "       " $0 }'
 output() {
   local logfile="$1"
   local c='s/^/       /'
 
   case $(uname) in
-    Darwin) tee -a "$logfile" | sed -l "$c";; # mac/bsd sed: -l buffers on line boundaries
-    *)      tee -a "$logfile" | sed -u "$c";; # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
+    Darwin) tee -a "$logfile";;
+    *)      tee -a "$logfile";;
   esac
 }
 


### PR DESCRIPTION
After the release of npm 3, we had numerous customers run into issues with npm's verbose output (big, nested dep trees) conflicting somehow with `sed` (which is used to format all output in the buildpack). This replaces `sed` with `awk` in the output function for (hopefully) the same output without issues on large builds.

I've tried writing a test to reproduce the `sed` errors without success. I suspect they have something to do with system limits (memory, open files, etc) that are not 1:1 reproduced in the heroku/cedar:14 Docker image used for testing.