### PR TITLE
Log out yarn version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -93,6 +93,9 @@ install_bins() {
     echo "engines.node (package.json):  ${node_engine:-unspecified}"
   fi
   echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
+  if $YARN; then
+    echo "engines.yarn (package.json):   ${yarn_engine:-unspecified (use default)}"
+  fi
   echo ""
 
   if [ -n "$iojs_engine" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -94,7 +94,7 @@ install_bins() {
   fi
   echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
   if $YARN; then
-    echo "engines.yarn (package.json):   ${yarn_engine:-unspecified (use default)}"
+    echo "engines.yarn (package.json):  ${yarn_engine:-unspecified (use default)}"
   fi
   echo ""
 


### PR DESCRIPTION
Fixes #423

Cases:

Not using Yarn:
<img width="558" alt="hyper 2017-06-09 10-43-45" src="https://user-images.githubusercontent.com/175496/26987478-8a74c2da-4d00-11e7-8f72-4eb6df2009ed.png">

`yarn.lock` but no version:
<img width="649" alt="hyper 2017-06-09 10-42-56" src="https://user-images.githubusercontent.com/175496/26987487-90045f4e-4d00-11e7-821e-728de89dd424.png">

`yarn.lock` with version:
<img width="637" alt="hyper 2017-06-09 10-43-26" src="https://user-images.githubusercontent.com/175496/26987494-946015b0-4d00-11e7-8603-f25792fb3f3d.png">
