### PR TITLE
Add more metrics around build scripts

### DIFF
--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -54,9 +54,12 @@ log_build_scripts() {
   if [ -n "$postinstall" ]; then
     mcount "scripts.postinstall"
 
-    if [ "$postinstall" == "npm run build" ]; then
+    if [ "$postinstall" == "npm run build" ] ||
+       [ "$postinstall" == "yarn run build" ] ||
+       [ "$postinstall" == "yarn build" ]; then
       mcount "scripts.postinstall-is-npm-build"
     fi
+
   fi
 
   if [ -n "$heroku_prebuild" ]; then
@@ -66,7 +69,9 @@ log_build_scripts() {
   if [ -n "$heroku_postbuild" ]; then
     mcount "scripts.heroku-postbuild"
 
-    if [ "$heroku_postbuild" == "npm run build" ]; then
+    if [ "$heroku_postbuild" == "npm run build" ] ||
+       [ "$heroku_postbuild" == "yarn run build" ] ||
+       [ "$heroku_postbuild" == "yarn build" ]; then
       mcount "scripts.heroku-postbuild-is-npm-build"
     fi
   fi

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -33,12 +33,29 @@ log_build_scripts() {
   local build=$(read_json "$BUILD_DIR/package.json" ".scripts[\"build\"]")
   local heroku_prebuild=$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-prebuild\"]")
   local heroku_postbuild=$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-postbuild\"]")
+  local postinstall=$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-postbuild\"]")
 
   if [ -n "$build" ]; then
     mcount "scripts.build"
 
     if [ -z "$heroku_postbuild" ]; then
       mcount "scripts.build-without-heroku-postbuild"
+    fi
+
+    if [ -z "$postinstall" ]; then
+      mcount "scripts.build-without-postinstall"
+    fi
+
+    if [ -z "$postinstall" ] && [ -z "$heroku_postbuild" ]; then
+      mcount "scripts.build-without-other-hooks"
+    fi
+  fi
+
+  if [ -n "$postinstall" ]; then
+    mcount "scripts.postinstall"
+
+    if [ "$postinstall" == "npm run build" ]; then
+      mcount "scripts.postinstall-is-npm-build"
     fi
   fi
 
@@ -48,6 +65,10 @@ log_build_scripts() {
 
   if [ -n "$heroku_postbuild" ]; then
     mcount "scripts.heroku-postbuild"
+
+    if [ "$heroku_postbuild" == "npm run build" ]; then
+      mcount "scripts.heroku-postbuild-is-npm-build"
+    fi
   fi
 
   if [ -n "$heroku_postbuild" ] && [ -n "$build" ]; then


### PR DESCRIPTION
In preparing to address #479 I need more metrics around just how many users are going to be affected and how I can best mitigate that.

Currently ~30% of users have a `build` script defined, but only ~10% have a `heroku-postbuild` script. [We've encouraged setting up a `postinstall`](https://blog.heroku.com/node-habits-2017#2-hook-things-up) hook, so I added metrics around that.