### PR TITLE
Faster cache and check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Node.js Buildpack Changelog
 
+## Master
+
+- Cache node_modules
+- No longer run `yarn check`
+
 ## v96 (2017-01-27)
 
 - Clear caches from the slug

--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 
 ### Constants
 
-DEFAULT_CACHE=".npm .cache/yarn bower_components"
+DEFAULT_CACHE="node_modules bower_components"
 
 ### Configure directories
 
@@ -118,7 +118,7 @@ restore_cache() {
   if [ "$cache_status" == "valid" ]; then
     local cache_directories=$(get_cache_directories)
     if [ "$cache_directories" == "" ]; then
-      echo "Loading 3 from cacheDirectories (default):"
+      echo "Loading 2 from cacheDirectories (default):"
       restore_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$DEFAULT_CACHE"
     else
       echo "Loading $(echo $cache_directories | wc -w | xargs) from cacheDirectories (package.json):"
@@ -157,14 +157,13 @@ cache_build() {
   if ! ${NODE_MODULES_CACHE:-true}; then
     echo "Skipping cache save (disabled by config)"
   elif [ "$cache_directories" == "" ]; then
-    echo "Saving 3 cacheDirectories (default):"
+    echo "Saving 2 cacheDirectories (default):"
     save_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$DEFAULT_CACHE"
   else
     echo "Saving $(echo $cache_directories | wc -w | xargs) cacheDirectories (package.json):"
     save_cache_directories "$BUILD_DIR" "$CACHE_DIR" $cache_directories
   fi
   save_signature
-  remove_caches_from_slug "$BUILD_DIR"
 }
 
 header "Caching build"

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -56,12 +56,6 @@ restore_cache_directories() {
   done
 }
 
-remove_caches_from_slug() {
-  local build_dir=${1:-}
-  rm -rf "$build_dir/.npm"
-  rm -rf "$build_dir/.cache/yarn"
-}
-
 clear_cache() {
   rm -rf $CACHE_DIR/node
   mkdir -p $CACHE_DIR/node

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -27,17 +27,10 @@ run_if_present() {
 
 yarn_node_modules() {
   local build_dir=${1:-}
+
   echo "Installing node modules (yarn.lock)"
   cd "$build_dir"
-  yarn install --pure-lockfile --ignore-engines --cache-folder $build_dir/.cache/yarn 2>&1
-  # according to docs: "Verifies that versions of the package dependencies in the current project’s package.json matches that of yarn’s lock file."
-  # however, appears to also check for the presence of deps in node_modules, so must be run after install
-  if $(yarn check 1>/dev/null); then
-    echo "yarn.lock and package.json match"
-  else
-    echo "yarn.lock is outdated"
-    warning "yarn.lock is outdated." "run \`yarn install\`, commit the updated \`yarn.lock\`, and redeploy"
-  fi
+  yarn install --pure-lockfile --ignore-engines 2>&1
 }
 
 npm_node_modules() {
@@ -51,7 +44,7 @@ npm_node_modules() {
     else
       echo "Installing node modules (package.json)"
     fi
-    npm install --unsafe-perm --userconfig $build_dir/.npmrc --cache $build_dir/.npm 2>&1
+    npm install --unsafe-perm --userconfig $build_dir/.npmrc 2>&1
   else
     echo "Skipping (no package.json)"
   fi

--- a/test/run
+++ b/test/run
@@ -1,15 +1,36 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testDisableCache() {
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  echo "true" > $env_dir/NODE_VERBOSE
+  compile "node-modules-cache-1" $cache $env_dir
+  assertCaptured "lodash@1.0.0"
+  assertEquals "1" "$(ls -1 $cache/node/node_modules | grep lodash | wc -l | tr -d ' ')"
+  assertCapturedSuccess
+
+  compile "node-modules-cache-2" $cache $env_dir
+  assertCaptured "lodash@1.0.0"
+  assertCaptured "Saving 2 cacheDirectories"
+  assertCapturedSuccess
+
+  echo "false" > $env_dir/NODE_MODULES_CACHE
+  compile "node-modules-cache-2" $cache $env_dir
+  assertCaptured "lodash@1.3.1"
+  assertNotCaptured "Saving 2 cacheDirectories"
+  assertCapturedSuccess
+}
+
 testNodeModulesCached() {
   cache=$(mktmpdir)
 
   compile "caching" $cache
-  assertCaptured "Saving 3 cacheDirectories (default)"
-  assertCaptured "- .npm"
-  assertCaptured "- .cache/yarn (nothing to cache)"
+  assertCaptured "Saving 2 cacheDirectories (default)"
+  assertCaptured "- node_modules"
   assertCaptured "- bower_components (nothing to cache)"
-  assertEquals "1" "$(ls -1 $cache/node/.npm | grep express | wc -l | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/node_modules | grep express | wc -l | tr -d ' ')"
   assertCapturedSuccess
 }
 
@@ -26,16 +47,16 @@ testBuildWithCache() {
 
   compile "stable-node" $cache
   assertCaptured "Skipping cache restore (new runtime"
-  assertEquals "1" "$(ls -1 $cache/node/.npm | grep hashish | wc -l | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/node_modules | grep hashish | wc -l | tr -d ' ')"
   assertCapturedSuccess
 
   compile "stable-node" $cache
-  assertNotCaptured "- .npm (not cached - skipping)"
+  assertNotCaptured "- node_modules (not cached - skipping)"
   assertCapturedSuccess
 
-  rm -rf "$cache/node/.npm"
+  rm -rf "$cache/node/node_modules"
   compile "stable-node" $cache
-  assertCaptured "- .npm (not cached - skipping)"
+  assertCaptured "- node_modules (not cached - skipping)"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
This reverts one of the changes made Friday: no longer caching `node_modules` by default. Both npm and yarn get enormous performance boosts from existing `node_modules` directories, so it's worth the tradeoff.

For performance reasons, this also removes `yarn check`, which doesn't yet work as documented and in some cases is actually slower than `yarn install`.

I considered replacing `yarn check` with a manual `yarn.lock` diff pre-and-post install, but we saw that in some valid cases enforcing a build failure if `yarn.lock` changed is [not ideal](https://github.com/heroku/heroku-buildpack-nodejs/issues/367), but letting a non-lockfile build pass basically defeats the purpose of having a lockfile in the first place. `--pure-lockfile` and no checking is the best compromise for now.