### PR TITLE
Check for .heroku/node

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,20 +18,9 @@ BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
-
-<<<<<<< HEAD
-mkdir -p "$BUILD_DIR/.heroku/node/"
-cd $BUILD_DIR
-export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
-
-LOG_FILE=$(mktemp -t node-build-log.XXXXX)
-echo "" > "$LOG_FILE"
-
 STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 BUILDPACK_LOG_FILE=${BUILDPACK_LOG_FILE:-/dev/null}
 
-=======
->>>>>>> Check for .heroku/node
 ### Load dependencies
 
 curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v2/stdlib.sh' > "$STDLIB_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -69,6 +69,7 @@ trap 'handle_failure' ERR
 
 ### Failures that should be caught immediately
 
+fail_dot_heroku "$BUILD_DIR"
 fail_dot_heroku_node "$BUILD_DIR"
 fail_invalid_package_json "$BUILD_DIR"
 warn_prebuilt_modules "$BUILD_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -19,6 +19,7 @@ CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 
+<<<<<<< HEAD
 mkdir -p "$BUILD_DIR/.heroku/node/"
 cd $BUILD_DIR
 export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
@@ -29,6 +30,8 @@ echo "" > "$LOG_FILE"
 STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 BUILDPACK_LOG_FILE=${BUILDPACK_LOG_FILE:-/dev/null}
 
+=======
+>>>>>>> Check for .heroku/node
 ### Load dependencies
 
 curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v2/stdlib.sh' > "$STDLIB_FILE"
@@ -40,6 +43,11 @@ source $BP_DIR/lib/environment.sh
 source $BP_DIR/lib/binaries.sh
 source $BP_DIR/lib/cache.sh
 source $BP_DIR/lib/dependencies.sh
+
+export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
+
+LOG_FILE=$(mktemp -t node-build-log.XXXXX)
+echo "" > "$LOG_FILE"
 
 ### Handle errors
 
@@ -61,6 +69,7 @@ trap 'handle_failure' ERR
 
 ### Failures that should be caught immediately
 
+fail_dot_heroku_node "$BUILD_DIR"
 fail_invalid_package_json "$BUILD_DIR"
 warn_prebuilt_modules "$BUILD_DIR"
 warn_missing_package_json "$BUILD_DIR"
@@ -75,6 +84,9 @@ create_env() {
 }
 
 header "Creating runtime environment"
+
+mkdir -p "$BUILD_DIR/.heroku/node/"
+cd $BUILD_DIR
 create_env # can't pipe the whole thing because piping causes subshells, preventing exports
 list_node_config | output "$LOG_FILE"
 

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -35,6 +35,20 @@ fail_invalid_package_json() {
   fi
 }
 
+fail_dot_heroku() {
+  if [ -f "${1:-}/.heroku" ]; then
+    header "Build failed"
+    warn "The directory .heroku could not be created
+
+       It looks like a .heroku file is checked into this project.
+       The Node.js buildpack uses the hidden directory .heroku to store
+       binaries like the node runtime and npm. You should remove the
+       .heroku file or ignore it by adding it to .slugignore
+       "
+    exit 1
+  fi
+}
+
 fail_dot_heroku_node() {
   if [ -f "${1:-}/.heroku/node" ]; then
     header "Build failed"

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -35,6 +35,20 @@ fail_invalid_package_json() {
   fi
 }
 
+fail_dot_heroku_node() {
+  if [ -f "${1:-}/.heroku/node" ]; then
+    header "Build failed"
+    warn "The directory .heroku/node could not be created
+
+       It looks like a .heroku file is checked into this project.
+       The Node.js buildpack uses the hidden directory .heroku to store
+       binaries like the node runtime and npm. You should remove the
+       .heroku file or ignore it by adding it to .slugignore
+       "
+    exit 1
+  fi
+}
+
 warning() {
   local tip=${1:-}
   local url=${2:-https://devcenter.heroku.com/articles/nodejs-support}

--- a/test/fixtures/dot-heroku-collision-2/.heroku/random-file
+++ b/test/fixtures/dot-heroku-collision-2/.heroku/random-file
@@ -1,0 +1,1 @@
+This is is in .heroku/ but doesn't conflict with our files

--- a/test/fixtures/dot-heroku-collision-2/package.json
+++ b/test/fixtures/dot-heroku-collision-2/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {},
+  "engines": {
+    "node": "0.10.29"
+  }
+}

--- a/test/fixtures/dot-heroku-collision/.heroku
+++ b/test/fixtures/dot-heroku-collision/.heroku
@@ -1,0 +1,1 @@
+This file could be anything!

--- a/test/fixtures/dot-heroku-collision/package.json
+++ b/test/fixtures/dot-heroku-collision/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {},
+  "engines": {
+    "node": "0.10.29"
+  }
+}

--- a/test/fixtures/dot-heroku-node-collision/.heroku/node
+++ b/test/fixtures/dot-heroku-node-collision/.heroku/node
@@ -1,0 +1,1 @@
+Filler file

--- a/test/fixtures/dot-heroku-node-collision/package.json
+++ b/test/fixtures/dot-heroku-node-collision/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {},
+  "engines": {
+    "node": "0.10.29"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -175,8 +175,22 @@ testWarningsOnFailure() {
   assertCapturedError
 }
 
+testDotHerokuCollision() {
+  compile "dot-heroku-collision"
+  assertCaptured "The directory .heroku could not be created"
+  assertCaptured ".heroku file is checked into this project"
+  assertNotCaptured "please submit a ticket"
+  assertCapturedError
+
+  compile "dot-heroku-collision-2"
+  assertCaptured "Build succeeded!"
+  assertNotCaptured ".heroku file is checked into this project"
+  assertCapturedSuccess
+}
+
 testDotHerokuNodeCollision() {
   compile "dot-heroku-node-collision"
+  assertCaptured "The directory .heroku/node could not be created"
   assertCaptured ".heroku file is checked into this project"
   assertNotCaptured "please submit a ticket"
   assertCapturedError

--- a/test/run
+++ b/test/run
@@ -175,6 +175,13 @@ testWarningsOnFailure() {
   assertCapturedError
 }
 
+testDotHerokuNodeCollision() {
+  compile "dot-heroku-node-collision"
+  assertCaptured ".heroku file is checked into this project"
+  assertNotCaptured "please submit a ticket"
+  assertCapturedError
+}
+
 testMultipleRuns() {
   local compileDir=$(mktmpdir)
   local cacheDir=$(mktmpdir)


### PR DESCRIPTION
If a user pushes a source tree that already includes .heroku/node, give a nice warning instead of a crypic error message.

Fixes #371 

Review me please? @hunterloftis @dzuelke @hone 

<img width="763" alt="hyper 2017-03-28 14-30-22" src="https://cloud.githubusercontent.com/assets/175496/24423574/1398dca8-13c3-11e7-87a3-1f7f21c5f0af.png">
