### PR TITLE
Allow user opt in to build script default behavior

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -74,6 +74,10 @@ fail_multiple_lockfiles "$BUILD_DIR"
 warn_prebuilt_modules "$BUILD_DIR"
 warn_missing_package_json "$BUILD_DIR"
 
+### Behavior flags
+[ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=$(read_json "$BUILD_DIR/package.json" ".[\"heroku-run-build-script\"]")
+warn_build_script_behavior_opt_in $NEW_BUILD_SCRIPT_BEHAVIOR | output "$LOG_FILE"
+
 ### Compile
 
 create_env() {

--- a/bin/compile
+++ b/bin/compile
@@ -62,9 +62,6 @@ trap 'handle_failure' ERR
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
 
-### Behavior flags
-[ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=false
-
 ### Failures that should be caught immediately
 
 fail_dot_heroku "$BUILD_DIR"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -46,6 +46,20 @@ run_build_script() {
   fi
 }
 
+<<<<<<< HEAD
+=======
+warn_build_script_behavior_opt_in() {
+  local opted_in="$1"
+  if [[ "$opted_in" = true ]]; then
+    header "Opting in to new default build script behavior"
+    echo "You have set \"heroku-run-build-script\" = true in your package.json"
+    echo ""
+    echo "- If a \"build\" script is defined in package.json it will be executed by default"
+    echo "- The \"heroku-postbuild\" script will be executed instead if present"
+  fi
+}
+
+>>>>>>> Allow user to opt-in to the build script changes
 log_build_scripts() {
   local build=$(read_json "$BUILD_DIR/package.json" ".scripts[\"build\"]")
   local heroku_prebuild=$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-prebuild\"]")

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -46,8 +46,6 @@ run_build_script() {
   fi
 }
 
-<<<<<<< HEAD
-=======
 warn_build_script_behavior_opt_in() {
   local opted_in="$1"
   if [[ "$opted_in" = true ]]; then
@@ -59,7 +57,6 @@ warn_build_script_behavior_opt_in() {
   fi
 }
 
->>>>>>> Allow user to opt-in to the build script changes
 log_build_scripts() {
   local build=$(read_json "$BUILD_DIR/package.json" ".scripts[\"build\"]")
   local heroku_prebuild=$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-prebuild\"]")

--- a/test/fixtures/build-script-opt-in/README.md
+++ b/test/fixtures/build-script-opt-in/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/build-script-opt-in/package.json
+++ b/test/fixtures/build-script-opt-in/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts" : {
+    "build" : "echo build hook message"
+  },
+  "heroku-run-build-script": true
+}

--- a/test/run
+++ b/test/run
@@ -26,8 +26,6 @@ testBuildScriptBehavior() {
   assertCapturedSuccess
 }
 
-<<<<<<< HEAD
-=======
 testBuildScriptOptIn() {
   compile "build-script-opt-in"
   assertCaptured "Running build"
@@ -35,7 +33,6 @@ testBuildScriptOptIn() {
   assertCapturedSuccess
 }
 
->>>>>>> Allow user to opt-in to the build script changes
 testPrePostBuildScripts() {
   compile "pre-post-build-scripts"
   assertCaptured "Running heroku-prebuild"

--- a/test/run
+++ b/test/run
@@ -26,6 +26,16 @@ testBuildScriptBehavior() {
   assertCapturedSuccess
 }
 
+<<<<<<< HEAD
+=======
+testBuildScriptOptIn() {
+  compile "build-script-opt-in"
+  assertCaptured "Running build"
+  assertCaptured "Opting in to new default build script behavior"
+  assertCapturedSuccess
+}
+
+>>>>>>> Allow user to opt-in to the build script changes
 testPrePostBuildScripts() {
   compile "pre-post-build-scripts"
   assertCaptured "Running heroku-prebuild"


### PR DESCRIPTION
Depends on: https://github.com/heroku/heroku-buildpack-nodejs/pull/584

This checks the user's `package.json` for a `heroku-run-build-script` key. If it is set to `true` the new build step will be run instead of the old step, and a message will be printed at the beginning of the build to confirm that is the case.

```
-----> Opting in to new default build script behavior
       You have set "heroku-run-build-script" = true in your package.json

       - If a "build" script is defined in package.json it will be executed by default
       - The "heroku-postbuild" script will be executed instead if present

-----> Creating runtime environment

...
```