### PR TITLE
Pin yarn to 0.24.x

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -9,7 +9,7 @@ needs_resolution() {
 
 install_yarn() {
   local dir="$1"
-  local version="$2"
+  local version=${2:-0.24.x}
 
   if needs_resolution "$version"; then
     echo "Resolving yarn version ${version:-(latest)} via semver.io..."


### PR DESCRIPTION
We had a customer affected by this yarn bug: https://github.com/yarnpkg/yarn/issues/3801 and their build suddenly broke when we started installing `0.27.x` as our default version of Yarn.

This pins the default version to back to `0.24.x` which I will remove once https://github.com/yarnpkg/yarn/issues/3801 is resolved.