### PR TITLE
tests and implementation for using the nodebin service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Node.js Buildpack Changelog
 
+## Master
+
+- Replace semver and s3pository with nodebin
+
 ## v98 (2017-01-31)
 
 - Default to the latest LTS node version (6.x)

--- a/bin/compile
+++ b/bin/compile
@@ -87,7 +87,11 @@ install_bins() {
   else
     echo "engines.node (package.json):  ${node_engine:-unspecified}"
   fi
-  echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
+  if [ -n "$yarn_engine" ]; then
+    echo "engines.yarn (package.json): ${yarn_engine:-unspecified}"
+  else
+    echo "engines.npm (package.json):   ${npm_engine:-default}"
+  fi
   echo ""
 
   if [ -n "$iojs_engine" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -36,6 +36,10 @@ source $BP_DIR/lib/binaries.sh
 source $BP_DIR/lib/cache.sh
 source $BP_DIR/lib/dependencies.sh
 
+### Check invalid package.json before adding an error trap
+
+fail_invalid_package_json "$BUILD_DIR"
+
 ### Handle errors
 
 handle_failure() {
@@ -54,9 +58,8 @@ trap 'handle_failure' ERR
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
 
-### Failures that should be caught immediately
+### Warnings that should be caught immediately
 
-fail_invalid_package_json "$BUILD_DIR"
 warn_prebuilt_modules "$BUILD_DIR"
 warn_missing_package_json "$BUILD_DIR"
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -1,24 +1,16 @@
-needs_resolution() {
-  local semver=$1
-  if ! [[ "$semver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 install_yarn() {
   local dir="$1"
   local version="$2"
+  local number
+  local url
 
-  if needs_resolution "$version"; then
-    echo "Resolving yarn version ${version:-(latest)} via semver.io..."
-    local version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/yarn/resolve)
+  echo "Resolving yarn version ${version:-(latest)}..."
+  if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/yarn/$platform/latest.txt"); then
+    echo "Unable to resolve; does that version exist?" && false
   fi
 
-  echo "Downloading and installing yarn ($version)..."
-  local download_url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
-  local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
+  echo "Downloading and installing yarn $number..."
+  local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false
   fi
@@ -37,38 +29,43 @@ install_yarn() {
 install_nodejs() {
   local version=${1:-6.x}
   local dir="$2"
+  local number
+  local url
 
-  if needs_resolution "$version"; then
-    echo "Resolving node version $version via semver.io..."
-    local version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/node/resolve)
+  echo "Resolving node version $version..."
+  if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
+    echo "Unable to resolve; does that version exist?" && false
   fi
 
-  echo "Downloading and installing node $version..."
-  local download_url="https://s3pository.heroku.com/node/v$version/node-v$version-$os-$cpu.tar.gz"
-  local code=$(curl "$download_url" --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
+  echo "Downloading and installing node $number..."
+  local code=$(curl "$url" --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
-    echo "Unable to download node $version; does it exist?" && false
+    echo "Unable to download node: $code" && false
   fi
   tar xzf /tmp/node.tar.gz -C /tmp
   rm -rf $dir/*
-  mv /tmp/node-v$version-$os-$cpu/* $dir
+  mv /tmp/node-v$number-$os-$cpu/* $dir
   chmod +x $dir/bin/*
 }
 
 install_iojs() {
   local version="$1"
   local dir="$2"
+  local number
+  local url
 
-  if needs_resolution "$version"; then
-    echo "Resolving iojs version ${version:-(latest stable)} via semver.io..."
-    version=$(curl --silent --get  --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/iojs/resolve)
+  echo "Resolving iojs version ${version:-(latest)}..."
+  if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/iojs/$platform/latest.txt"); then
+    echo "Unable to resolve; does that version exist?" && false
   fi
 
-  echo "Downloading and installing iojs $version..."
-  local download_url="https://iojs.org/dist/v$version/iojs-v$version-$os-$cpu.tar.gz"
-  curl "$download_url" --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz || (echo "Unable to download iojs $version; does it exist?" && false)
-  tar xzf /tmp/node.tar.gz -C /tmp
-  mv /tmp/iojs-v$version-$os-$cpu/* $dir
+  echo "Downloading and installing iojs $number..."
+  local code=$(curl "$url" --silent --fail --retry 5 --retry-max-time 15 -o /tmp/iojs.tar.gz --write-out "%{http_code}")
+  if [ "$code" != "200" ]; then
+    echo "Unable to download iojs: $code" && false
+  fi
+  tar xzf /tmp/iojs.tar.gz -C /tmp
+  mv /tmp/iojs-v$number-$os-$cpu/* $dir
   chmod +x $dir/bin/*
 }
 
@@ -78,15 +75,14 @@ install_npm() {
   if [ "$version" == "" ]; then
     echo "Using default npm version: `npm --version`"
   else
-    if needs_resolution "$version"; then
-      echo "Resolving npm version ${version} via semver.io..."
-      version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/npm/resolve)
-    fi
     if [[ `npm --version` == "$version" ]]; then
       echo "npm `npm --version` already installed with node"
     else
-      echo "Downloading and installing npm $version (replacing version `npm --version`)..."
-      npm install --unsafe-perm --quiet -g npm@$version 2>&1 >/dev/null
+      echo "Bootstrapping npm $version (replacing `npm --version`)..."
+      if ! npm install --unsafe-perm --quiet -g "npm@$version" 2>@1 >/dev/null; then
+        echo "Unable to install npm $version; does it exist?" && false
+      fi
+      echo "npm `npm --version` installed"
     fi
   fi
 }

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -1,3 +1,20 @@
+get_os() {
+  uname | tr A-Z a-z
+}
+
+get_cpu() {
+  if [[ "$(uname -p)" = "i686" ]]; then
+    echo "x86"
+  else
+    echo "x64"
+  fi
+}
+
+os=$(get_os)
+cpu=$(get_cpu)
+platform="$os-$cpu"
+export JQ="$BP_DIR/vendor/jq-$os"
+
 create_default_env() {
   export NPM_CONFIG_PRODUCTION=${NPM_CONFIG_PRODUCTION:-true}
   export NPM_CONFIG_LOGLEVEL=${NPM_CONFIG_LOGLEVEL:-error}

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -22,8 +22,7 @@ failure_message() {
 
 fail_invalid_package_json() {
   if ! cat ${1:-}/package.json | $JQ "." 1>/dev/null; then
-    error "Unable to parse package.json"
-    return 1
+    error "This project's package.json file has invalid syntax" && false
   fi
 }
 

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -1,19 +1,3 @@
-get_os() {
-  uname | tr A-Z a-z
-}
-
-get_cpu() {
-  if [[ "$(uname -p)" = "i686" ]]; then
-    echo "x86"
-  else
-    echo "x64"
-  fi
-}
-
-os=$(get_os)
-cpu=$(get_cpu)
-export JQ="$BP_DIR/vendor/jq-$os"
-
 read_json() {
   local file=$1
   local key=$2

--- a/test/fixtures/all-engines/package.json
+++ b/test/fixtures/all-engines/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "all-engines",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "engines": {
+    "node": ">6.0 <6.5",
+    "npm": "^3.x",
+    "yarn": "~0.20.0"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -89,6 +89,8 @@ testYarnRun() {
 
 testYarnEngine() {
   compile "yarn-engine"
+  assertCaptured "engines.yarn (package.json): 0.16.1"
+  assertNotCaptured "engines.npm"
   assertCaptured "installing yarn 0.16.1"
   assertCapturedSuccess
 }

--- a/test/run
+++ b/test/run
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testAllEngines() {
+  compile "all-engines"
+  assertCapturedSuccess
+}
+
 testNoVersion() {
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "Resolving node version 6.x via semver.io"
+  assertCaptured "Resolving node version 6.x"
   assertCaptured "Downloading and installing node 6."
   assertCapturedSuccess
 }
@@ -71,7 +76,7 @@ testBuildWithCache() {
 testYarnSemver() {
   compile "yarn-semver"
   assertCaptured "Resolving yarn version ~0.17"
-  assertCaptured "installing yarn (0.17."
+  assertCaptured "installing yarn 0.17."
   assertCapturedSuccess
 }
 
@@ -84,7 +89,7 @@ testYarnRun() {
 
 testYarnEngine() {
   compile "yarn-engine"
-  assertCaptured "installing yarn (0.16.1)"
+  assertCaptured "installing yarn 0.16.1"
   assertCapturedSuccess
 }
 
@@ -189,10 +194,8 @@ testUntrackedDependencies() {
 
 testBadJson() {
   compile "bad-json"
-  assertCaptured "Build failed"
-  assertCaptured "We're sorry this build is failing"
   assertNotCaptured "Installing binaries"
-  assertCapturedError 1 "Unable to parse"
+  assertCapturedError 1 "This project's package.json file has invalid syntax"
 }
 
 testBuildWithUserCacheDirectoriesCamel() {
@@ -249,15 +252,15 @@ testConcurrencyCustomLimit() {
 
 testInvalidNode() {
   compile "invalid-node"
-  assertCaptured "Downloading and installing node 0.11.333"
-  assertCaptured "Unable to download node 0.11.333"
+  assertCaptured "Resolving node version 0.11.333"
+  assertCaptured "Unable to resolve"
   assertCapturedError
 }
 
 testInvalidIo() {
   compile "invalid-io"
-  assertCaptured "Downloading and installing iojs 2.0.99"
-  assertCaptured "Unable to download iojs 2.0.99"
+  assertCaptured "Resolving iojs version 2.0.99"
+  assertCaptured "Unable to resolve"
   assertCapturedError
 }
 
@@ -310,7 +313,6 @@ testIoJs() {
 
 testSpecificVersion() {
   compile "specific-version"
-  assertNotCaptured "Resolving node version"
   assertCaptured "Downloading and installing node 0.10.29"
   assertCaptured "Using default npm version: 1.4.14"
   assertCapturedSuccess
@@ -325,7 +327,7 @@ testStableVersion() {
 
 testUnstableVersion() {
   compile "unstable-version"
-  assertCaptured "Resolving node version 0.11.x via semver.io"
+  assertCaptured "Resolving node version 0.11.x"
   assertCaptured "Downloading and installing node 0.11."
   assertCapturedSuccess
 }
@@ -344,7 +346,7 @@ testOldNpm2() {
 
 testNonexistentNpm() {
   compile "nonexistent-npm"
-  assertCaptured "version not found: npm@1.1.65"
+  assertCaptured "Unable to install npm 1.1.65; does it exist?"
   assertCapturedError 1 ""
 }
 
@@ -356,14 +358,13 @@ testSameNpm() {
 
 testNpmVersionRange() {
   compile "npm-version-range"
-  assertCaptured "Resolving npm version"
-  assertCaptured "installing npm 1.4."
+  assertCaptured "Bootstrapping npm 1.4."
   assertCapturedSuccess
 }
 
 testNpmVersionSpecific() {
   compile "npm-version-specific"
-  assertCaptured "installing npm 2.1.11"
+  assertCaptured "Bootstrapping npm 2.1.11"
   assertNotCaptured "Resolving npm version"
   assertNotCaptured "WARNING"
   assertCapturedSuccess
@@ -397,23 +398,23 @@ testInfoEmpty() {
 testDangerousRangeStar() {
   compile "dangerous-range-star"
   assertCaptured "Dangerous semver range"
-  assertCaptured "Resolving node version * via semver.io"
-  assertCaptured "Downloading and installing node 6."
+  assertCaptured "Resolving node version *"
+  assertCaptured "Downloading and installing node 7."
   assertCapturedError
 }
 
 testDangerousRangeGreaterThan() {
   compile "dangerous-range-greater-than"
   assertCaptured "Dangerous semver range"
-  assertCaptured "Resolving node version >0.4 via semver.io"
-  assertCaptured "Downloading and installing node 6."
+  assertCaptured "Resolving node version >0.4"
+  assertCaptured "Downloading and installing node 7."
   assertCapturedError
 }
 
 testRangeWithSpace() {
   compile "range-with-space"
-  assertCaptured "Resolving node version >= 0.8.x via semver.io"
-  assertCaptured "Downloading and installing node 6."
+  assertCaptured "Resolving node version >= 0.8.x"
+  assertCaptured "Downloading and installing node 7."
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -392,7 +392,7 @@ testTicketOnFailure() {
 testInfoEmpty() {
   compile "info-empty"
   assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "engines.npm (package.json):   unspecified"
+  assertCaptured "engines.npm (package.json):   default"
   assertCaptured "Installing node modules (package.json)"
   assertCapturedSuccess
 }


### PR DESCRIPTION
- Uses nodebin to evaluate versions instead of semver.io
- Uses nodebin to pull binaries instead of s3pository
- Uses nodebin to determine binary urls instead of string concatenation and prayers
- Uses npm to install bootstrapped npm versions instead of semver.io
- Moves package.json syntax failures above the failure trap, so they don't show a confusingly long error message