### PR TITLE
test and implementation for compiling the same directory multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Node.js Buildpack Changelog
 
+## Pending
+
+Enables compiling the same directory multiple times
+
 ## v86 (2015-10-08)
 
 Fixes piped output buffering issues

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -20,6 +20,7 @@ install_nodejs() {
   local download_url="http://s3pository.heroku.com/node/v$version/node-v$version-$os-$cpu.tar.gz"
   curl "$download_url" --silent --fail -o /tmp/node.tar.gz || (echo "Unable to download node $version; does it exist?" && false)
   tar xzf /tmp/node.tar.gz -C /tmp
+  rm -rf $dir/*
   mv /tmp/node-v$version-$os-$cpu/* $dir
   chmod +x $dir/bin/*
 }

--- a/test/run
+++ b/test/run
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testMultipleRuns() {
+  local compileDir=$(mktmpdir)
+  local cacheDir=$(mktmpdir)
+
+  cp -a test/fixtures/stable-node/. ${compileDir}
+  compileDir "$compileDir" "$cacheDir"
+  assertCapturedSuccess
+  compileDir "$compileDir" "$cacheDir"
+  assertCapturedSuccess
+}
+
 testDisableCache() {
   cache=$(mktmpdir)
   env_dir=$(mktmpdir)
@@ -495,6 +506,18 @@ compile() {
   cp -a $(pwd)/* ${bp_dir}
   cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
   capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
+}
+
+compileDir() {
+  default_process_types_cleanup
+
+  local bp_dir=$(mktmpdir)
+  local compile_dir=${1:-$(mktmpdir)}
+  local cache_dir=${2:-$(mktmpdir)}
+  local env_dir=$3
+
+  cp -a $(pwd)/* ${bp_dir}
+  capture ${bp_dir}/bin/compile ${compile_dir} ${cache_dir} ${env_dir}
 }
 
 release() {


### PR DESCRIPTION
It's a weird use case but we've seen folks trying to use the node buildpack twice - before and after other buildpacks.

It'd be nice if it just worked in that case.