### PR TITLE
Switch over to using nodebin for yarn

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -10,15 +10,16 @@ needs_resolution() {
 install_yarn() {
   local dir="$1"
   local version="$2"
+  local number
+  local url
 
-  if needs_resolution "$version"; then
-    echo "Resolving yarn version ${version:-(latest)} via semver.io..."
-    local version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/yarn/resolve)
+  echo "Resolving yarn version ${version:-(latest)}..."
+  if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/yarn/$platform/latest.txt"); then
+    echo "Unable to resolve; does that version exist?" && false
   fi
 
-  echo "Downloading and installing yarn ($version)..."
-  local download_url="https://yarnpkg.com/downloads/$version/yarn-v$version.tar.gz"
-  local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
+  echo "Downloading and installing yarn ($number)..."
+  local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false
   fi

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -1,3 +1,20 @@
+get_os() {
+  uname | tr A-Z a-z
+}
+
+get_cpu() {
+  if [[ "$(uname -p)" = "i686" ]]; then
+    echo "x86"
+  else
+    echo "x64"
+  fi
+}
+
+os=$(get_os)
+cpu=$(get_cpu)
+platform="$os-$cpu"
+export JQ="$BP_DIR/vendor/jq-$os"
+
 create_default_env() {
   export NPM_CONFIG_PRODUCTION=${NPM_CONFIG_PRODUCTION:-true}
   export NPM_CONFIG_LOGLEVEL=${NPM_CONFIG_LOGLEVEL:-error}

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -1,19 +1,3 @@
-get_os() {
-  uname | tr A-Z a-z
-}
-
-get_cpu() {
-  if [[ "$(uname -p)" = "i686" ]]; then
-    echo "x86"
-  else
-    echo "x64"
-  fi
-}
-
-os=$(get_os)
-cpu=$(get_cpu)
-export JQ="$BP_DIR/vendor/jq-$os"
-
 read_json() {
   local file=$1
   local key=$2


### PR DESCRIPTION
This switches over to using the new nodebin service to download the Yarn binary. We'll roll this out first and then convert the other binaries over to the new service if things look good.

Notably this will fix #418 