### PR TITLE
Add seperate logic for rebuilding with yarn

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -127,7 +127,11 @@ build_dependencies() {
   run_if_present 'heroku-prebuild'
   if $PREBUILD; then
     echo "Prebuild detected (node_modules already exists)"
-    rebuild_node_modules "$BUILD_DIR"
+    if [ -f "$BUILD_DIR/yarn.lock" ]; then
+      rebuild_yarn_modules "$BUILD_DIR"
+    else
+      rebuild_node_modules "$BUILD_DIR"
+    fi
   elif [ -f "$BUILD_DIR/yarn.lock" ]; then
     yarn_node_modules "$BUILD_DIR"
   else

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -31,6 +31,13 @@ install_node_modules() {
   fi
 }
 
+rebuild_yarn_modules() {
+  local build_dir=${1:-}
+
+  echo "Installing node modules (yarn)"
+  yarn install --force 2>&1
+}
+
 rebuild_node_modules() {
   local build_dir=${1:-}
 


### PR DESCRIPTION
From the [Migrating from npm](https://yarnpkg.com/en/docs/migrating-from-npm) docs, we can see that we should use:

```sh
yarn install --force
```

Instead of 

```sh
npm rebuild
```

When rebuilding. This PR handles this!