### PR TITLE
Read memory limit

### DIFF
--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -15,15 +15,12 @@ log_concurrency() {
 
 detect_memory() {
   local default=$1
-  local limit=$(ulimit -u)
 
-  case $limit in
-    256) echo "512";;      # Standard-1X
-    512) echo "1024";;     # Standard-2X
-    16384) echo "2560";;   # Performance-M
-    32768) echo "14336";;  # Performance-L
-    *) echo "$default";;
-  esac
+  if [ -e /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+    expr "$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)" / 1048576
+  else
+    echo "$default"
+  fi
 }
 
 export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(detect_memory 512)}


### PR DESCRIPTION
The `/sys/fs/cgroup/memory/memory.limit_in_bytes` file is now available in both the common runtime and in private spaces.

It contains the actual memory limit of the dyno. 

It's furthermore portable meaning a better default will be set if using the buildpack with Docker.