### PR TITLE
use lts range instead of latest

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -35,9 +35,8 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local user_version="$1"
+  local version=${1:-6.x}
   local dir="$2"
-  local version=${user_version:-6.x}
 
   if needs_resolution "$version"; then
     echo "Resolving node version $version via semver.io..."

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -35,11 +35,12 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version="$1"
+  local user_version="$1"
   local dir="$2"
+  local version=${user_version:-6.x}
 
   if needs_resolution "$version"; then
-    echo "Resolving node version ${version:-(latest stable)} via semver.io..."
+    echo "Resolving node version $version via semver.io..."
     local version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/node/resolve)
   fi
 

--- a/test/run
+++ b/test/run
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testNoVersion() {
+  compile "no-version"
+  assertCaptured "engines.node (package.json):  unspecified"
+  assertCaptured "Resolving node version 6.x via semver.io"
+  assertCaptured "Downloading and installing node 6."
+  assertCapturedSuccess
+}
+
 testDisableCache() {
   cache=$(mktmpdir)
   env_dir=$(mktmpdir)
@@ -297,14 +305,6 @@ testIoJs() {
   assertCaptured "engines.iojs (package.json):  1.0."
   assertCaptured "Downloading and installing iojs 1.0."
   assertNotCaptured "Downloading and installing npm"
-  assertCapturedSuccess
-}
-
-testNoVersion() {
-  compile "no-version"
-  assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "Resolving node version (latest stable) via semver.io"
-  assertCaptured "Downloading and installing node 6."
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Whenever a node version isn't specified, pull down the LTS version (6.x) instead of latest.