### PR TITLE
Rework output when caching directories

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -162,7 +162,7 @@ restore_cache() {
   elif [[ "$cache_status" == "new-signature" ]]; then
     header "Restoring cache"
     if [[ "$cache_directories" == "" ]]; then
-      echo "Cached directories were not be restored because of a change in versions of node, npm, or yarn"
+      echo "Cached directories were not restored because of a change in versions of node, npm, or yarn"
       echo "Module installation may take longer for this build"
     else
       # If the user has specified custom cache directories, be more explicit

--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,6 @@ unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 
 ### Constants
 
-DEFAULT_CACHE="node_modules bower_components"
 BPLOG_PREFIX="buildpack.nodejs"
 
 ### Configure directories
@@ -141,6 +140,7 @@ install_bins | output "$LOG_FILE"
 
 restore_cache() {
   local cache_status="$(get_cache_status)"
+  local cache_directories="$(get_cache_directories)"
 
   if $YARN; then
     if [ -e "$BUILD_DIR/node_modules" ]; then
@@ -148,23 +148,38 @@ restore_cache() {
       rm -rf "$BUILD_DIR/node_modules"
     fi
   fi
-  if [ "$cache_status" == "valid" ]; then
-    local cache_directories=$(get_cache_directories)
-    if [ "$cache_directories" == "" ]; then
-      echo "Loading 2 from cacheDirectories (default):"
-      restore_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$DEFAULT_CACHE"
+
+  if [[ "$cache_status" == "disabled" ]]; then
+    header "Restoring cache"
+    echo "Caching has been disabled because NODE_MODULES_CACHE=${NODE_MODULES_CACHE}"
+  elif [[ "$cache_status" == "valid" ]]; then
+    header "Restoring cache"
+    if [[ "$cache_directories" == "" ]]; then
+      restore_default_cache_directories "$BUILD_DIR" "$CACHE_DIR"
     else
-      echo "Loading $(echo $cache_directories | wc -w | xargs) from cacheDirectories (package.json):"
-      restore_cache_directories "$BUILD_DIR" "$CACHE_DIR" $cache_directories
+      restore_custom_cache_directories "$BUILD_DIR" "$CACHE_DIR" $cache_directories
+    fi
+  elif [[ "$cache_status" == "new-signature" ]]; then
+    header "Restoring cache"
+    if [[ "$cache_directories" == "" ]]; then
+      echo "Cached directories were not be restored because of a change in versions of node, npm, or yarn"
+      echo "Module installation may take longer for this build"
+    else
+      # If the user has specified custom cache directories, be more explicit
+      echo "Invalidating cache due to a change in node, npm, or yarn versions"
+      echo "Will not restore the following directories for this build:"
+      for directory in $(< $cache_directories); do
+        echo "  $directory"
+      done
     fi
   else
-    echo "Skipping cache restore ($cache_status)"
+    # No cache exists, be silent
+    :
   fi
 
   mcount "cache.$cache_status"
 }
 
-header "Restoring cache" | output "$LOG_FILE"
 restore_cache | output "$LOG_FILE"
 
 build_dependencies() {
@@ -195,21 +210,21 @@ build_dependencies | output "$LOG_FILE"
 cache_build() {
   local cache_directories=$(get_cache_directories)
 
-  echo "Clearing previous node cache"
   clear_cache
   if ! ${NODE_MODULES_CACHE:-true}; then
-    echo "Skipping cache save (disabled by config)"
-  elif [ "$cache_directories" == "" ]; then
-    echo "Saving 2 cacheDirectories (default):"
-    save_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$DEFAULT_CACHE"
+    # we've already warned that caching is disabled in the restore step
+    # so be silent here
+    :
+  elif [[ "$cache_directories" == "" ]]; then
+    header "Caching build"
+    save_default_cache_directories "$BUILD_DIR" "$CACHE_DIR"
   else
-    echo "Saving $(echo $cache_directories | wc -w | xargs) cacheDirectories (package.json):"
-    save_cache_directories "$BUILD_DIR" "$CACHE_DIR" $cache_directories
+    header "Caching build"
+    save_custom_cache_directories "$BUILD_DIR" "$CACHE_DIR" $cache_directories
   fi
   save_signature
 }
 
-header "Caching build"
 cache_build | output "$LOG_FILE"
 
 prune_devdependencies() {

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -39,9 +39,33 @@ get_cache_directories() {
   fi
 }
 
-restore_cache_directories() {
+restore_default_cache_directories() {
   local build_dir=${1:-}
   local cache_dir=${2:-}
+
+  # node_modules
+  if [[ -e "$build_dir/node_modules" ]]; then
+    echo "- node_modules is checked into source control and cannot be cached"
+  elif [[ -e "$cache_dir/node/node_modules" ]]; then
+    echo "- node_modules"
+    mkdir -p $(dirname "$build_dir/node_modules")
+    mv "$cache_dir/node/node_modules" "$build_dir/node_modules"
+  else
+    echo "- node_modules (not cached - skipping)"
+  fi
+
+  # bower_components, should be silent if it is not in the cache
+  if [[ -e "$cache_dir/node/bower_components" ]]; then
+    echo "- bower_components"
+  fi
+}
+
+restore_custom_cache_directories() {
+  local build_dir=${1:-}
+  local cache_dir=${2:-}
+  local cache_directories="${@:3}"
+
+  echo "Loading $(echo $cache_directories | wc -w | xargs) from cacheDirectories (package.json):"
 
   for cachepath in ${@:3}; do
     if [ -e "$build_dir/$cachepath" ]; then
@@ -63,9 +87,36 @@ clear_cache() {
   mkdir -p $CACHE_DIR/node
 }
 
-save_cache_directories() {
+save_default_cache_directories() {
   local build_dir=${1:-}
   local cache_dir=${2:-}
+
+  # node_modules
+  if [[ -e "$build_dir/node_modules" ]]; then
+    echo "- node_modules"
+    mkdir -p "$cache_dir/node/node_modules"
+    cp -a "$build_dir/node_modules" $(dirname "$cache_dir/node/node_modules")
+  else
+    # this can happen if there are no dependencies
+    mcount "cache.no-node-modules"
+    echo "- node_modules (nothing to cache)"
+  fi
+
+  # bower_components
+  if [[ -e "$build_dir/bower_components" ]]; then
+    mcount "cache.saved-bower-components"
+    echo "- bower_components"
+    mkdir -p "$cache_dir/node/bower_components"
+    cp -a "$build_dir/bower_components" $(dirname "$cache_dir/node/bower_components")
+  fi
+}
+
+save_custom_cache_directories() {
+  local build_dir=${1:-}
+  local cache_dir=${2:-}
+  local cache_directories="${@:3}"
+
+  echo "Saving $(echo $cache_directories | wc -w | xargs) cacheDirectories (package.json):"
 
   for cachepath in ${@:3}; do
     if [ -e "$build_dir/$cachepath" ]; then

--- a/test/run
+++ b/test/run
@@ -106,7 +106,7 @@ testCacheWithPrebuild() {
   assertCapturedSuccess
 
   compile "cache-prebuild" $cache $env_dir
-  assertCaptured "Cached directories were not be restored because of a change in versions of node"
+  assertCaptured "Cached directories were not restored because of a change in versions of node"
   assertCapturedSuccess
 }
 
@@ -447,7 +447,7 @@ testSignatureInvalidation() {
 
   compile "node-0.12.7" $cache
   assertCaptured "Downloading and installing node 0.12.7"
-  assertCaptured "Cached directories were not be restored because of a change in versions of node"
+  assertCaptured "Cached directories were not restored because of a change in versions of node"
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -28,13 +28,11 @@ testDisableCache() {
 
   compile "node-modules-cache-2" $cache $env_dir
   assertCaptured "lodash@1.0.0"
-  assertCaptured "Saving 2 cacheDirectories"
   assertCapturedSuccess
 
   echo "false" > $env_dir/NODE_MODULES_CACHE
   compile "node-modules-cache-2" $cache $env_dir
   assertCaptured "lodash@1.3.1"
-  assertNotCaptured "Saving 2 cacheDirectories"
   assertCapturedSuccess
 }
 
@@ -42,9 +40,7 @@ testNodeModulesCached() {
   cache=$(mktmpdir)
 
   compile "caching" $cache
-  assertCaptured "Saving 2 cacheDirectories (default)"
   assertCaptured "- node_modules"
-  assertCaptured "- bower_components (nothing to cache)"
   assertEquals "1" "$(ls -1 $cache/node/node_modules | grep express | wc -l | tr -d ' ')"
   assertCapturedSuccess
 }
@@ -86,12 +82,12 @@ testBuildWithCache() {
   cache=$(mktmpdir)
 
   compile "stable-node" $cache
-  assertCaptured "Skipping cache restore (not-found)"
+  assertNotCaptured "Restoring cache"
   assertEquals "1" "$(ls -1 $cache/node/node_modules | grep hashish | wc -l | tr -d ' ')"
   assertCapturedSuccess
 
   compile "stable-node" $cache
-  assertNotCaptured "- node_modules (not cached - skipping)"
+  assertCaptured "- node_modules"
   assertFileContains "${STACK}" "${cache}/node/signature"
   assertCapturedSuccess
 
@@ -110,7 +106,7 @@ testCacheWithPrebuild() {
   assertCapturedSuccess
 
   compile "cache-prebuild" $cache $env_dir
-  assertCaptured "Skipping cache restore (new-signature"
+  assertCaptured "Cached directories were not be restored because of a change in versions of node"
   assertCapturedSuccess
 }
 
@@ -451,7 +447,7 @@ testSignatureInvalidation() {
 
   compile "node-0.12.7" $cache
   assertCaptured "Downloading and installing node 0.12.7"
-  assertCaptured "Skipping cache restore (new-signature"
+  assertCaptured "Cached directories were not be restored because of a change in versions of node"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
This splits the logic when the buildpack saves and restores the cache into two separate branches:

- when the user hasn't specified specific directories to cache (most everyone)
- when the user has given a list of specific directories to cache (power users)

This gives us more control over the default messaging, which has included messaging for `bower_components` for every build for a long time. Most users will never use bower, nor should we encourage them to.

These changes silence and minimize the messaging for the default case and gives more detail to those users who have customized

Examples:

#### Default when cache exists

```
-----> Restoring cache
       - node_modules

-----> Building dependencies
       Installing node modules (package.json)
       
-----> Caching build
       - node_modules
```

#### When `node_modules` are checked in

```
-----> Restoring cache
       - node_modules is checked into source control and cannot be cached

-----> Building dependencies
       Prebuild detected (node_modules already exists)
       Rebuilding any native modules
       [[ ... ]]
       
-----> Caching build
       - node_modules
```

#### When the cache can't be restored

```
-----> Restoring cache
       Cached directories were not restored because of a change in versions of node, npm, or yarn
       Module installation may take longer for this build

-----> Building dependencies
       Installing node modules (package.json)
       
-----> Caching build
       - node_modules
```

#### Custom list of directories

```
-----> Restoring cache
       Loading 3 from cacheDirectories (package.json):
       - server/node_modules
       - client/node_modules
       - non/existent (not cached - skipping)

-----> Building dependencies
       Installing node modules (package.json)
       
       > node-buildpack-test-app@0.0.1 postinstall /tmp/test6HzaF
       > npm install --prefix=server && npm install --prefix=client
       
       
-----> Caching build
       Saving 3 cacheDirectories (package.json):
       - server/node_modules
       - client/node_modules
       - non/existent (nothing to cache)
```




