### PR TITLE
Allow pipeing headers through the log file without indentation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -80,7 +80,7 @@ create_env() {
   create_default_env
 }
 
-header "Creating runtime environment"
+header "Creating runtime environment" | output "$LOG_FILE"
 
 mkdir -p "$BUILD_DIR/.heroku/node/"
 cd $BUILD_DIR
@@ -136,7 +136,7 @@ install_bins() {
   warn_old_npm
 }
 
-header "Installing binaries"
+header "Installing binaries" | output "$LOG_FILE"
 install_bins | output "$LOG_FILE"
 
 restore_cache() {
@@ -164,7 +164,7 @@ restore_cache() {
   mcount "cache.$cache_status"
 }
 
-header "Restoring cache"
+header "Restoring cache" | output "$LOG_FILE"
 restore_cache | output "$LOG_FILE"
 
 build_dependencies() {
@@ -189,7 +189,7 @@ build_dependencies() {
   log_build_scripts
 }
 
-header "Building dependencies"
+header "Building dependencies" | output "$LOG_FILE"
 build_dependencies | output "$LOG_FILE"
 
 cache_build() {
@@ -220,7 +220,7 @@ prune_devdependencies() {
   fi
 }
 
-header "Pruning devDependencies"
+header "Pruning devDependencies" | output "$LOG_FILE"
 prune_devdependencies | output "$LOG_FILE"
 
 summarize_build() {
@@ -233,7 +233,7 @@ summarize_build() {
 
 install_plugin $BP_DIR $BUILD_DIR
 
-header "Build succeeded!"
+header "Build succeeded!" | output "$LOG_FILE"
 mcount "compile"
 summarize_build | output "$LOG_FILE"
 

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -8,7 +8,12 @@ output() {
 
   while read LINE;
   do
-    echo "       $LINE" || true
+    # do not indent headers that are being piped through the output
+    if [[ "$LINE" =~ ^-----\>.* ]]; then
+      echo "$LINE" || true
+    else
+      echo "       $LINE" || true
+    fi
     echo "$LINE" >> "$logfile" || true
   done
 }


### PR DESCRIPTION
Currently there's no way to capture the header output if it's piped through `output` because it's automatically indented, which means we can't add any headers inside any of the functions that are piped.

This prevents the header from being indented by matching on the `----->` at the beginning of the line.