### PR TITLE
Added check for serverless yml file, and exit 1 if it exists.

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-if [ -f $1/package.json ]; then
+
+# Necessary to determine between standard nodejs web app and serverless cloudfunction nodejs.
+if [ -f $1/package.json ] && [ ! -f $1/serverless.yml ] ; then
   echo "Node.js"
   exit 0
 fi


### PR DESCRIPTION
This change is necessary to discriminate against Nodejs code that also has the serverless.yml file.

See https://serverless.com

A new build pack (https://github.com/caffeinated-expert/heroku-buildpack-gcf-nodejs) based on (https://github.com/caffeinated-expert/heroku-buildpack-nodejs) has been created and will request Heroku to accept this buildpack into their codebase.