### PR TITLE
Differentiate between an empty cache and a new signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Log output now differentiates between an empty cache and a new cache signature
+
 ## v106 (2017-06-19)
 
 - Default to npm v5 if `package-lock.json` is present (#429)

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -19,6 +19,8 @@ load_signature() {
 get_cache_status() {
   if ! ${NODE_MODULES_CACHE:-true}; then
     echo "disabled"
+  elif ! test -d "${CACHE_DIR}/node/"; then
+    echo "not-found"
   elif [ "$(create_signature)" != "$(load_signature)" ]; then
     echo "new-signature"
   else

--- a/test/run
+++ b/test/run
@@ -54,7 +54,7 @@ testBuildWithCache() {
   cache=$(mktmpdir)
 
   compile "stable-node" $cache
-  assertCaptured "Skipping cache restore (new-signature"
+  assertCaptured "Skipping cache restore (not-found)"
   assertEquals "1" "$(ls -1 $cache/node/node_modules | grep hashish | wc -l | tr -d ' ')"
   assertCapturedSuccess
 


### PR DESCRIPTION
Previously new apps (or apps where the cache has been cleared using the heroku-repo plugin) would give a skipping cache restore message of "new-signature" which was slightly misleading.