### PR TITLE
Revert "Pad WEB_CONCURRENCY with a leading zero"

### DIFF
--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -1,16 +1,11 @@
 calculate_concurrency() {
-  local memory_available=$1
-  local web_memory=$2
-  local concurrency=$((memory_available/web_memory))
-
-  if (( concurrency < 1 )); then
-    concurrency=1
+  MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(detect_memory 512)}
+  WEB_MEMORY=${WEB_MEMORY-512}
+  WEB_CONCURRENCY=${WEB_CONCURRENCY-$((MEMORY_AVAILABLE/WEB_MEMORY))}
+  if (( WEB_CONCURRENCY < 1 )); then
+    WEB_CONCURRENCY=1
   fi
-
-  # We prepend the calculated value with a leading '0' so that other buildpacks
-  # can distinguish between a value set by the Node buildpack  and a value set 
-  # by the user
-  echo "0$concurrency"
+  WEB_CONCURRENCY=$WEB_CONCURRENCY
 }
 
 log_concurrency() {
@@ -35,11 +30,11 @@ export PATH="$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin:$PATH:$HOME/bin:$HOME
 export NODE_HOME="$HOME/.heroku/node"
 export NODE_ENV=${NODE_ENV:-production}
 
-export MEMORY_AVAILABLE=${MEMORY_AVAILABLE:-$(detect_memory 512)}
-export WEB_MEMORY=${WEB_MEMORY:-512}
+calculate_concurrency
 
-# if the user hasn't set a value for WEB_CONCURRENCY we compute a reasonable value
-export WEB_CONCURRENCY=${WEB_CONCURRENCY:-$(calculate_concurrency $MEMORY_AVAILABLE $WEB_MEMORY)}
+export MEMORY_AVAILABLE=$MEMORY_AVAILABLE
+export WEB_MEMORY=$WEB_MEMORY
+export WEB_CONCURRENCY=$WEB_CONCURRENCY
 
 if [ "$LOG_CONCURRENCY" = "true" ]; then
   log_concurrency

--- a/test/run
+++ b/test/run
@@ -223,45 +223,38 @@ testBuildWithUserCacheDirectoriesCamel() {
   assertCapturedSuccess
 }
 
-testConcurrencyExplicit() {
-  LOG_CONCURRENCY=true MEMORY_AVAILABLE=1024 WEB_MEMORY=256 WEB_CONCURRENCY=3 capture $(pwd)/profile/nodejs.sh
-  assertCaptured "Detected 1024 MB available memory, 256 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=3"
-  assertCapturedSuccess
-}
-
 testConcurrency1X() {
   LOG_CONCURRENCY=true MEMORY_AVAILABLE=512 capture $(pwd)/profile/nodejs.sh
   assertCaptured "Detected 512 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=01"
+  assertCaptured "Recommending WEB_CONCURRENCY=1"
   assertCapturedSuccess
 }
 
 testConcurrency2X() {
   LOG_CONCURRENCY=true MEMORY_AVAILABLE=1024 capture $(pwd)/profile/nodejs.sh
   assertCaptured "Detected 1024 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=02"
+  assertCaptured "Recommending WEB_CONCURRENCY=2"
   assertCapturedSuccess
 }
 
 testConcurrencyPerformanceM() {
   LOG_CONCURRENCY=true MEMORY_AVAILABLE=2560 capture $(pwd)/profile/nodejs.sh
   assertCaptured "Detected 2560 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=05"
+  assertCaptured "Recommending WEB_CONCURRENCY=5"
   assertCapturedSuccess
 }
 
 testConcurrencyPerformanceL() {
    LOG_CONCURRENCY=true MEMORY_AVAILABLE=14336 capture $(pwd)/profile/nodejs.sh
    assertCaptured "Detected 14336 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-   assertCaptured "Recommending WEB_CONCURRENCY=028"
+   assertCaptured "Recommending WEB_CONCURRENCY=28"
    assertCapturedSuccess
 }
 
 testConcurrencyCustomLimit() {
   LOG_CONCURRENCY=true MEMORY_AVAILABLE=1024 WEB_MEMORY=256 capture $(pwd)/profile/nodejs.sh
   assertCaptured "Detected 1024 MB available memory, 256 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=04"
+  assertCaptured "Recommending WEB_CONCURRENCY=4"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
This reverts https://github.com/heroku/heroku-buildpack-nodejs/pull/389 since it affected a few customers negatively.

This reverts commit dd6a5f5aaa9e3a577e77299960c3a5513d1f93e2. Generated with the command: `git revert dd6a5f5aaa9e3a577e77299960c3a5513d1f93e2`