### PR TITLE
Extended warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Do not fail build on output errors
 - Do not prune before install (shrinkwrap unsupported by prune)
+- Extended warnings (missing dependencies, econnreset, no start)
 
 ## v90 (2016-4-20)
 

--- a/bin/compile
+++ b/bin/compile
@@ -43,6 +43,7 @@ handle_failure() {
   warn_untracked_dependencies "$LOG_FILE"
   warn_angular_resolution "$LOG_FILE"
   warn_missing_devdeps "$LOG_FILE"
+  warn_no_start "$LOG_FILE"
   failure_message | output "$LOG_FILE"
 }
 trap 'handle_failure' ERR
@@ -159,3 +160,5 @@ summarize_build() {
 
 header "Build succeeded!"
 summarize_build | output "$LOG_FILE"
+
+warn_no_start "$LOG_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -43,7 +43,7 @@ handle_failure() {
   warn_untracked_dependencies "$LOG_FILE"
   warn_angular_resolution "$LOG_FILE"
   warn_missing_devdeps "$LOG_FILE"
-  warn_no_start "$LOG_FILE"
+  warn_econnreset "$LOG_FILE"
   failure_message | output "$LOG_FILE"
 }
 trap 'handle_failure' ERR

--- a/bin/compile
+++ b/bin/compile
@@ -162,3 +162,4 @@ header "Build succeeded!"
 summarize_build | output "$LOG_FILE"
 
 warn_no_start "$LOG_FILE"
+warn_unmet_dep "$LOG_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -42,6 +42,7 @@ handle_failure() {
   header "Build failed"
   warn_untracked_dependencies "$LOG_FILE"
   warn_angular_resolution "$LOG_FILE"
+  warn_missing_devdeps "$LOG_FILE"
   failure_message | output "$LOG_FILE"
 }
 trap 'handle_failure' ERR

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -18,7 +18,10 @@ install_nodejs() {
 
   echo "Downloading and installing node $version..."
   local download_url="https://s3pository.heroku.com/node/v$version/node-v$version-$os-$cpu.tar.gz"
-  curl "$download_url" --silent --fail  --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz || (echo "Unable to download node $version; does it exist?" && false)
+  local code=$(curl "$download_url" --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
+  if [ "$code" != "200" ]; then
+    echo "Unable to download node $version; does it exist?" && false
+  fi
   tar xzf /tmp/node.tar.gz -C /tmp
   rm -rf $dir/*
   mv /tmp/node-v$version-$os-$cpu/* $dir

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -57,7 +57,7 @@ warn_node_engine() {
 warn_prebuilt_modules() {
   local build_dir=${1:-}
   if [ -e "$build_dir/node_modules" ]; then
-    warning "node_modules checked into source control" "https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git"
+    warning "node_modules checked into source control" "https://blog.heroku.com/node-habits-2016#9-only-git-the-important-bits"
   fi
 }
 

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -35,6 +35,14 @@ warning() {
   echo "" >> $warnings
 }
 
+warn() {
+  local tip=${1:-}
+  local url=${2:-https://devcenter.heroku.com/articles/nodejs-support}
+  echo " !     $tip" || true
+  echo "       $url" || true
+  echo ""
+}
+
 warn_node_engine() {
   local node_engine=${1:-}
   if [ "$node_engine" == "" ]; then
@@ -97,6 +105,18 @@ warn_missing_devdeps() {
       echo "devDependencies: $devDeps"
       if [ "$devDeps" != "" ]; then
         warning "A module may be specified in devDependencies instead of dependencies" "https://devcenter.heroku.com/articles/nodejs-support#devdependencies"
+      fi
+    fi
+  fi
+}
+
+warn_no_start() {
+  local log_file="$1"
+  if ! [ -e "$BUILD_DIR/Procfile" ]; then
+    local startScript=$(read_json "$BUILD_DIR/package.json" ".scripts.start")
+    if [ "$startScript" == "" ]; then
+      if ! [ -e "$BUILD_DIR/server.js" ]; then
+        warn "This app may not specify any way to start a node process" "https://devcenter.heroku.com/articles/nodejs-support#default-web-process-type"
       fi
     fi
   fi

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -87,3 +87,17 @@ warn_angular_resolution() {
     warning "Bower may need a resolution hint for angular" "https://github.com/bower/bower/issues/1746"
   fi
 }
+
+warn_missing_devdeps() {
+  local log_file="$1"
+  if grep -qi 'cannot find module' "$log_file"; then
+    warning "A module may be missing from package.json" "https://devcenter.heroku.com/articles/troubleshooting-node-deploys#ensure-you-aren-t-relying-on-untracked-dependencies"
+    if [ "$NPM_CONFIG_PRODUCTION" == "true" ]; then
+      local devDeps=$(read_json "$BUILD_DIR/package.json" ".devDependencies")
+      echo "devDependencies: $devDeps"
+      if [ "$devDeps" != "" ]; then
+        warning "A module may be specified in devDependencies instead of dependencies" "https://devcenter.heroku.com/articles/nodejs-support#devdependencies"
+      fi
+    fi
+  fi
+}

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -128,3 +128,10 @@ warn_econnreset() {
     warning "ECONNRESET issues may be related to npm versions" "https://github.com/npm/registry/issues/10#issuecomment-217141066"
   fi
 }
+
+warn_unmet_dep() {
+  local log_file="$1"
+  if grep -qi 'unmet dependency' "$log_file" || grep -qi 'unmet peer dependency' "$log_file"; then
+    warn "Unmet dependencies don't fail npm install but may cause runtime issues" "https://github.com/npm/npm/issues/7494"
+  fi
+}

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -121,3 +121,10 @@ warn_no_start() {
     fi
   fi
 }
+
+warn_econnreset() {
+  local log_file="$1"
+  if grep -qi 'econnreset' "$log_file"; then
+    warning "ECONNRESET issues may be related to npm versions" "https://github.com/npm/registry/issues/10#issuecomment-217141066"
+  fi
+}

--- a/test/fixtures/econnreset-mock/package.json
+++ b/test/fixtures/econnreset-mock/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "econnreset-mock",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "postinstall": "echo 'npm ERR! network read ECONNRESET' && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/invalid-node/package.json
+++ b/test/fixtures/invalid-node/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
   },
   "engines": {
-    "node": "0.11.33"
+    "node": "0.11.333"
   }
 }

--- a/test/fixtures/missing-devdeps-1/package.json
+++ b/test/fixtures/missing-devdeps-1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "missing-devdeps-1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/missing-devdeps-1/postinstall.js
+++ b/test/fixtures/missing-devdeps-1/postinstall.js
@@ -1,0 +1,1 @@
+const lodash = require('lodash');

--- a/test/fixtures/missing-devdeps-2/package.json
+++ b/test/fixtures/missing-devdeps-2/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "missing-devdeps-1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "lodash": "4.13.1"
+  }
+}

--- a/test/fixtures/missing-devdeps-2/postinstall.js
+++ b/test/fixtures/missing-devdeps-2/postinstall.js
@@ -1,0 +1,1 @@
+const lodash = require('lodash');

--- a/test/fixtures/no-start/package.json
+++ b/test/fixtures/no-start/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "no-start",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/no-version/package.json
+++ b/test/fixtures/no-version/package.json
@@ -5,5 +5,8 @@
   "repository" : {
     "type" : "git",
     "url" : "http://github.com/example/example.git"
+  },
+  "scripts": {
+    "start": "node server.js"
   }
 }

--- a/test/fixtures/unmet-dep/package.json
+++ b/test/fixtures/unmet-dep/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "unmet-dep",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "grunt-steroids": "0.2.3"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testWarnDevDeps() {
+  compile "missing-devdeps-1"
+  assertCaptured "A module may be missing"
+  assertNotCaptured "A module may be specified"
+  assertCapturedError
+  compile "missing-devdeps-2"
+  assertCaptured "A module may be missing"
+  assertCaptured "A module may be specified"
+  assertCapturedError
+  compile "failing-build"
+  assertNotCaptured "A module may be missing"
+  assertNotCaptured "A module may be specified"
+  assertCapturedError
+}
+
 testEnvBlacklist() {
   local cache=$(mktmpdir)
   local env_dir=$(mktmpdir)

--- a/test/run
+++ b/test/run
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testWarnUnmetDep() {
+  compile "unmet-dep"
+  assertCaptured "may cause runtime issues"
+  assertCapturedSuccess
+  compile "no-version"
+  assertNotCaptured "may cause runtime issues"
+  assertCapturedSuccess
+}
+
 testWarnEconnreset() {
   compile "econnreset-mock"
   assertCaptured "may be related to npm versions"

--- a/test/run
+++ b/test/run
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testWarnNoStart() {
+  compile "no-start"
+  assertCaptured "may not specify any way to start"
+  assertCapturedSuccess
+  compile "no-version"
+  assertNotCaptured "may not specify any way to start"
+  assertCapturedSuccess
+}
+
 testWarnDevDeps() {
   compile "missing-devdeps-1"
   assertCaptured "A module may be missing"

--- a/test/run
+++ b/test/run
@@ -201,8 +201,8 @@ testConcurrencySaneMaximum() {
 
 testInvalidNode() {
   compile "invalid-node"
-  assertCaptured "Downloading and installing node 0.11.33"
-  assertCaptured "Unable to download node 0.11.33"
+  assertCaptured "Downloading and installing node 0.11.333"
+  assertCaptured "Unable to download node 0.11.333"
   assertCapturedError
 }
 

--- a/test/run
+++ b/test/run
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testWarnEconnreset() {
+  compile "econnreset-mock"
+  assertCaptured "may be related to npm versions"
+  assertCapturedError
+  compile "no-version"
+  assertNotCaptured "may be related to npm versions"
+  assertCapturedSuccess
+}
+
 testWarnNoStart() {
   compile "no-start"
   assertCaptured "may not specify any way to start"


### PR DESCRIPTION
Adds these warnings:
- missing build dependencies
- missing devDependencies
- missing start mechanism
- ECONNRESET
- unmet dependencies / peer dependencies

To the existing set of warnings:
- invalid package.json
- node engine not/under specified
- prebuilt node_modules
- old npm
- untracked deps (grunt / gulp / bower)
- missing angular resolution

Resolves #319 #316 #310 and #288
