### PR TITLE
Install with Yarn when in engines

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -57,6 +57,15 @@ handle_failure() {
 }
 trap 'handle_failure' ERR
 
+### Failures that should be caught immediately
+
+fail_dot_heroku "$BUILD_DIR"
+fail_dot_heroku_node "$BUILD_DIR"
+fail_invalid_package_json "$BUILD_DIR"
+fail_multiple_lockfiles "$BUILD_DIR"
+warn_prebuilt_modules "$BUILD_DIR"
+warn_missing_package_json "$BUILD_DIR"
+
 ### Check initial state
 
 yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
@@ -68,15 +77,6 @@ else
   YARN=false
 fi
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
-
-### Failures that should be caught immediately
-
-fail_dot_heroku "$BUILD_DIR"
-fail_dot_heroku_node "$BUILD_DIR"
-fail_invalid_package_json "$BUILD_DIR"
-fail_multiple_lockfiles "$BUILD_DIR"
-warn_prebuilt_modules "$BUILD_DIR"
-warn_missing_package_json "$BUILD_DIR"
 
 ### Compile
 

--- a/bin/compile
+++ b/bin/compile
@@ -67,16 +67,21 @@ warn_prebuilt_modules "$BUILD_DIR"
 warn_missing_package_json "$BUILD_DIR"
 
 ### Check initial state
-
-yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
+package_manager=$(read_json "$BUILD_DIR/package.json" ".manager")
 
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
-if [ -f "$BUILD_DIR/yarn.lock" ] || [ -n "$yarn_engine" ]; then
+[ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
+[ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
+
+### Set package manager to be used
+
+if [ "$package_manager" == "yarn" ]; then
   YARN=true
-else
+fi
+
+if [ "$package_manager" == "npm" ]; then
   YARN=false
 fi
-[ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
 
 ### Compile
 
@@ -98,6 +103,7 @@ install_bins() {
   local node_engine=$(read_json "$BUILD_DIR/package.json" ".engines.node")
   local iojs_engine=$(read_json "$BUILD_DIR/package.json" ".engines.iojs")
   local npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
+  local yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
 
   if [ -n "$iojs_engine" ]; then
     echo "engines.iojs (package.json):  $iojs_engine (iojs)"

--- a/bin/compile
+++ b/bin/compile
@@ -122,9 +122,6 @@ install_bins() {
     mcount "version.node.$(node --version)"
   fi
 
-  # Download yarn if there is a yarn.lock file or if the user
-  # has specified a version of yarn under "engines". We'll still
-  # only install using yarn if there is a yarn.lock file
   if $YARN || [ -n "$yarn_engine" ]; then
     install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -59,8 +59,14 @@ trap 'handle_failure' ERR
 
 ### Check initial state
 
+yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
+
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
-[ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
+if [ -f "$BUILD_DIR/yarn.lock" ] || [ -n "$yarn_engine" ]; then
+  YARN=true
+else
+  YARN=false
+fi
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
 
 ### Failures that should be caught immediately
@@ -92,7 +98,6 @@ install_bins() {
   local node_engine=$(read_json "$BUILD_DIR/package.json" ".engines.node")
   local iojs_engine=$(read_json "$BUILD_DIR/package.json" ".engines.iojs")
   local npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
-  local yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
 
   if [ -n "$iojs_engine" ]; then
     echo "engines.iojs (package.json):  $iojs_engine (iojs)"

--- a/test/fixtures/yarn-manager/package.json
+++ b/test/fixtures/yarn-manager/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "main": "index.js",
+  "manager": "yarn",
+  "license": "MIT",
+  "dependencies": {
+    "lodash": "^4.16.4"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -152,9 +152,6 @@ testYarnEngine() {
   assertCapturedSuccess
 }
 
-# If they specify a version of yarn inside package.json but
-# don't have a yarn.lock file download and make yarn available
-# though we will only install using yarn if a yarn.lock exists
 testYarnOnlyEngine() {
   compile "yarn-only-engine"
   assertCaptured "installing yarn (0.24.5)"

--- a/test/run
+++ b/test/run
@@ -158,6 +158,8 @@ testYarnEngine() {
 testYarnOnlyEngine() {
   compile "yarn-only-engine"
   assertCaptured "installing yarn (0.24.5)"
+  assertCaptured "Installing node modules (yarn.lock)"
+  assertNotCaptured "Installing node modules (package.json"
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -114,6 +114,14 @@ testCacheWithPrebuild() {
   assertCapturedSuccess
 }
 
+testYarnManagerPreference() {
+  compile "yarn-manager"
+  assertCaptured "installing yarn"
+  assertCaptured "Installing node modules (yarn.lock)"
+  assertNotCaptured "Installing node modules (package.json"
+  assertCapturedSuccess
+}
+
 testYarnSemver() {
   compile "yarn-semver"
   assertCaptured "Resolving yarn version ~0.17"
@@ -155,8 +163,6 @@ testYarnEngine() {
 testYarnOnlyEngine() {
   compile "yarn-only-engine"
   assertCaptured "installing yarn (0.24.5)"
-  assertCaptured "Installing node modules (yarn.lock)"
-  assertNotCaptured "Installing node modules (package.json"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
PR to install node dependencies with `yarn` if it is specified in the `package.json` of the app.
In a custom `"manager"` field.

**Justification**
- There is varying behaviour for installing `io.js` & `yarn` depending on whether they are specified in package.json `engines`. `io.js` is installed and used when in package.json. `yarn` is installed an not used.
- I believe this buildpack should offer the option of using `yarn` without the need for a `yarn.lock` file. I understand that using `yarn.lock` is a lot quicker, however when using some dependencies it is not always possible.

**Tested**
- Tests updated
- in Heroku CI.
- in Heroku node.js app.
