### PR TITLE
Move the default Yarn cache directory to a tmp dir

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -22,6 +22,7 @@ STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 
 ### Configure package manager cache directories
 [ ! "$YARN_CACHE_FOLDER" ] && YARN_CACHE_FOLDER=$(mktemp -d -t yarncache.XXXXX)
+[ ! "$NPM_CONFIG_CACHE" ] && NPM_CONFIG_CACHE=$(mktemp -d -t npmcache.XXXXX)
 
 ### Load dependencies
 

--- a/bin/compile
+++ b/bin/compile
@@ -20,6 +20,9 @@ ENV_DIR=${3:-}
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 
+### Configure package manager cache directories
+[ ! "$YARN_CACHE_FOLDER" ] && YARN_CACHE_FOLDER=$(mktemp -d -t yarncache.XXXXX)
+
 ### Load dependencies
 
 curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh' > "$STDLIB_FILE"

--- a/test/fixtures/npm5/package-lock.json
+++ b/test/fixtures/npm5/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    }
+  }
+}

--- a/test/fixtures/npm5/package.json
+++ b/test/fixtures/npm5/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "engines": {
+    "npm": "5.3.0"
+  },
+  "dependencies": {
+    "lodash": "^4.16.4"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -63,6 +63,18 @@ testYarnCacheDirectory() {
   assertCapturedSuccess
 }
 
+testNpm5CacheDirectory() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  local cache_dir=$(mktmpdir)
+  echo "${cache_dir}/npm"> "$env_dir"/NPM_CONFIG_CACHE
+  compile "npm5" $cache $env_dir
+  # These will be created if npm is using the directory for its cache
+  assertDirectoryExists ${cache_dir}/npm
+  assertDirectoryExists ${cache_dir}/npm/_cacache
+  assertCapturedSuccess
+}
+
 testBuildWithCache() {
   cache=$(mktmpdir)
 

--- a/test/run
+++ b/test/run
@@ -50,6 +50,19 @@ testYarn() {
   assertCapturedSuccess
 }
 
+testYarnCacheDirectory() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  local cache_dir=$(mktmpdir)
+  echo "${cache_dir}/yarn"> "$env_dir"/YARN_CACHE_FOLDER
+  compile "yarn" $cache $env_dir
+  # These will be created if yarn is using the directory for its cache
+  assertDirectoryExists ${cache_dir}/yarn
+  assertDirectoryExists ${cache_dir}/yarn/v1
+  assertDirectoryExists ${cache_dir}/yarn/v1/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
+  assertCapturedSuccess
+}
+
 testBuildWithCache() {
   cache=$(mktmpdir)
 
@@ -681,6 +694,7 @@ testMultiExport() {
   assertCapturedSuccess
 }
 
+
 # Utils
 
 pushd $(dirname 0) >/dev/null
@@ -737,6 +751,15 @@ release() {
 
 assertFile() {
   assertEquals "$1" "$(cat ${compile_dir}/$2)"
+}
+
+assertDirectoryExists() {
+  if [[ ! -e "$1" ]]; then
+    fail "$1 does not exist"
+  fi
+  if [[ ! -d $1 ]]; then
+    fail "$1 is not a directory"
+  fi
 }
 
 source $(pwd)/test/shunit2


### PR DESCRIPTION
Fixes #439

Copying the issue text here for context:

> Yarn and npm5 both have cache directories that get defaulted to the $HOME directory on linux. ~/.npm for npm5 and ~/.cache/yarn for yarn.

> This creates an issue for Heroku since $HOME=/app which is the same directory where your application is run. So far this hasn't been a problem because apps are built in a temporary directory, but this will be changing to /app as well in the future. If this were to happen today we'd see a big increase in slug size because the cache directory would be included along with your application.

> It's a bigger issue in Heroku CI in the case of running tests with Jest. Jest will automatically pick up tests in the cache directory, causing your CI tests to fail in hard-to-debug ways when they run fine locally. Context: facebook/jest#3935

> The solution in both cases is to take control of the cache directories and move them into /tmp by default. Though if users want to cache these cache directories we need to provide a mechanism for them to be able to.