### PR TITLE
custom node binary with GC optimizations based on dyno size

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -100,6 +100,8 @@ install_bins() {
     install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
   fi
 
+  install_heroku_node "$BUILD_DIR/.heroku/node/bin"
+
   warn_old_npm
 }
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -90,3 +90,16 @@ install_npm() {
     fi
   fi
 }
+
+install_heroku_node() {
+  local dir="$1"
+
+  echo "Installing Heroku custom node binary..."
+
+  mv $dir/node $dir/node-original
+
+  echo "#!/usr/bin/env bash" > $dir/node
+  echo 'exec "`dirname "$0"`/node-original" $NODE_OPTS "$@"' >> $dir/node
+
+  chmod +x $dir/node
+}

--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -26,15 +26,35 @@ detect_memory() {
   esac
 }
 
+detect_node_opts() {
+    local mem
+
+    if (( ENV_WEB_MEMORY > 0 )); then
+      # WEB_MEMORY was manually set, assume user knows what they are doing
+      mem=${ENV_WEB_MEMORY}
+    else
+        # WEB_MEMORY was not set, optimize node memory for concurrency and available memory
+      mem=$((MEMORY_AVAILABLE / WEB_CONCURRENCY))
+    fi
+
+    local old_space=$((mem / 10 * 9)) # max old space size ~90% of available
+
+    echo "--optimize_for_size --max_old_space_size=$old_space --gc_interval=100"
+}
+
 export PATH="$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin:$PATH:$HOME/bin:$HOME/node_modules/.bin"
 export NODE_HOME="$HOME/.heroku/node"
 export NODE_ENV=${NODE_ENV:-production}
+
+ENV_WEB_MEMORY=${WEB_MEMORY-0}
 
 calculate_concurrency
 
 export MEMORY_AVAILABLE=$MEMORY_AVAILABLE
 export WEB_MEMORY=$WEB_MEMORY
 export WEB_CONCURRENCY=$WEB_CONCURRENCY
+
+export NODE_OPTS=${NODE_OPTS-$(detect_node_opts)}
 
 if [ "$LOG_CONCURRENCY" = "true" ]; then
   log_concurrency


### PR DESCRIPTION
- Custom node binary that reads `$NODE_OPTS`
- If user does not set `NODE_OPTS`, some flags are set based on dyno size, `WEB_CONCURRENCY` etc to optimize memory usage

Meant to resolve #287 

I based the default flags on this: https://blog.heroku.com/node-habits-2016#7-avoid-garbage but the original issue mentions some other flags. Any input on this is appreciated!

