### PR TITLE
Fix CI tests that dependended on Node 10

### DIFF
--- a/test/run
+++ b/test/run
@@ -584,7 +584,7 @@ testDangerousRangeStar() {
   compile "dangerous-range-star"
   assertCaptured "Dangerous semver range"
   assertCaptured "Resolving node version *"
-  assertCaptured "Downloading and installing node 10."
+  assertCaptured "Downloading and installing node"
   assertCapturedError
 }
 
@@ -592,14 +592,14 @@ testDangerousRangeGreaterThan() {
   compile "dangerous-range-greater-than"
   assertCaptured "Dangerous semver range"
   assertCaptured "Resolving node version >0.4"
-  assertCaptured "Downloading and installing node 10."
+  assertCaptured "Downloading and installing node"
   assertCapturedError
 }
 
 testRangeWithSpace() {
   compile "range-with-space"
   assertCaptured "Resolving node version >= 0.8.x"
-  assertCaptured "Downloading and installing node 10."
+  assertCaptured "Downloading and installing node"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
These tests use >= version requirements, so they would break whenever new major versions are released. That's not really necessary, so this removes the bits that will continually break so we don't have to keep bumping them in the future.