### PR TITLE
Test for package-lock.json

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -55,6 +55,7 @@ trap 'handle_failure' ERR
 
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
+[ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
 
 ### Failures that should be caught immediately
 
@@ -103,7 +104,7 @@ install_bins() {
   else
     warn_node_engine "$node_engine"
     install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
-    install_npm "$npm_engine" "$BUILD_DIR/.heroku/node"
+    install_npm "$npm_engine" "$BUILD_DIR/.heroku/node" $NPM_LOCK
     mcount "version.node.$(node --version)"
   fi
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -74,6 +74,13 @@ install_iojs() {
 
 install_npm() {
   local version="$1"
+  local dir="$2"
+  local npm_lock="$3"
+
+  if $npm_lock && [ "$version" == "" ]; then
+    echo "Detected package-lock.json: defaulting npm to version 5.x.x"
+    version="5.x.x"
+  fi
 
   if [ "$version" == "" ]; then
     echo "Using default npm version: `npm --version`"

--- a/test/fixtures/npm-lockfile-no-version/package-lock.json
+++ b/test/fixtures/npm-lockfile-no-version/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    }
+  }
+}

--- a/test/fixtures/npm-lockfile-no-version/package.json
+++ b/test/fixtures/npm-lockfile-no-version/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "lodash": "^4.16.4"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -119,6 +119,13 @@ testErrorYarnAndNpmLockfiles() {
   assertCapturedError
 }
 
+testDefaultToNpm5() {
+  compile "npm-lockfile-no-version"
+  assertCaptured "Detected package-lock.json"
+  assertCaptured "Downloading and installing npm 5."
+  assertCapturedSuccess
+}
+
 testWarnUnmetDepNpm() {
   compile "unmet-dep"
   assertCaptured "fail npm install"


### PR DESCRIPTION
If the user has not specified a version for npm, but there is a package-lock.json we should automatically install npm 5.

npm v5 is a pretty big diversion from previous iterations in that it has a lock file by default. However our default version is whatever is installed with our Node installation. If the user has specified Node 8 then that will be npm v5, but that's not our default.

If we detect that the user is using npm v5 through the presence of the lockfile we should smartly update them to a version of npm that will respect it, even if they don't define the version themselves.

Fixes #422 