### PR TITLE
Add an option to prune packages after build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -210,6 +210,22 @@ cache_build() {
 header "Caching build"
 cache_build | output "$LOG_FILE"
 
+prune_packages() {
+  if ${NODE_MODULES_PRUNE:-true}; then
+    echo "Pruning extraneous packages"
+    if $YARN; then
+      yarn install --production
+    else
+      npm prune --production
+    fi
+  else
+    echo "Skipping pruning extraneous packages"
+  fi
+}
+
+header "Cleanup"
+prune_packages | output "$LOG_FILE"
+
 summarize_build() {
   if $NODE_VERBOSE; then
     list_dependencies "$BUILD_DIR"

--- a/test/fixtures/prune/package.json
+++ b/test/fixtures/prune/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "prune",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "lodash": "^4.16.4"
+  },
+  "devDependencies": {
+    "babel": "^6.23.0"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -740,6 +740,24 @@ testCIEnvVarsOverride() {
   assertCapturedSuccess 
 }
 
+testPruneDependencies() {
+  env_dir=$(mktmpdir)
+  echo "true" > $env_dir/NODE_MODULES_PRUNE
+  compile "prune" $(mktmpdir) $env_dir
+  assertCaptured "Pruning extraneous packages"
+  test ! -f ${BUILD_DIR}/node_modules/babel
+  assertCapturedSuccess
+}
+
+testPruneDependenciesSkip() {
+  env_dir=$(mktmpdir)
+  echo "false" > $env_dir/NODE_MODULES_PRUNE
+  compile "prune" $(mktmpdir) $env_dir
+  assertCaptured "Skipping pruning extraneous packages"
+  test -f ${BUILD_DIR}/node_modules/babel
+  assertCapturedSuccess
+}
+
 # Utils
 
 pushd $(dirname 0) >/dev/null


### PR DESCRIPTION
We have a long list of `devDependencies` that we need during the build, but don't need at runtime. We set `NPM_CONFIG_PRODUCTION` to `false` so they get installed. However, they still end up in the slug. This setting can be enabled to remove the `devDependencies` before the slug gets created, but after the cache was saved.

I am not entirely sure I followed the standards for the tests or whether it's desired to have this option in the buildpack. But, it's worth a shot.