### PR TITLE
Ci env vars

### DIFF
--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
 
-NPM_CONFIG_PRODUCTION=false NODE_ENV=test "$(dirname ${0:-})/compile" "$1" "$2" "$3"
+BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+
+echo "$BP_DIR"
+
+source $BP_DIR/lib/environment.sh
+
+export NPM_CONFIG_PRODUCTION=${NPM_CONFIG_PRODUCTION:-false}
+export NODE_ENV=${NODE_ENV:-test}
+"$BP_DIR/bin/compile" "$1" "$2" "$3"
+
+write_ci_profile "$BP_DIR" "$1"

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -2,8 +2,6 @@
 
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 
-echo "$BP_DIR"
-
 source $BP_DIR/lib/environment.sh
 
 export NPM_CONFIG_PRODUCTION=${NPM_CONFIG_PRODUCTION:-false}

--- a/ci-profile/nodejs.sh
+++ b/ci-profile/nodejs.sh
@@ -1,0 +1,3 @@
+export PATH="$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin:$PATH:$HOME/bin:$HOME/node_modules/.bin"
+export NODE_HOME="$HOME/.heroku/node"
+export NODE_ENV=${NODE_ENV:-test}

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -64,6 +64,13 @@ write_profile() {
   cp $bp_dir/profile/* $build_dir/.profile.d/
 }
 
+write_ci_profile() {
+  local bp_dir="$1"
+  local build_dir="$2"
+  write_profile "$1" "$2"
+  cp $bp_dir/ci-profile/* $build_dir/.profile.d/ 
+}
+
 write_export() {
   local bp_dir="$1"
   local build_dir="$2"

--- a/test/fixtures/ci-env-test/README.md
+++ b/test/fixtures/ci-env-test/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/ci-env-test/package.json
+++ b/test/fixtures/ci-env-test/package.json
@@ -11,6 +11,6 @@
   "scripts" : {
     "heroku-prebuild" : "echo heroku-prebuild hook message",
     "heroku-postbuild" : "echo heroku-postbuild hook message",
-    "test": "echo NODE_ENV: $NODE_ENV && echo NPM_CONFIG_PRODUCTION: $NPM_CONFIG_PRODUCTION"
+    "test": "echo NODE_ENV: $NODE_ENV"
   }
 }

--- a/test/fixtures/ci-env-test/package.json
+++ b/test/fixtures/ci-env-test/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "8.x"
+  },
+  "scripts" : {
+    "heroku-prebuild" : "echo heroku-prebuild hook message",
+    "heroku-postbuild" : "echo heroku-postbuild hook message",
+    "test": "echo NODE_ENV: $NODE_ENV && echo NPM_CONFIG_PRODUCTION: $NPM_CONFIG_PRODUCTION"
+  }
+}

--- a/test/quick
+++ b/test/quick
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source $(pwd)/lib/environment.sh
+
 mktmpdir() {
   local dir=$(mktemp -t testXXXXX)
   rm -rf $dir
@@ -33,10 +35,19 @@ compileTest() {
   cp -a $(pwd)/* ${bp_dir}
   cp -a ${bp_dir}/test/fixtures/$fixture/. ${build_dir}
   "$bp_dir/bin/test-compile" "$build_dir" "$cache_dir"
+
+  export HOME=${build_dir}
+  export_env_dir $env_dir
+  for f in ${build_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
+
   "$bp_dir/bin/test" "$build_dir"
 }
 
 fixture=${1:-'stable-node'}
-compile "$fixture"
-# compileTest "$fixture"
+
+if [[ "$2" == "test" ]]; then
+  compileTest "$fixture"
+else
+  compile "$fixture"
+fi
 

--- a/test/quick
+++ b/test/quick
@@ -21,5 +21,22 @@ compile() {
   "$bp_dir/bin/compile" "$build_dir" "$cache_dir"
 }
 
+compileTest() {
+  local fixture=$1
+  local bp_dir=$(mktmpdir)
+  local build_dir=$(mktmpdir)
+  local cache_dir=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  echo "Compiling $fixture"
+  echo "in $build_dir"
+  echo "(caching in $cache_dir)"
+  cp -a $(pwd)/* ${bp_dir}
+  cp -a ${bp_dir}/test/fixtures/$fixture/. ${build_dir}
+  "$bp_dir/bin/test-compile" "$build_dir" "$cache_dir"
+  "$bp_dir/bin/test" "$build_dir"
+}
+
 fixture=${1:-'stable-node'}
 compile "$fixture"
+# compileTest "$fixture"
+

--- a/test/run
+++ b/test/run
@@ -727,19 +727,16 @@ testMultiExport() {
 testCIEnvVars() {
   compileTest "ci-env-test"
   assertCaptured "NODE_ENV: test"
-  assertCaptured "NPM_CONFIG_PRODUCTION: false"
   assertCapturedSuccess 
 }
 
 testCIEnvVarsOverride() {
   env_dir=$(mktmpdir)
   echo "banana" > $env_dir/NODE_ENV
-  echo "apple" > $env_dir/NPM_CONFIG_PRODUCTION
 
   compileTest "ci-env-test" "$(mktmpdir)" $env_dir
 
   assertCaptured "NODE_ENV: banana"
-  assertCaptured "NPM_CONFIG_PRODUCTION: apple"
   assertCapturedSuccess 
 }
 
@@ -749,6 +746,7 @@ pushd $(dirname 0) >/dev/null
 popd >/dev/null
 
 source $(pwd)/test/utils
+source $(pwd)/lib/environment.sh
 
 mktmpdir() {
   dir=$(mktemp -t testXXXXX)
@@ -787,16 +785,19 @@ compileTest() {
   local cache_dir=${2:-$(mktmpdir)}
   local env_dir=$3
 
-  # On Heroku, $HOME is the /app dir, so we need to set it to
-  # the compile_dir here
-  export HOME=${compile_dir}
-
   cp -a $(pwd)/* ${bp_dir}
   cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
   capture ${bp_dir}/bin/test-compile ${compile_dir} ${2:-$(mktmpdir)} $3
 
-  # We need the runtime $PATH before we run the test
-  for f in ${compile_dir}/.profile.d/*; do source $f; done
+  # On Heroku, $HOME is the /app dir, so we need to set it to
+  # the compile_dir here
+  export HOME=${compile_dir}
+
+  # bin/test is not ran during build, rather during runtime, which means
+  # we need to set any environment variables set via the env_dir and run
+  # all of the .profile.d scripts
+  export_env_dir $env_dir
+  for f in ${compile_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
 
   capture ${bp_dir}/bin/test ${compile_dir}
 }

--- a/test/run
+++ b/test/run
@@ -724,6 +724,24 @@ testMultiExport() {
   assertCapturedSuccess
 }
 
+testCIEnvVars() {
+  compileTest "ci-env-test"
+  assertCaptured "NODE_ENV: test"
+  assertCaptured "NPM_CONFIG_PRODUCTION: false"
+  assertCapturedSuccess 
+}
+
+testCIEnvVarsOverride() {
+  env_dir=$(mktmpdir)
+  echo "banana" > $env_dir/NODE_ENV
+  echo "apple" > $env_dir/NPM_CONFIG_PRODUCTION
+
+  compileTest "ci-env-test" "$(mktmpdir)" $env_dir
+
+  assertCaptured "NODE_ENV: banana"
+  assertCaptured "NPM_CONFIG_PRODUCTION: apple"
+  assertCapturedSuccess 
+}
 
 # Utils
 
@@ -759,6 +777,28 @@ compile() {
   cp -a $(pwd)/* ${bp_dir}
   cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
   capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
+}
+
+compileTest() {
+  default_process_types_cleanup
+
+  local bp_dir=$(mktmpdir)
+  local compile_dir=$(mktmpdir)
+  local cache_dir=${2:-$(mktmpdir)}
+  local env_dir=$3
+
+  # On Heroku, $HOME is the /app dir, so we need to set it to
+  # the compile_dir here
+  export HOME=${compile_dir}
+
+  cp -a $(pwd)/* ${bp_dir}
+  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
+  capture ${bp_dir}/bin/test-compile ${compile_dir} ${2:-$(mktmpdir)} $3
+
+  # We need the runtime $PATH before we run the test
+  for f in ${compile_dir}/.profile.d/*; do source $f; done
+
+  capture ${bp_dir}/bin/test ${compile_dir}
 }
 
 compileDir() {


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-buildpack-nodejs/issues/414 
and
Fixes https://github.com/heroku/heroku-buildpack-nodejs/issues/504

Summary:

In CI, we set `NODE_ENV=test`, but the actual tests would be run at runtime where the `.profile.d` scripts would overwrite it

source: https://github.com/heroku/heroku-buildpack-nodejs/blob/940c813daa56b537008dc0c26bf045d75ff5a4ab/profile/nodejs.sh#L3

This PR fixes that by overwriting `.profile.d/nodejs.sh` with a new startup script, and makes sure this is tested.