### PR TITLE
Remove the use of semver.io to bootstrap npm

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -85,16 +85,13 @@ install_npm() {
 
   if [ "$version" == "" ]; then
     echo "Using default npm version: `npm --version`"
+  elif [[ `npm --version` == "$version" ]]; then
+    echo "npm `npm --version` already installed with node"
   else
-    if needs_resolution "$version"; then
-      echo "Resolving npm version ${version} via semver.io..."
-      version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.herokuapp.com/npm/resolve)
+    echo "Bootstrapping npm $version (replacing `npm --version`)..."
+    if ! npm install --unsafe-perm --quiet -g "npm@$version" 2>@1>/dev/null; then
+      echo "Unable to install npm $version; does it exist?" && false
     fi
-    if [[ `npm --version` == "$version" ]]; then
-      echo "npm `npm --version` already installed with node"
-    else
-      echo "Downloading and installing npm $version (replacing version `npm --version`)..."
-      npm install --unsafe-perm --quiet -g npm@$version 2>&1 >/dev/null
-    fi
+    echo "npm `npm --version` installed"
   fi
 }

--- a/test/run
+++ b/test/run
@@ -132,7 +132,7 @@ testErrorYarnAndNpmShrinkwrap() {
 testDefaultToNpm5() {
   compile "npm-lockfile-no-version"
   assertCaptured "Detected package-lock.json"
-  assertCaptured "Downloading and installing npm 5."
+  assertCaptured "Bootstrapping npm 5"
   assertCapturedSuccess
 }
 
@@ -431,7 +431,7 @@ testOldNpm2() {
 
 testNonexistentNpm() {
   compile "nonexistent-npm"
-  assertCaptured "version not found: npm@1.1.65"
+  assertCaptured "Unable to install npm 1.1.65"
   assertCapturedError 1 ""
 }
 
@@ -443,15 +443,13 @@ testSameNpm() {
 
 testNpmVersionRange() {
   compile "npm-version-range"
-  assertCaptured "Resolving npm version"
-  assertCaptured "installing npm 1.4."
+  assertCaptured "Bootstrapping npm 1.4.x"
   assertCapturedSuccess
 }
 
 testNpmVersionSpecific() {
   compile "npm-version-specific"
-  assertCaptured "installing npm 2.1.11"
-  assertNotCaptured "Resolving npm version"
+  assertCaptured "Bootstrapping npm 2.1.11"
   assertNotCaptured "WARNING"
   assertCapturedSuccess
 }


### PR DESCRIPTION
Rather than use semver.io to determine which version of npm to install given a semver range, let npm do it itself