### PR TITLE
Adjust output() so it preserves leading whitespace

### DIFF
--- a/lib/output.sh
+++ b/lib/output.sh
@@ -1,3 +1,6 @@
+# TODO: Merge these with the output helpers in buildpack-stdlib:
+# https://github.com/heroku/buildpack-stdlib
+
 info() {
   echo "       $*" || true
 }
@@ -6,7 +9,7 @@ info() {
 output() {
   local logfile="$1"
 
-  while read LINE;
+  while IFS= read -r LINE;
   do
     # do not indent headers that are being piped through the output
     if [[ "$LINE" =~ ^-----\>.* ]]; then

--- a/test/unit
+++ b/test/unit
@@ -36,8 +36,19 @@ testMonitorMemory() {
   assertEquals "second line" "$(tail -n 1 $stdout_capture)" "--bar=baz lol hi"
 }
 
+testOutput() {
+  local stdout
+
+  stdout=$(echo '    Indented line' | output /dev/null)
+  assertEquals 'should preserve leading whitespace' '           Indented line' "${stdout}"
+
+  stdout=$(echo 'Foo \ bar' | output /dev/null)
+  assertEquals 'should preserve unescaped backslashes' '       Foo \ bar' "${stdout}"
+}
+
 # the modules to be tested
 source "$(pwd)"/lib/monitor.sh
+source "$(pwd)"/lib/output.sh
 
 # import the testing framework
 source "$(pwd)"/test/shunit2

--- a/test/unit
+++ b/test/unit
@@ -32,8 +32,8 @@ testMonitorMemory() {
   monitor_memory_usage $mem_output print_args --foo --bar="baz lol hi" > $stdout_capture
   assertTrue "should use less than 2mb" "[[ $(cat $mem_output) -lt 2 ]]"
   assertTrue "should output 2 lines" "[[ $(wc -l < $stdout_capture) -eq 2 ]]"
-  assertEquals "first line" "$(head -n 1 $stdout_capture)" "--foo"
-  assertEquals "second line" "$(tail -n 1 $stdout_capture)" "--bar=baz lol hi"
+  assertEquals "first line" "--foo" "$(head -n 1 $stdout_capture)"
+  assertEquals "second line" "--bar=baz lol hi" "$(tail -n 1 $stdout_capture)"
 }
 
 testOutput() {


### PR DESCRIPTION
Unless `IFS` is adjusted, `read` strips leading and trailing whitespace from each line. In addition, without the `-r` argument to `read`, unescaped backslashes are discarded.

See:
http://mywiki.wooledge.org/BashFAQ/001

Fixes #571.