### PR TITLE
Make yarn available to application if defined in engines

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -104,6 +104,9 @@ install_bins() {
     mcount "version.node.$(node --version)"
   fi
 
+  # Download yarn if there is a yarn.lock file or if the user
+  # has specified a version of yarn under "engines". We'll still
+  # only install using yarn if there is a yarn.lock file
   if $YARN || [ -n "$yarn_engine" ]; then
     install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -103,8 +103,12 @@ install_bins() {
     install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
     mcount "version.node.$(node --version)"
   fi
-  if $YARN; then
+
+  if $YARN || [ -n "$yarn_engine" ]; then
     install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
+  fi
+
+  if $YARN; then
     mcount "version.yarn.$(yarn --version)"
   else
     mcount "version.npm.$(npm --version)"

--- a/test/fixtures/yarn-only-engine/package.json
+++ b/test/fixtures/yarn-only-engine/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "engines": {
+    "yarn": "0.24.5"
+  },
+  "dependencies": {
+    "lodash": "^4.16.4"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -88,6 +88,15 @@ testYarnEngine() {
   assertCapturedSuccess
 }
 
+# If they specify a version of yarn inside package.json but
+# don't have a yarn.lock file download and make yarn available
+# though we will only install using yarn if a yarn.lock exists
+testYarnOnlyEngine() {
+  compile "yarn-only-engine"
+  assertCaptured "installing yarn (0.16.1)"
+  assertCapturedSuccess
+}
+
 testWarnUnmetDepNpm() {
   compile "unmet-dep"
   assertCaptured "fail npm install"

--- a/test/run
+++ b/test/run
@@ -93,7 +93,7 @@ testYarnEngine() {
 # though we will only install using yarn if a yarn.lock exists
 testYarnOnlyEngine() {
   compile "yarn-only-engine"
-  assertCaptured "installing yarn (0.16.1)"
+  assertCaptured "installing yarn (0.24.5)"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Fixes #402 

As long as the user has explicitly defined a yarn version within `package.json` it makes sense for us to download an install it for them, even without a `yarn.lock` file.

Use case:
Desire to use yarn to build a frontend app in a ruby application that's not at the root. Adding a `yarn.lock` to the root doesn't make much sense.