### PR TITLE
add retry for curl to resolve NPM version

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -49,7 +49,7 @@ install_npm() {
   else
     if needs_resolution "$version"; then
       echo "Resolving npm version ${version} via semver.io..."
-      version=$(curl --silent --get --data-urlencode "range=${version}" https://semver.herokuapp.com/npm/resolve)
+      version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/npm/resolve)
     fi
     if [[ `npm --version` == "$version" ]]; then
       echo "npm `npm --version` already installed with node"


### PR DESCRIPTION
I've noticed that once in a while, pushes fail during the NPM resolution step and cause the buildpack to fail compilation entirely.  By adding a retry, we can account for occasional "semver" downtime and other transient errors, and potentially avoid failing an application's staging process.