### PR TITLE
fix: handle case where memory.limit_in_bytes is nonsensically large

### DIFF
--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -18,9 +18,16 @@ log_concurrency() {
 
 detect_memory() {
   local default=$1
+  local detected max_detected_memory=8796093022207
 
   if [ -e /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-    echo $(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1048576))
+    detected=$(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1048576))
+    # The hardcoded value is 16GB of memory
+    if (( detected > max_detected_memory )); then
+      echo "$max_detected_memory"
+    else
+      echo "$detected"
+    fi
   else
     echo "$default"
   fi

--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
 calculate_concurrency() {
-  WEB_CONCURRENCY=${WEB_CONCURRENCY-$((MEMORY_AVAILABLE/WEB_MEMORY))}
-  if (( WEB_CONCURRENCY < 1 )); then
-    WEB_CONCURRENCY=1
-  elif (( WEB_CONCURRENCY > 200 )); then
+  local available=$1
+  local web_memory=$2
+  local concurrency
+
+  concurrency=${WEB_CONCURRENCY-$(($available/$web_memory))}
+  if (( concurrency < 1 )); then
+    concurrency=1
+  elif (( concurrency > 200 )); then
     # Ex: This will happen on Dokku on DO
-    WEB_CONCURRENCY=1
+    concurrency=1
   fi
-  echo $WEB_CONCURRENCY
+  echo "$concurrency"
 }
 
 log_concurrency() {
@@ -18,18 +22,23 @@ log_concurrency() {
 
 detect_memory() {
   local default=$1
-  local detected max_detected_memory=8796093022207
 
   if [ -e /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-    detected=$(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1048576))
-    # The hardcoded value is 16GB of memory
-    if (( detected > max_detected_memory )); then
-      echo "$max_detected_memory"
-    else
-      echo "$detected"
-    fi
+    echo $(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1048576))
   else
     echo "$default"
+  fi
+}
+
+bound_memory() {
+  local detected=$1
+  local detected max_detected_memory=14336
+
+  # The hardcoded value is 16GB of memory
+  if (( detected > max_detected_memory )); then
+    echo "$max_detected_memory"
+  else
+    echo "$detected"
   fi
 }
 
@@ -46,9 +55,10 @@ appropriate for your application."
   fi
 }
 
-export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(detect_memory 512)}
+DETECTED=$(detect_memory 512)
+export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(bound_memory $DETECTED)}
 export WEB_MEMORY=${WEB_MEMORY-512}
-export WEB_CONCURRENCY=$(calculate_concurrency)
+export WEB_CONCURRENCY=$(calculate_concurrency $MEMORY_AVAILABLE $WEB_MEMORY)
 
 warn_bad_web_concurrency
 

--- a/test/unit
+++ b/test/unit
@@ -168,6 +168,48 @@ testBuildData() {
   assertEquals "a=\"this should come first\" foo=\"value with spaces\" test=different-foo" "$(log_build_data)"
 }
 
+testWebConcurrencyProfileScript() {
+  # this was set when we sourced the WEB_CONCURRENCY.sh file
+  unset WEB_MEMORY
+  unset MEMORY_AVAILABLE
+  unset WEB_CONCURRENCY
+
+  # memory in MB of a 2X dyno
+  assertEquals "512" "$(bound_memory 512)"
+
+  # memory in MB of a 2X dyno
+  assertEquals "1024" "$(bound_memory 1024)"
+
+  # memory in MB of a Peformance-M dyno
+  assertEquals "2560" "$(bound_memory 2560)"
+
+  # memory in MB of a Peformance-L dyno
+  assertEquals "14336" "$(bound_memory 14336)"
+
+  # one more MB
+  assertEquals "14336" "$(bound_memory 14337)"
+
+  # On non-Heroku systems `detect_memory` can return non-sensically large values
+  # In this case, we should bound
+  assertEquals "14336" "$(bound_memory 1000000)"
+
+  # test calculate_concurrency
+
+  # 1x
+  assertEquals "1" "$(calculate_concurrency 512 512)"
+  # 2x
+  assertEquals "2" "$(calculate_concurrency 1024 512)"
+  # Performance-M
+  assertEquals "5" "$(calculate_concurrency 2560 512)"
+  # Performance-L
+  assertEquals "28" "$(calculate_concurrency 14336 512)"
+
+  # In case some very large memory available value gets passed in
+  assertEquals "1" "$(calculate_concurrency 103401 512)"
+  # of if web memory is set really low
+  assertEquals "1" "$(calculate_concurrency 512 1)"
+}
+
 # mocks
 source "$(pwd)"/test/mocks/stdlib.sh
 
@@ -176,6 +218,7 @@ source "$(pwd)"/lib/monitor.sh
 source "$(pwd)"/lib/output.sh
 source "$(pwd)"/lib/kvstore.sh
 source "$(pwd)"/lib/build-data.sh
+source "$(pwd)"/profile/WEB_CONCURRENCY.sh
 
 # import the testing framework
 source "$(pwd)"/test/shunit2


### PR DESCRIPTION
In certain CI environments, this value can be misreported, resulting in an invalid initial `MEMORY_AVAILABLE` value.

In these cases, we default the max detected memory to 16GB, or slightly larger than a `performance-l` instance.

> Note: I have a client who has some deployments to Heroku but does not wish to use Heroku CI and currently deploys to GCP, so this fix is so that their CI doesn't throw warnings when they run on servers with 16GB+ memory.