### PR TITLE
Mention 'stack' in the cache invalidation message

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -167,11 +167,11 @@ restore_cache() {
   elif [[ "$cache_status" == "new-signature" ]]; then
     header "Restoring cache"
     if [[ "$cache_directories" == "" ]]; then
-      echo "Cached directories were not restored because of a change in versions of node, npm, or yarn"
+      echo "Cached directories were not restored due to a change in version of node, npm, yarn or stack"
       echo "Module installation may take longer for this build"
     else
       # If the user has specified custom cache directories, be more explicit
-      echo "Invalidating cache due to a change in node, npm, or yarn versions"
+      echo "Invalidating cache due to a change in version of node, npm, yarn or stack"
       echo "Will not restore the following directories for this build:"
       for directory in $(< $cache_directories); do
         echo "  $directory"

--- a/test/run
+++ b/test/run
@@ -118,7 +118,7 @@ testCacheWithPrebuild() {
   assertCapturedSuccess
 
   compile "cache-prebuild" $cache $env_dir
-  assertCaptured "Cached directories were not restored because of a change in versions of node"
+  assertCaptured "Cached directories were not restored due to a change in version of node"
   assertCapturedSuccess
 }
 
@@ -459,7 +459,7 @@ testSignatureInvalidation() {
 
   compile "node-0.12.7" $cache
   assertCaptured "Downloading and installing node 0.12.7"
-  assertCaptured "Cached directories were not restored because of a change in versions of node"
+  assertCaptured "Cached directories were not restored due to a change in version of node"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
The "Cached directories were not restored" message now includes the stack version in the list of possible reasons.

(Technically there is one reason still omitted - `PREBUILD`, however that's more of an edge case, and trying to explain that in the message would lead to it being too verbose.)