### PR TITLE
export NODE_WEB_CONCURRENCY

### DIFF
--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -37,6 +37,7 @@ calculate_concurrency
 export MEMORY_AVAILABLE=$MEMORY_AVAILABLE
 export WEB_MEMORY=$WEB_MEMORY
 export WEB_CONCURRENCY=$WEB_CONCURRENCY
+export NODE_WEB_CONCURRENCY=$WEB_CONCURRENCY
 
 if [ "$LOG_CONCURRENCY" = "true" ]; then
   log_concurrency


### PR DESCRIPTION
Export NODE_WEB_CONCURRENCY as a shadow of WEB_CONCURRENCY (so subsequent buildpacks like PHP can infer whether WEB_CONCURRENCY has been set by node or the user).

/cc @dzuelke 
