### PR TITLE
If the user is using yarn, use yarn start

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
+local start_command="npm start"
+if $YARN; then
+  start_command="yarn start"
+fi
+
 cat << EOF
 addons: []
 default_process_types:
-  web: npm start
+  web: $start_command
 EOF

--- a/bin/release
+++ b/bin/release
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-local start_command="npm start"
 if $YARN; then
-  start_command="yarn start"
-fi
-
-cat << EOF
+  cat << EOF
 addons: []
 default_process_types:
-  web: $start_command
+  web: yarn start
 EOF
+else
+  cat << EOF
+addons: []
+default_process_types:
+  web: npm start
+EOF
+fi

--- a/test/run
+++ b/test/run
@@ -539,6 +539,12 @@ testDefaultProcType() {
   assertCapturedSuccess
 }
 
+testYarnDefaltProcType() {
+  release "yarn"
+  assertCaptured "web: yarn start"
+  assertCapturedSuccess
+}
+
 testDynamicProcfile() {
   compile "dynamic-procfile"
   assertFileContains "web: node index.js customArg" "${compile_dir}/Procfile"

--- a/test/run
+++ b/test/run
@@ -539,7 +539,7 @@ testDefaultProcType() {
   assertCapturedSuccess
 }
 
-testYarnDefaltProcType() {
+testYarnDefaultProcType() {
   release "yarn"
   assertCaptured "web: yarn start"
   assertCapturedSuccess


### PR DESCRIPTION
Fixes #424

Without a procfile we default to `npm start` to kick off the app, but if the user is using yarn this should be `yarn start`.

I'm not aware of any differences in how they behave, but there could be subtle issues over time.