### PR TITLE
Add new build script behavior behind a flag

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -208,12 +208,14 @@ build_dependencies() {
   mtime "modules.time.cache.$cache_status" "${start}"
 
   if [[ "$NEW_BUILD_SCRIPT_BEHAVIOR" = true ]]; then
+    mcount "build-script.new-behavior"
     run_build_script
   else
+    mcount "build-script.legacy-behavior"
     run_if_present 'heroku-postbuild'
-    # TODO: run_if_present 'build'
-    log_build_scripts
   fi
+
+  log_build_scripts
 }
 
 header "Building dependencies" | output "$LOG_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -62,6 +62,9 @@ trap 'handle_failure' ERR
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
 
+### Behavior flags
+[ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=false
+
 ### Failures that should be caught immediately
 
 fail_dot_heroku "$BUILD_DIR"
@@ -204,9 +207,13 @@ build_dependencies() {
 
   mtime "modules.time.cache.$cache_status" "${start}"
 
-  run_if_present 'heroku-postbuild'
-  # TODO: run_if_present 'build'
-  log_build_scripts
+  if [[ "$NEW_BUILD_SCRIPT_BEHAVIOR" = true ]]; then
+    run_build_script
+  else
+    run_if_present 'heroku-postbuild'
+    # TODO: run_if_present 'build'
+    log_build_scripts
+  fi
 }
 
 header "Building dependencies" | output "$LOG_FILE"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -29,6 +29,23 @@ run_if_present() {
   fi
 }
 
+run_build_script() {
+  local has_build_script=$(read_json "$BUILD_DIR/package.json" ".scripts.build")
+  local has_heroku_build_script=$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-postbuild\"]")
+
+  if [[ -n "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]]; then
+    echo "Detected both 'build' and 'heroku-postbuild' scripts"
+    mcount "scripts.heroku-postbuild-and-build"
+    run_if_present 'heroku-postbuild'
+  elif [[ -n "$has_heroku_build_script" ]]; then
+    mcount "scripts.heroku-postbuild"
+    run_if_present 'heroku-postbuild'
+  elif [[ -n "$has_build_script" ]]; then
+    mcount "scripts.build"
+    run_if_present 'build'
+  fi
+}
+
 log_build_scripts() {
   local build=$(read_json "$BUILD_DIR/package.json" ".scripts[\"build\"]")
   local heroku_prebuild=$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-prebuild\"]")

--- a/test/fixtures/build-script-override/README.md
+++ b/test/fixtures/build-script-override/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/build-script-override/package.json
+++ b/test/fixtures/build-script-override/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "~0.10.0"
+  },
+  "scripts" : {
+    "build": "echo build hook message",
+    "heroku-postbuild": "echo heroku-postbuild hook message"
+  }
+}

--- a/test/fixtures/build-script/README.md
+++ b/test/fixtures/build-script/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/build-script/package.json
+++ b/test/fixtures/build-script/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "~0.10.0"
+  },
+  "scripts" : {
+    "build" : "echo build hook message"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -8,6 +8,45 @@
 #  assertCapturedError
 #}
 
+testBuildScriptBehavior() {
+  # opt in to new build script behavior
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+  echo "true" > $env_dir/NEW_BUILD_SCRIPT_BEHAVIOR
+
+  # The 'build' script is run by default
+  compile "build-script" $cache $env_dir
+  assertCaptured "Running build"
+  assertCapturedSuccess
+
+  # the 'heroku-postbuild' script takes precedence over the 'build' script
+  compile "build-script-override" $cache $env_dir
+  assertCaptured "Detected both 'build' and 'heroku-postbuild' scripts"
+  assertCaptured "Running heroku-postbuild"
+  assertCapturedSuccess
+}
+
+testPrePostBuildScripts() {
+  compile "pre-post-build-scripts"
+  assertCaptured "Running heroku-prebuild"
+  assertCaptured "echo heroku-prebuild hook message"
+  assertCaptured "Running heroku-postbuild"
+  assertCaptured "echo heroku-postbuild hook message"
+  assertCapturedSuccess
+
+  compile "stable-node"
+  assertNotCaptured "Running heroku-prebuild"
+  assertNotCaptured "Running heroku-postbuild"
+  assertCapturedSuccess
+}
+
+testYarnRun() {
+  compile "yarn-run"
+  assertCaptured "Running heroku-postbuild (yarn)"
+  assertCaptured "foobar"
+  assertCapturedSuccess
+}
+
 testNoVersion() {
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
@@ -165,13 +204,6 @@ testYarnSemverInvalid() {
   assertCapturedError
 }
 
-testYarnRun() {
-  compile "yarn-run"
-  assertCaptured "Running heroku-postbuild (yarn)"
-  assertCaptured "foobar"
-  assertCapturedSuccess
-}
-
 testYarnEngine() {
   compile "yarn-engine"
   assertCaptured "installing yarn (1.4.0)"
@@ -292,20 +324,6 @@ testEnvBlacklist() {
   compile "echo-lang" $cache $env_dir
   assertCaptured "safeVar"
   assertNotCaptured "tr_TR.UTF-8"
-  assertCapturedSuccess
-}
-
-testPrePostBuildScripts() {
-  compile "pre-post-build-scripts"
-  assertCaptured "Running heroku-prebuild"
-  assertCaptured "echo heroku-prebuild hook message"
-  assertCaptured "Running heroku-postbuild"
-  assertCaptured "echo heroku-postbuild hook message"
-  assertCapturedSuccess
-
-  compile "stable-node"
-  assertNotCaptured "Running heroku-prebuild"
-  assertNotCaptured "Running heroku-postbuild"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
First step to addressing: https://github.com/heroku/heroku-buildpack-nodejs/issues/583

This adds a new logic branch that will run the 'build' script by default, and run the 'heroku-postbuild' script instead if it is defined.

This branch will not be run for any user yet. Further changes will start to enable this.