### PR TITLE
remove formatting pipes from stdout

### DIFF
--- a/lib/output.sh
+++ b/lib/output.sh
@@ -6,8 +6,12 @@ info() {
 # try awk? awk  '{ print "       " $0 }'
 output() {
   local logfile="$1"
+  local c='s/^/       /'
 
-  tee -i -a "$logfile" 2> /dev/null
+  case $(uname) in
+    Darwin) tee -i -a "$logfile" 2> /dev/null | sed -l "$c";;
+    *)      tee -i -a "$logfile" 2> /dev/null | sed -u "$c";;
+  esac
 }
 
 header() {

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -9,8 +9,8 @@ output() {
   local c='s/^/       /'
 
   case $(uname) in
-    Darwin) tee -i -a "$logfile" 2> /dev/null | sed -l "$c";;
-    *)      tee -i -a "$logfile" 2> /dev/null | sed -u "$c";;
+    Darwin) stdbuf -oL -eL sed -l "$c" | tee -i -a "$logfile" 2> /dev/null;;
+    *)      stdbuf -oL -eL sed -u "$c" | tee -i -a "$logfile" 2> /dev/null;;
   esac
 }
 

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -6,9 +6,8 @@ info() {
 # try awk? awk  '{ print "       " $0 }'
 output() {
   local logfile="$1"
-  local c='s/^/       /'
 
-  tee -a "$logfile"
+  tee -i -a "$logfile" 2> /dev/null
 }
 
 header() {

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -8,10 +8,7 @@ output() {
   local logfile="$1"
   local c='s/^/       /'
 
-  case $(uname) in
-    Darwin) tee -a "$logfile" | awk '{ print "       " $0 }';;
-    *)      tee -a "$logfile" | awk -W interactive '{ print "       " $0 }';;
-  esac
+  tee -a "$logfile"
 }
 
 header() {


### PR DESCRIPTION
This should be temporary; ideally we'll be able to format output from the various build steps. However, both the latest npm and some of the larger webpack builds are pushing really large buffers to stdout via `sed` or `awk`, which causes some builds to fail. Reproducing the issue is difficult as these builds don't fail on a Docker (test) container.

For the moment, it's better to have somewhat uglier output than to sometimes fail builds with large output.

We'll see if this resolves https://github.com/heroku/heroku-buildpack-nodejs/issues/273 before merging.