### PR TITLE
Fix tests broken by Node 10 release and npm changes

### DIFF
--- a/test/fixtures/cache-directories/package.json
+++ b/test/fixtures/cache-directories/package.json
@@ -7,7 +7,7 @@
     "url" : "http://github.com/example/example.git"
   },
   "engines": {
-    "node": "0.10.18"
+    "node": "8.x"
   },
   "dependencies": {
     "bower": "1.3.12"

--- a/test/fixtures/caching/package.json
+++ b/test/fixtures/caching/package.json
@@ -7,7 +7,8 @@
     "url" : "http://github.com/example/example.git"
   },
   "engines": {
-    "node": "0.10.18"
+    "node": "8.x",
+    "npm": "5.x"
   },
   "dependencies": {
     "express": "latest"

--- a/test/fixtures/npm-version-range/package.json
+++ b/test/fixtures/npm-version-range/package.json
@@ -7,7 +7,7 @@
     "url" : "http://github.com/example/example.git"
   },
   "engines": {
-    "node": "0.10.12",
-    "npm": "1.4.x"
+    "node": "8.x",
+    "npm": "5.7.x"
   }
 }

--- a/test/run
+++ b/test/run
@@ -536,7 +536,7 @@ testSameNpm() {
 
 testNpmVersionRange() {
   compile "npm-version-range"
-  assertCaptured "Bootstrapping npm 1.4.x"
+  assertCaptured "Bootstrapping npm 5.7.x"
   assertCapturedSuccess
 }
 
@@ -576,7 +576,7 @@ testDangerousRangeStar() {
   compile "dangerous-range-star"
   assertCaptured "Dangerous semver range"
   assertCaptured "Resolving node version *"
-  assertCaptured "Downloading and installing node 9."
+  assertCaptured "Downloading and installing node 10."
   assertCapturedError
 }
 
@@ -584,14 +584,14 @@ testDangerousRangeGreaterThan() {
   compile "dangerous-range-greater-than"
   assertCaptured "Dangerous semver range"
   assertCaptured "Resolving node version >0.4"
-  assertCaptured "Downloading and installing node 9."
+  assertCaptured "Downloading and installing node 10."
   assertCapturedError
 }
 
 testRangeWithSpace() {
   compile "range-with-space"
   assertCaptured "Resolving node version >= 0.8.x"
-  assertCaptured "Downloading and installing node 9."
+  assertCaptured "Downloading and installing node 10."
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Ancient npm versions are broken by SSL changes: https://github.com/npm/npm/issues/20203

Other tests are broken because `>=` version requirements resolve to Node 10 now.