### PR TITLE
Fix issue with old Node and metrics plugin

### DIFF
--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -2,9 +2,14 @@ export PATH="$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin:$PATH:$HOME/bin:$HOME
 export NODE_HOME="$HOME/.heroku/node"
 export NODE_ENV=${NODE_ENV:-production}
 
-# If the metrics url is not present, this is the wrong type of dyno, or the user has opted out, 
-# don't include the metrics plugin
-if [[ -n "$HEROKU_METRICS_URL" ]] && [[ "${DYNO}" != run\.* ]] && [[ -z "$HEROKU_SKIP_NODE_PLUGIN" ]]; then
+# If the user has opted into the feature
+if [[ -n "$HEROKU_METRICS_URL" ]] && \
+   # if we're not on a one-off dyno
+   [[ "${DYNO}" != run\.* ]] && \
+   # if the plugin was installed for this node version
+   [[ -d $HOME/.heroku/heroku-nodejs-plugin ]] && \
+   # the user has not opted out
+   [[ -z "$HEROKU_SKIP_NODE_PLUGIN" ]]; then
 
   # Don't clobber NODE_OPTIONS if the user has set it, just add the require flag to the end
   if [[ -z "$NODE_OPTIONS" ]]; then

--- a/test/run
+++ b/test/run
@@ -946,6 +946,17 @@ testPluginInstallationRunTime() {
   cleanupStartup
 }
 
+testPluginInstallationUnsupportedNodeRunTime() {
+  local env_dir=$(mktmpdir)
+  compile "node-6" "$(mktmpdir)" $env_dir
+
+  # This can happen if a user opts-in to the feature but is not using a supported node version
+  export HEROKU_METRICS_URL=https://localhost:5000
+  executeStartup $env_dir
+  assertEquals "" "$NODE_OPTIONS"
+  cleanupStartup
+}
+
 # Utils
 
 pushd $(dirname 0) >/dev/null


### PR DESCRIPTION
The resolves an issue where a user that is not using a version of Node supported by the metrics plugin (not 8, 9, or 10) opts in to the feature. 

Since the plugin for the appropriate version of Node is copied into the slug at build time, but the metrics url is set at runtime, we need to verify that the plugin exists before including it.