### PR TITLE
Add $STACK to the cache signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Add `$STACK` to the cache signature (#445)
+
 ## v106 (2017-06-19)
 
 - Default to npm v5 if `package-lock.json` is present (#429)

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -1,7 +1,7 @@
 source $BP_DIR/lib/binaries.sh
 
 create_signature() {
-  echo "$(node --version); $(npm --version); $(yarn --version 2>/dev/null || true) $PREBUILD"
+  echo "${STACK}; $(node --version); $(npm --version); $(yarn --version 2>/dev/null || true); ${PREBUILD}"
 }
 
 save_signature() {

--- a/test/run
+++ b/test/run
@@ -60,6 +60,7 @@ testBuildWithCache() {
 
   compile "stable-node" $cache
   assertNotCaptured "- node_modules (not cached - skipping)"
+  assertFileContains "${STACK}" "${cache}/node/signature"
   assertCapturedSuccess
 
   rm -rf "$cache/node/node_modules"


### PR DESCRIPTION
To ensure that the cache is busted when apps update to a new stack.

Fixes #445.