### PR TITLE
use HTTPS for downloading Node

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -17,7 +17,7 @@ install_nodejs() {
   fi
 
   echo "Downloading and installing node $version..."
-  local download_url="http://s3pository.heroku.com/node/v$version/node-v$version-$os-$cpu.tar.gz"
+  local download_url="https://s3pository.heroku.com/node/v$version/node-v$version-$os-$cpu.tar.gz"
   curl "$download_url" --silent --fail  --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz || (echo "Unable to download node $version; does it exist?" && false)
   tar xzf /tmp/node.tar.gz -C /tmp
   rm -rf $dir/*


### PR DESCRIPTION
Since the HTTPS URL is available for downloading the Node packages, use that instead of HTTP for better security.

![screen shot 2015-12-17 at 11 12 51 am](https://cloud.githubusercontent.com/assets/86842/11874728/326f7698-a4af-11e5-8921-00cc1f431fc4.png)

/cc @mbland