### PR TITLE
Fix travis builds

### DIFF
--- a/test/fixtures/node-10/README.md
+++ b/test/fixtures/node-10/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/node-10/package.json
+++ b/test/fixtures/node-10/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts": {
+    "start": "node foo.js"
+  }
+}

--- a/test/fixtures/node-6/README.md
+++ b/test/fixtures/node-6/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/node-6/package.json
+++ b/test/fixtures/node-6/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "6.x"
+  },
+  "scripts": {
+    "start": "node foo.js"
+  }
+}

--- a/test/fixtures/node-8/README.md
+++ b/test/fixtures/node-8/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/node-8/package.json
+++ b/test/fixtures/node-8/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "8.x"
+  },
+  "scripts": {
+    "start": "node foo.js"
+  }
+}

--- a/test/fixtures/node-9/README.md
+++ b/test/fixtures/node-9/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/node-9/package.json
+++ b/test/fixtures/node-9/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "9.x"
+  },
+  "scripts": {
+    "start": "node foo.js"
+  }
+}

--- a/test/fixtures/yarn/package.json
+++ b/test/fixtures/yarn/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "engines": {
+    "yarn": "1.x"
+  },
   "dependencies": {
     "lodash": "^4.16.4"
   }

--- a/test/run
+++ b/test/run
@@ -64,9 +64,8 @@ testYarnCacheDirectory() {
   echo "${cache_dir}/yarn"> "$env_dir"/YARN_CACHE_FOLDER
   compile "yarn" $cache $env_dir
   # These will be created if yarn is using the directory for its cache
-  assertDirectoryExists ${cache_dir}/yarn
-  assertDirectoryExists ${cache_dir}/yarn/v1
-  assertDirectoryExists ${cache_dir}/yarn/v1/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
+  assertDirectoryExists ${cache_dir}/v2
+  assertFileExists ${cache_dir}/v2/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
   assertCapturedSuccess
 }
 
@@ -977,15 +976,6 @@ release() {
 
 assertFile() {
   assertEquals "$1" "$(cat ${compile_dir}/$2)"
-}
-
-assertDirectoryExists() {
-  if [[ ! -e "$1" ]]; then
-    fail "$1 does not exist"
-  fi
-  if [[ ! -d $1 ]]; then
-    fail "$1 is not a directory"
-  fi
 }
 
 source $(pwd)/test/shunit2

--- a/test/run
+++ b/test/run
@@ -64,8 +64,9 @@ testYarnCacheDirectory() {
   echo "${cache_dir}/yarn"> "$env_dir"/YARN_CACHE_FOLDER
   compile "yarn" $cache $env_dir
   # These will be created if yarn is using the directory for its cache
-  assertDirectoryExists ${cache_dir}/v2
-  assertFileExists ${cache_dir}/v2/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
+  assertDirectoryExists ${cache_dir}/yarn
+  assertDirectoryExists ${cache_dir}/yarn/v2
+  assertFileExists ${cache_dir}/yarn/v2/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
   assertCapturedSuccess
 }
 

--- a/test/utils
+++ b/test/utils
@@ -188,3 +188,24 @@ assertFileMD5()
 
   assertEquals "${expected_md5_cmd_output}" "`${md5_cmd}`"
 }
+
+assertDirectoryExists() {
+  if [[ ! -e "$1" ]]; then
+    fail "$1 does not exist"
+  fi
+  if [[ ! -d $1 ]]; then
+    fail "$1 is not a directory"
+  fi
+}
+
+assertFileExists()
+{
+  filename=$1
+  assertTrue "$filename doesn't exist" "[[ -e $filename ]]"
+}
+
+assertFileDoesNotExist()
+{
+  filename=$1
+  assertTrue "$filename exists" "[[ ! -e $filename ]]"
+}


### PR DESCRIPTION
- Yarn reworked the structure of their cache directory with a recent release, which broke one of the tests.

- added new fixtures for Node versions: 6, 8, 9, and 10

- Added new utilities for asserting that a file exists or does not exist after a build