### PR TITLE
Fix some Bash issues

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -28,7 +28,7 @@ install_yarn() {
 
 install_nodejs() {
   local version=${1:-8.x}
-  local dir="$2"
+  local dir="${2:?}"
 
   echo "Resolving node version $version..."
   if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
@@ -41,7 +41,7 @@ install_nodejs() {
     echo "Unable to download node: $code" && false
   fi
   tar xzf /tmp/node.tar.gz -C /tmp
-  rm -rf $dir/*
+  rm -rf "$dir"/*
   mv /tmp/node-v$number-$os-$cpu/* $dir
   chmod +x $dir/bin/*
 }

--- a/test/utils
+++ b/test/utils
@@ -36,7 +36,7 @@ capture()
 
   LAST_COMMAND="$@"
 
-  $@ >${STD_OUT} 2>${STD_ERR}
+  "$@" >${STD_OUT} 2>${STD_ERR}
   RETURN=$?
   rtrn=${RETURN} # deprecated
 }


### PR DESCRIPTION
Use `"${var:?}"` to ensure this never expands to `/*` .
Double quote array expansions, otherwise they're like `$*` and break on spaces.
Argument mixes string and array. Use `*` or separate argument.
