### PR TITLE
yarn support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .anvil
 .DS_Store
+.idea

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,7 @@ BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 
 mkdir -p "$BUILD_DIR/.heroku/node/"
 cd $BUILD_DIR
-export PATH="$BUILD_DIR/.heroku/node/bin":$PATH
+export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 
 LOG_FILE='/tmp/node-build-log.txt'
 echo "" > "$LOG_FILE"
@@ -98,7 +98,7 @@ install_bins() {
     install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
     install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
     if [ -n "$yarn_engine" ]; then
-      export PATH="$BUILD_DIR/.heroku/yarn/bin":$PATH
+      echo "installing yarn"
       install_yarn "$yarn_engine" "$BUILD_DIR/.heroku/yarn"
     fi
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 ### Constants
 
 DEFAULT_CACHE="node_modules bower_components"
-BUILD_MODE="npm"
+YARN_ENABLED=false
 
 ### Configure directories
 
@@ -83,15 +83,10 @@ install_bins() {
   else
     echo "engines.node (package.json):  ${node_engine:-unspecified}"
   fi
-
+  echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
   if [ -n "$yarn_engine" ]; then
-        BUILD_MODE="yarn"
-        export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
-
-      echo "engines.yarn (package.json):  $yarn_engine (yarn)"
-    else
-      echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
-    fi
+    echo "engines.yarn (package.json):  $yarn_engine (yarn)"
+  fi
   echo ""
 
   if [ -n "$iojs_engine" ]; then
@@ -101,11 +96,11 @@ install_bins() {
   else
     warn_node_engine "$node_engine"
     install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
-      if [ "$BUILD_MODE" == "yarn" ]; then
-        install_yarn "$yarn_engine" "$BUILD_DIR/.heroku/yarn"
-      else
-        install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
-      fi
+    install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
+    if [ -n "$yarn_engine" ]; then
+      export PATH="$BUILD_DIR/.heroku/yarn/bin":$PATH
+      install_yarn "$yarn_engine" "$BUILD_DIR/.heroku/yarn"
+    fi
   fi
 
   warn_old_npm
@@ -136,11 +131,11 @@ restore_cache | output "$LOG_FILE"
 
 build_dependencies() {
   run_if_present 'heroku-prebuild'
-  if $PREBUILD; then
+  if $YARN_ENABLED; then
+    yarn_node_modules "$BUILD_DIR"
+  elif $PREBUILD; then
     echo "Prebuild detected (node_modules already exists)"
     rebuild_node_modules "$BUILD_DIR"
-  elif [ "$BUILD_MODE" == "yarn" ]; then
-    yarn_node_modules "$BUILD_DIR"
   else
     install_node_modules "$BUILD_DIR"
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -131,7 +131,7 @@ restore_cache | output "$LOG_FILE"
 
 build_dependencies() {
   run_if_present 'heroku-prebuild'
-  if $YARN_ENABLED; then
+  if [ "$YARN_ENABLED" = true ]; then
     yarn_node_modules "$BUILD_DIR"
   elif $PREBUILD; then
     echo "Prebuild detected (node_modules already exists)"

--- a/bin/compile
+++ b/bin/compile
@@ -98,7 +98,6 @@ install_bins() {
     install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
     install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
     if [ -n "$yarn_engine" ]; then
-      echo "installing yarn"
       install_yarn "$yarn_engine" "$BUILD_DIR/.heroku/yarn"
     fi
   fi
@@ -167,7 +166,7 @@ cache_build | output "$LOG_FILE"
 
 summarize_build() {
   cd $BUILD_DIR
-  if [ "$BUILD_MODE" == "yarn" ]; then
+  if [ "$YARN_ENABLED" = true ]; then
     echo ""
     (yarn ls || true) 2>/dev/null
     echo ""

--- a/bin/compile
+++ b/bin/compile
@@ -11,6 +11,7 @@ unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 ### Constants
 
 DEFAULT_CACHE="node_modules bower_components"
+BUILD_MODE="npm"
 
 ### Configure directories
 
@@ -21,7 +22,7 @@ BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 
 mkdir -p "$BUILD_DIR/.heroku/node/"
 cd $BUILD_DIR
-export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
+export PATH="$BUILD_DIR/.heroku/node/bin":$PATH
 
 LOG_FILE='/tmp/node-build-log.txt'
 echo "" > "$LOG_FILE"
@@ -75,13 +76,22 @@ install_bins() {
   local node_engine=$(read_json "$BUILD_DIR/package.json" ".engines.node")
   local iojs_engine=$(read_json "$BUILD_DIR/package.json" ".engines.iojs")
   local npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
+  local yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
 
   if [ -n "$iojs_engine" ]; then
     echo "engines.iojs (package.json):  $iojs_engine (iojs)"
   else
     echo "engines.node (package.json):  ${node_engine:-unspecified}"
   fi
-  echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
+
+  if [ -n "$yarn_engine" ]; then
+        BUILD_MODE="yarn"
+        export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
+
+      echo "engines.yarn (package.json):  $yarn_engine (yarn)"
+    else
+      echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
+    fi
   echo ""
 
   if [ -n "$iojs_engine" ]; then
@@ -91,10 +101,11 @@ install_bins() {
   else
     warn_node_engine "$node_engine"
     install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
-    install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
-  fi
-  if [ -f "$BUILD_DIR/yarn.lock" ]; then
-    install_yarn "$BUILD_DIR/.heroku/yarn"
+      if [ "$BUILD_MODE" == "yarn" ]; then
+        install_yarn "$yarn_engine" "$BUILD_DIR/.heroku/yarn"
+      else
+        install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
+      fi
   fi
 
   warn_old_npm
@@ -128,7 +139,7 @@ build_dependencies() {
   if $PREBUILD; then
     echo "Prebuild detected (node_modules already exists)"
     rebuild_node_modules "$BUILD_DIR"
-  elif [ -f "$BUILD_DIR/yarn.lock" ]; then
+  elif [ "$BUILD_MODE" == "yarn" ]; then
     yarn_node_modules "$BUILD_DIR"
   else
     install_node_modules "$BUILD_DIR"
@@ -161,7 +172,7 @@ cache_build | output "$LOG_FILE"
 
 summarize_build() {
   cd $BUILD_DIR
-  if [ -f "$BUILD_DIR/yarn.lock" ]; then
+  if [ "$BUILD_MODE" == "yarn" ]; then
     echo ""
     (yarn ls || true) 2>/dev/null
     echo ""

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 ### Constants
 
 DEFAULT_CACHE="node_modules bower_components"
-YARN_ENABLED=false
+YARN_ENABLED=true
 
 ### Configure directories
 
@@ -85,7 +85,7 @@ install_bins() {
   fi
   echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
   if [ -n "$yarn_engine" ]; then
-    echo "engines.yarn (package.json):  $yarn_engine (yarn)"
+    echo "engines.yarn (package.json):  $yarn_engine"
   fi
   echo ""
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -13,7 +13,6 @@ install_yarn() {
 
   echo "Downloading and installing yarn $version..."
   local download_url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
-  echo "from $download_url"
 
   local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
@@ -28,7 +27,6 @@ install_yarn() {
     tar xzf /tmp/yarn.tar.gz -C "$dir" --strip 1
   fi
   chmod +x $dir/bin/*
-  yarn --version
   echo "Installed yarn $(yarn --version)"
 }
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -13,6 +13,7 @@ install_yarn() {
 
   echo "Downloading and installing yarn $version..."
   local download_url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
+  echo "from $download_url"
 
   local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
@@ -27,6 +28,7 @@ install_yarn() {
     tar xzf /tmp/yarn.tar.gz -C "$dir" --strip 1
   fi
   chmod +x $dir/bin/*
+  yarn --version
   echo "Installed yarn $(yarn --version)"
 }
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -8,10 +8,12 @@ needs_resolution() {
 }
 
 install_yarn() {
-  local dir="$1"
+  local version="$1"
+  local dir="$2"
 
-  echo "Downloading and installing yarn..."
-  local download_url="https://yarnpkg.com/latest.tar.gz"
+  echo "Downloading and installing yarn $version..."
+  local download_url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
+
   local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -10,7 +10,7 @@ run_if_present() {
 yarn_node_modules() {
   local build_dir=${1:-}
 
-  echo "Installing node modules (yarn)"
+  echo "Installing node modules (yarn install --force)"
   yarn install --force 2>&1
 }
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -11,7 +11,7 @@ yarn_node_modules() {
   local build_dir=${1:-}
 
   echo "Installing node modules (yarn)"
-  yarn 2>&1
+  yarn install --force 2>&1
 }
 
 install_node_modules() {

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -9,9 +9,11 @@ run_if_present() {
 
 yarn_node_modules() {
   local build_dir=${1:-}
-
-  echo "Installing node modules (yarn install --force)"
-  yarn install --force 2>&1
+  if [ -e $build_dir/package.json ]; then
+    cd $build_dir
+  fi
+  echo "Installing node modules (yarn)"
+  yarn 2>&1
 }
 
 install_node_modules() {


### PR DESCRIPTION
this extends the current yarn branch to look for yarn config in `package.json` instead of detecting a yarn.lock file. 
```json
{
  "engines": {
    "yarn": "0.17.10"
  }
}
````
it does not alter the previous installation for node and npm. yarn will always be an *extra* feature. at least as long as yarn still has its little bugs

also currently there is no range resolving. I created a PR on semver.io for this: https://github.com/heroku/semver.io/pull/60. When this gets merged there, I can add it to this PR.

i'm not sure about caching, maybe a heroku pro could have a look at it. otherwise, this would close #337 