### PR TITLE
Only write export script if dir is writable

### DIFF
--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -73,6 +73,12 @@ write_ci_profile() {
 write_export() {
   local bp_dir="$1"
   local build_dir="$2"
-  echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > $bp_dir/export
-  echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> $bp_dir/export
+
+  # only write the export script if the buildpack directory is writable.
+  # this may occur in situations outside of Heroku, such as running the
+  # buildpacks locally.
+  if [ -w ${bp_dir} ]; then
+    echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > $bp_dir/export
+    echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> $bp_dir/export
+  fi
 }


### PR DESCRIPTION
This is required to prevent failure during `heroku local:build` which doesn't support writing to the buildpack dir at this time.