### PR TITLE
Add $PREBUILD to cache signature

### DIFF
--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -1,7 +1,7 @@
 source $BP_DIR/lib/binaries.sh
 
 create_signature() {
-  echo "$(node --version); $(npm --version); $(yarn --version 2>/dev/null || true)"
+  echo "$(node --version); $(npm --version); $(yarn --version 2>/dev/null || true) $PREBUILD"
 }
 
 save_signature() {

--- a/test/fixtures/cache-prebuild/README.md
+++ b/test/fixtures/cache-prebuild/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/cache-prebuild/package.json
+++ b/test/fixtures/cache-prebuild/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -68,6 +68,19 @@ testBuildWithCache() {
   assertCapturedSuccess
 }
 
+testCacheWithPrebuild() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  echo 'true' > "$env_dir"/PREBUILD
+
+  compile "cache-prebuild" $cache
+  assertCapturedSuccess
+
+  compile "cache-prebuild" $cache $env_dir
+  assertCaptured "Skipping cache restore (new-signature"
+  assertCapturedSuccess
+}
+
 testYarnSemver() {
   compile "yarn-semver"
   assertCaptured "Resolving yarn version ~0.17"


### PR DESCRIPTION
The buildpack should bust the cache whenever the PREBUILD boolean changes to prevent the user from caching their local `node_modules` directory

Fixes #399