### PR TITLE
Increase Node memory default during builds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -86,6 +86,7 @@ mkdir -p "$BUILD_DIR/.heroku/node/"
 cd $BUILD_DIR
 create_env # can't pipe the whole thing because piping causes subshells, preventing exports
 list_node_config | output "$LOG_FILE"
+create_build_env
 
 ### Configure package manager cache directories
 [ ! "$YARN_CACHE_FOLDER" ] && export YARN_CACHE_FOLDER=$(mktemp -d -t yarncache.XXXXX)

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -22,6 +22,14 @@ create_default_env() {
   export NODE_VERBOSE=${NODE_VERBOSE:-false}
 }
 
+create_build_env() {
+  # if the user hasn't set NODE_OPTIONS, increase the default amount of space
+  # that a node process can address to match that of the build dynos (2.5GB)
+  if [[ -z $NODE_OPTIONS ]]; then
+    export NODE_OPTIONS="--max_old_space_size=2560"
+  fi
+}
+
 list_node_config() {
   echo ""
   printenv | grep ^NPM_CONFIG_ || true

--- a/test/fixtures/print-node-options/README.md
+++ b/test/fixtures/print-node-options/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/print-node-options/package.json
+++ b/test/fixtures/print-node-options/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "8.x"
+  },
+  "scripts": {
+    "start": "node foo.js",
+    "heroku-postbuild": "echo NODE_OPTIONS=$NODE_OPTIONS"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -49,6 +49,18 @@ testNodeModulesCached() {
   assertCapturedSuccess
 }
 
+testSetBuildEnv() {
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  compile "print-node-options"
+  assertCaptured "NODE_OPTIONS=--max_old_space_size=2560"
+
+  echo "--max_old_space_size=1234" > $env_dir/NODE_OPTIONS
+  compile "print-node-options" $cache $env_dir
+  assertCaptured "NODE_OPTIONS=--max_old_space_size=1234"
+}
+
 testYarn() {
   compile "yarn"
   assertCaptured "installing yarn"


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-buildpack-nodejs/issues/549

We've seen an increasing failures due to frontend build exceeding Node default 1.5GB memory limit during build. Heroku runs these builds on machines with 2.5GB of memory. This increases the default limit for Node 8 and above by passing commands via `NODE_OPTIONS` during build if the user has not set this manually.

The drawback is that once users hit this new limit, there will be nothing they can do to get past it. The current limit currently serves as an early warning system that something might be wrong with your build before it gets too bad.