### PR TITLE
Add BUILD_DIR to env var blacklist

### DIFF
--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -40,7 +40,7 @@ export_env_dir() {
   local env_dir=$1
   if [ -d "$env_dir" ]; then
     local whitelist_regex=${2:-''}
-    local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG)$'}
+    local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG|BUILD_DIR)$'}
     if [ -d "$env_dir" ]; then
       for e in $(ls $env_dir); do
         echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&


### PR DESCRIPTION
Fixes #383

Context: A user tried to set `BUILD_DIR` to make the buildpack work for a subdirectory