### PR TITLE
Unpin the default Yarn version from 1.9.x

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -1,6 +1,6 @@
 install_yarn() {
   local dir="$1"
-  local version=${2:-1.9.x}
+  local version=${2:-1.x}
   local number
   local url
 


### PR DESCRIPTION
Now that 1.11.0 is released with https://github.com/yarnpkg/yarn/pull/6413 merged, Heroku users should see fewer failed builds due to 500 responses from the registry.