### PR TITLE
Allow Node 11 integration tests to pass

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,7 +62,7 @@ def resolve_all_supported_node_versions(options = {})
 end
 
 def version_supports_metrics(version)
-  SemVersion.new(version).satisfies?('>= 8.0.0')
+  SemVersion.new(version).satisfies?('>= 8.0.0') && SemVersion.new(version).satisfies?('< 11.0.0')
 end
 
 def get_test_versions


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-buildpack-nodejs/issues/576

Example failing CI run: https://travis-ci.org/heroku/heroku-buildpack-nodejs/builds/448028570

Nodebin automatically picks up new versions of Node, runs them against our CI suite in this repository and then makes them available on the platform. Currently Node `11.0.0` is failing these runs because it satisfies the `supports_metrics` test when it shouldn't yet. This small change tweaks to the `supports_metrics` predicate to be more accurate.

I will create a follow-up PR that adds a new build of the metrics plugin for Node 11, but this will make it available for now.