### PR TITLE
Skip heroku-postbuild script when NODE_ENV is test

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -170,7 +170,11 @@ build_dependencies() {
 
   mtime "modules.time.cache.$cache_status" "${start}"
 
-  run_if_present 'heroku-postbuild'
+  # Don't run heroku-postbuild script when running tests
+  if [ "$NODE_ENV" != "test" ]; then
+    run_if_present 'heroku-postbuild'
+  fi
+
   # TODO: run_if_present 'build'
   log_build_scripts
 }


### PR DESCRIPTION
Large apps tend to transpile code, bundle assets etc. which makes for some extremely long build times. These tasks tend to be run by specifying a postinstall/heroku-postbuild script in package.json.

When testing via Heroku CI this behavior can't disabled drastically slowing down tests as postinstall/heroku-postbuild is run before npm run test.

This PR will skip running heroku-postbuild (but not postinstall) when `NODE_ENV=test` and instead rely on test-setup to manually invoke something like npm run heroku-postbuild/postinstall

For projects that rely on heroku-postbuild running before tests, this represents a breaking change.