### PR TITLE
remove npm prune to work around shrinkwrap issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current
 
 - Do not fail build on output errors
+- Do not prune before install (shrinkwrap unsupported by prune)
 
 ## v90 (2016-4-20)
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -13,8 +13,6 @@ install_node_modules() {
   if [ -e $build_dir/package.json ]; then
     cd $build_dir
 
-    echo "Pruning any extraneous modules"
-    npm prune --unsafe-perm --userconfig $build_dir/.npmrc 2>&1
     if [ -e $build_dir/npm-shrinkwrap.json ]; then
       echo "Installing node modules (package.json + shrinkwrap)"
     else

--- a/test/run
+++ b/test/run
@@ -214,7 +214,6 @@ testModulesCheckedIn() {
   assertCaptured "(preinstall script)"
   assertCaptured "Installing any new modules"
   assertCaptured "(postinstall script)"
-  assertNotCaptured "Pruning any extraneous modules"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
https://github.com/heroku/heroku-buildpack-nodejs/issues/282#issuecomment-160877795

Since `npm prune` causes issues when `npm-shrinkwrap.json` is present, we may need to find another mechanism of keeping the cache from bloating. Perhaps a size check + timestamp.