### PR TITLE
Add heroku-postinstall hook

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -161,5 +161,7 @@ summarize_build() {
 header "Build succeeded!"
 summarize_build | output "$LOG_FILE"
 
+run_if_present 'heroku-postinstall'
+
 warn_no_start "$LOG_FILE"
 warn_unmet_dep "$LOG_FILE"


### PR DESCRIPTION
Users can optionally specify a `heroku-postinstall` script in `package.json`, which is executed after a successful installation (importantly, after the cache has been saved). This can be used to do any cleanup necessary before the slug is generated.
