### PR TITLE
Detect when WEB_CONCURRENCY is way too high

### DIFF
--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -4,6 +4,9 @@ calculate_concurrency() {
   WEB_CONCURRENCY=${WEB_CONCURRENCY-$((MEMORY_AVAILABLE/WEB_MEMORY))}
   if (( WEB_CONCURRENCY < 1 )); then
     WEB_CONCURRENCY=1
+  elif (( WEB_CONCURRENCY > 100 )); then
+    # Ex: This will happen on Dokku on DO
+    WEB_CONCURRENCY=1
   fi
   echo $WEB_CONCURRENCY
 }
@@ -22,6 +25,22 @@ detect_memory() {
     echo "$default"
   fi
 }
+
+warn_bad_web_concurrency() {
+  local memory=${MEMORY_AVAILABLE-$(detect_memory 512)}
+
+  # No webserver will have 10000GB of RAM
+  if [ $memory -gt "10000000" ]; then
+    echo "Could not determine a reasonable value for WEB_CONCCURENCY.
+This is likely due to running the Heroku NodeJS buildpack on a non-Heroku
+platform.
+
+WEB_CONCURRENCY has been set to 1. Please review whether this value is
+appropriate for your application."
+  fi
+}
+
+warn_bad_web_concurrency
 
 export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(detect_memory 512)}
 export WEB_MEMORY=${WEB_MEMORY-512}

--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -4,7 +4,7 @@ calculate_concurrency() {
   WEB_CONCURRENCY=${WEB_CONCURRENCY-$((MEMORY_AVAILABLE/WEB_MEMORY))}
   if (( WEB_CONCURRENCY < 1 )); then
     WEB_CONCURRENCY=1
-  elif (( WEB_CONCURRENCY > 100 )); then
+  elif (( WEB_CONCURRENCY > 200 )); then
     # Ex: This will happen on Dokku on DO
     WEB_CONCURRENCY=1
   fi
@@ -27,24 +27,23 @@ detect_memory() {
 }
 
 warn_bad_web_concurrency() {
-  local memory=${MEMORY_AVAILABLE-$(detect_memory 512)}
-
-  # No webserver will have 10000GB of RAM
-  if [ $memory -gt "10000000" ]; then
+  local concurrency=$((MEMORY_AVAILABLE/WEB_MEMORY))
+  if [ "$concurrency" -gt "200" ]; then
     echo "Could not determine a reasonable value for WEB_CONCCURENCY.
 This is likely due to running the Heroku NodeJS buildpack on a non-Heroku
 platform.
 
 WEB_CONCURRENCY has been set to 1. Please review whether this value is
 appropriate for your application."
+    echo ""
   fi
 }
-
-warn_bad_web_concurrency
 
 export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(detect_memory 512)}
 export WEB_MEMORY=${WEB_MEMORY-512}
 export WEB_CONCURRENCY=$(calculate_concurrency)
+
+warn_bad_web_concurrency
 
 if [[ "${LOG_CONCURRENCY+isset}" && "$LOG_CONCURRENCY" == "true" ]]; then
   log_concurrency

--- a/test/run
+++ b/test/run
@@ -386,6 +386,15 @@ testConcurrencyCustomLimit() {
   assertCapturedSuccess
 }
 
+# When /sys/fs/cgroup/memory/memory.limit_in_bytes lies and gives a ridiculous value
+# This happens on Dokku for example
+testConcurrencyTooHigh() {
+  LOG_CONCURRENCY=true MEMORY_AVAILABLE=10000000000 capture $(pwd)/profile/WEB_CONCURRENCY.sh
+  assertCaptured "Could not determine a reasonable value for WEB_CONCCURENCY"
+  assertCaptured "Recommending WEB_CONCURRENCY=1"
+  assertCapturedSuccess
+}
+
 testInvalidNode() {
   compile "invalid-node"
   assertCaptured "Resolving node version 0.11.333"


### PR DESCRIPTION
Fixes #484

With https://github.com/heroku/heroku-buildpack-nodejs/pull/474 we started reading `/sys/fs/cgroup/memory/memory.limit_in_bytes` to get the amount of addressable RAM on the machine and determine a sane value for `WEB_CONCURRENCY`.

However non-Heroku environments may not set this value. In the case of Dokku on Digital Ocean this value exists, but is unreasonably high. This will detect the case where we calculate a ridiculous `WEB_CONCURRENCY` value, default to 1, and print a warning.