### PR TITLE
Warn the user if they specify an old version of npm but have a lockfile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -217,3 +217,4 @@ summarize_build | output "$LOG_FILE"
 
 warn_no_start "$LOG_FILE"
 warn_unmet_dep "$LOG_FILE"
+warn_old_npm_lockfile $NPM_LOCK

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -143,6 +143,16 @@ warn_old_npm() {
   fi
 }
 
+warn_old_npm_lockfile() {
+  local npm_lock=$1
+  local npm_version="$(npm --version)"
+  if $npm_lock && [ "${npm_version:0:1}" -lt "5" ]; then
+    warn "This version of npm ($npm_version) does not support package-lock.json. Please
+       update your npm version in package.json." "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+    mcount 'warnings.npm.old-and-lockfile'
+  fi
+}
+
 warn_young_yarn() {
   if $YARN; then
     warning "This project was built with yarn, which is new and under development. Some projects can still be built more reliably with npm" "https://devcenter.heroku.com/articles/nodejs-support#build-behavior"

--- a/test/fixtures/npm-lockfile-old-version/package-lock.json
+++ b/test/fixtures/npm-lockfile-old-version/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    }
+  }
+}

--- a/test/fixtures/npm-lockfile-old-version/package.json
+++ b/test/fixtures/npm-lockfile-old-version/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "lodash": "^4.16.4"
+  },
+  "engines": {
+    "npm": "2.x.x"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -126,6 +126,13 @@ testDefaultToNpm5() {
   assertCapturedSuccess
 }
 
+testOldNpmWithLockfile() {
+  compile "npm-lockfile-old-version"
+  assertCaptured "This version of npm"
+  assertCaptured "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+  assertCapturedSuccess
+}
+
 testWarnUnmetDepNpm() {
   compile "unmet-dep"
   assertCaptured "fail npm install"


### PR DESCRIPTION
Fixes #428

If a user specified a version of npm a long time ago and forgot about it, but upgrades to npm 5 locally, this will warn them.

<img width="875" alt="hyper 2017-06-13 22-49-01" src="https://user-images.githubusercontent.com/175496/27117347-15dd771c-508b-11e7-87d0-596aa0791c67.png">
