### PR TITLE
Skip pruning if NPM_CONFIG_PRODUCTION or YARN_PRODUCTION is defined

### DIFF
--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -103,8 +103,8 @@ yarn_prune_devdependencies() {
   elif [ "$NODE_ENV" != "production" ]; then
     echo "Skipping because NODE_ENV is not 'production'"
     return 0
-  elif [ -n "$YARN_PRODUCTION" ] && [ "$YARN_PRODUCTION" != "true" ]; then
-    echo "Skipping because YARN_PRODUCTION is not 'true'"
+  elif [ -n "$YARN_PRODUCTION" ]; then
+    echo "Skipping because YARN_PRODUCTION is '$YARN_PRODUCTION'"
     return 0
   else 
     local start=$(nowms)
@@ -163,8 +163,8 @@ npm_prune_devdependencies() {
   elif [ "$NODE_ENV" != "production" ]; then
     echo "Skipping because NODE_ENV is not 'production'"
     return 0
-  elif [ -n "$NPM_CONFIG_PRODUCTION" ] && [ "$NPM_CONFIG_PRODUCTION" != "true" ]; then
-    echo "Skipping because NPM_CONFIG_PRODUCTION is not 'true'"
+  elif [ -n "$NPM_CONFIG_PRODUCTION" ]; then
+    echo "Skipping because NPM_CONFIG_PRODUCTION is '$NPM_CONFIG_PRODUCTION'"
     return 0
   elif [ "$npm_version" == "5.3.0" ]; then
     mcount "skip-prune-issue-npm-5.3.0"

--- a/test/run
+++ b/test/run
@@ -682,7 +682,14 @@ testDevDepenenciesWithNoPruning() {
   echo "false" > $env_dir/NPM_CONFIG_PRODUCTION
   compile "dependencies" "$(mktmpdir)" $env_dir
   assertCaptured "lodash"
-  assertCaptured "Skipping because NPM_CONFIG_PRODUCTION is not 'true'"
+  assertCaptured "Skipping because NPM_CONFIG_PRODUCTION is 'false'"
+  assertCapturedSuccess
+
+  env_dir=$(mktmpdir)
+  echo "true" > $env_dir/NPM_CONFIG_PRODUCTION
+  compile "dependencies" "$(mktmpdir)" $env_dir
+  assertNotCaptured "lodash"
+  assertCaptured "Skipping because NPM_CONFIG_PRODUCTION is 'true'"
   assertCapturedSuccess
 }
 
@@ -692,7 +699,14 @@ testDevDepenenciesWithNoPruningYarn() {
   echo "false" > $env_dir/YARN_PRODUCTION
   compile "dependencies-yarn" "$(mktmpdir)" $env_dir
   assertCaptured "lodash"
-  assertCaptured "Skipping because YARN_PRODUCTION is not 'true'"
+  assertCaptured "Skipping because YARN_PRODUCTION is 'false'"
+  assertCapturedSuccess
+
+  env_dir=$(mktmpdir)
+  echo "true" > $env_dir/YARN_PRODUCTION
+  compile "dependencies-yarn" "$(mktmpdir)" $env_dir
+  assertNotCaptured "lodash"
+  assertCaptured "Skipping because YARN_PRODUCTION is 'true'"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Fixes part of @edmorley's issues in https://github.com/heroku/heroku-buildpack-nodejs/issues/526 by skipping pruning when `NPM_CONFIG_PRODUCTION=true` or `YARN_PRODUCTION=true` since there will be no `devDependencies` to strip away.