### PR TITLE
Fix branch detection for automated hatchet tests

### DIFF
--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -31,7 +31,7 @@ elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
   export IS_RUNNING_ON_TRAVIS=true
   export HATCHET_BUILDPACK_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
 else
-  export HATCHET_BUILDPACK_BRANCH=$(git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#\1#')
+  export HATCHET_BUILDPACK_BRANCH=$(git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#\1#' | sed 's#tags\/##')
 fi
 
 gem install bundler


### PR DESCRIPTION
When new versions of Node are detected by the `nodebin` service, they are put into a staging bucket and trigger a set of Hatchet tests to be run on Travis CI.

Currently the `etc/hatchet.sh` script that it is running is pulling out the wrong branch. You can see the failing log here: https://travis-ci.org/heroku/heroku-buildpack-nodejs/builds/425495686

```
error fetching custom buildpack https://github.com/heroku/heroku-buildpack-nodejs#tags/v126
```

This change updates the bash script to also trim off the `tags/` from this string, which will reference the tag `v126` which will be valid

```
❯ git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#\1#'
tags/v126
                                                                                                                                                                                                    
❯ git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#\1#' | sed 's#tags\/##'
v126
```
