### PR TITLE
Remove YARN_PRODUCTION and add NODE_ENV=test to test-compile

### DIFF
--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-NPM_CONFIG_PRODUCTION=false YARN_PRODUCTION=false "$(dirname ${0:-})/compile" "$1" "$2" "$3"
+NPM_CONFIG_PRODUCTION=false NODE_ENV=test "$(dirname ${0:-})/compile" "$1" "$2" "$3"


### PR DESCRIPTION
`YARN_PRODUCTION` doesn't seem to actually be a thing, and changing `NODE_ENV` to something other than `production` is necessary for yarn to install `devDependencies`.