### PR TITLE
Add key-value store

### DIFF
--- a/lib/kvstore.sh
+++ b/lib/kvstore.sh
@@ -1,0 +1,53 @@
+
+kv_create() {
+  local f=$1
+  mkdir -p $(dirname $f)
+  touch $f
+}
+
+kv_clear() {
+  local f=$1
+  echo "" > $f
+}
+
+kv_set() {
+  if [[ $# -eq 3 ]]; then
+    local f=$1
+    if [[ -f $f ]]; then
+      echo "$2=$3" >> $f
+    fi
+  fi
+}
+
+kv_get() {
+  if [[ $# -eq 2 ]]; then
+    local f=$1
+    if [[ -f $f ]]; then
+      grep "^$2=" $f | sed -e "s/^$2=//" | tail -n 1
+    fi
+  fi
+}
+
+kv_keys() {
+  local f=$1
+  local keys=()
+
+  if [[ -f $f ]]; then
+    # get list of keys
+    while IFS="=" read -r key value; do
+      keys+=("$key")
+    done < $f
+
+    echo "${keys[@]}" | tr ' ' '\n' | sort -u
+  fi
+}
+
+kv_list() {
+  local f=$1
+
+  kv_keys $f | tr ' ' '\n' | while read -r key; do
+    if [[ -n $key ]]; then
+      echo "$key=$(kv_get $f $key)"
+    fi
+  done
+}

--- a/test/unit
+++ b/test/unit
@@ -46,9 +46,75 @@ testOutput() {
   assertEquals 'should preserve unescaped backslashes' '       Foo \ bar' "${stdout}"
 }
 
+testKeyValue() {
+  local store=$(mktemp)
+
+  kv_create $store
+
+  kv_set $store key value
+  kv_set $store foo bar
+  kv_set $store key other_value
+  kv_set $store bar baz
+
+  assertEquals "other_value" "$(kv_get $store key)"
+  assertEquals "bar" "$(kv_get $store foo)"
+  assertEquals "baz" "$(kv_get $store bar)"
+
+  # if the key isn't there it should return an empty string
+  assertEquals "" "$(kv_get $store not_there)"
+
+  # kv_keys returns each key on a new line
+  assertEquals "$(printf "%s\n" bar foo key)" "$(kv_keys $store)"
+
+  # kv_list returns key=value on individual lines
+  assertEquals "$(printf "%s\n" bar=baz foo=bar key=other_value)" "$(kv_list $store)"
+
+  # calling create on an existing store doesn't erase it
+  kv_create $store
+  assertEquals "$(printf "%s\n" bar=baz foo=bar key=other_value)" "$(kv_list $store)"
+
+  # now clear the store
+  kv_clear $store
+
+  assertEquals "" "$(kv_get $store key)"
+  assertEquals "" "$(kv_keys $store)"
+  assertEquals "" "$(kv_list $store)"
+}
+
+# if the file doesn't exist, everything should be a no-op
+testKeyValueNoFile() {
+  # empty file argument
+  local empty=""
+
+  kv_set $empty key value
+
+  assertEquals "$(kv_get $empty key)" ""
+  assertEquals "$(kv_keys $empty)" ""
+  assertEquals "$(kv_list $empty)" ""
+
+  local store="/tmp/does-not-exist"
+
+  kv_set $store key value
+
+  assertEquals "" "$(kv_get $store key)"
+  assertEquals "" "$(kv_keys $store)"
+  assertEquals "" "$(kv_list $store)"
+
+  # running these commands has not created this file
+  assertTrue "[[ ! -e $store ]]"
+
+  local space=" "
+  kv_set $space key value
+
+  assertEquals "$(kv_get $space key)" ""
+  assertEquals "$(kv_keys $space)" ""
+  assertEquals "$(kv_list $space)" ""
+}
+
 # the modules to be tested
 source "$(pwd)"/lib/monitor.sh
 source "$(pwd)"/lib/output.sh
+source "$(pwd)"/lib/kvstore.sh
 
 # import the testing framework
 source "$(pwd)"/test/shunit2


### PR DESCRIPTION
This adds the implementation and unit tests for a key-value store in bash that is serialized to disk