### PR TITLE
Move cached directories one level down within the node cache

### DIFF
--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -1,7 +1,7 @@
 source $BP_DIR/lib/binaries.sh
 
 create_signature() {
-  echo "${STACK}; $(node --version); $(npm --version); $(yarn --version 2>/dev/null || true); ${PREBUILD}"
+  echo "v2; ${STACK}; $(node --version); $(npm --version); $(yarn --version 2>/dev/null || true); ${PREBUILD}"
 }
 
 save_signature() {

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -46,10 +46,10 @@ restore_default_cache_directories() {
   # node_modules
   if [[ -e "$build_dir/node_modules" ]]; then
     echo "- node_modules is checked into source control and cannot be cached"
-  elif [[ -e "$cache_dir/node/node_modules" ]]; then
+  elif [[ -e "$cache_dir/node/cache/node_modules" ]]; then
     echo "- node_modules"
     mkdir -p "$(dirname "$build_dir/node_modules")"
-    mv "$cache_dir/node/node_modules" "$build_dir/node_modules"
+    mv "$cache_dir/node/cache/node_modules" "$build_dir/node_modules"
   else
     echo "- node_modules (not cached - skipping)"
   fi
@@ -71,10 +71,10 @@ restore_custom_cache_directories() {
     if [ -e "$build_dir/$cachepath" ]; then
       echo "- $cachepath (exists - skipping)"
     else
-      if [ -e "$cache_dir/node/$cachepath" ]; then
+      if [ -e "$cache_dir/node/cache/$cachepath" ]; then
         echo "- $cachepath"
         mkdir -p "$(dirname "$build_dir/$cachepath")"
-        mv "$cache_dir/node/$cachepath" "$build_dir/$cachepath"
+        mv "$cache_dir/node/cache/$cachepath" "$build_dir/$cachepath"
       else
         echo "- $cachepath (not cached - skipping)"
       fi
@@ -85,6 +85,7 @@ restore_custom_cache_directories() {
 clear_cache() {
   rm -rf $CACHE_DIR/node
   mkdir -p $CACHE_DIR/node
+  mkdir -p $CACHE_DIR/node/cache
 }
 
 save_default_cache_directories() {
@@ -95,7 +96,7 @@ save_default_cache_directories() {
   if [[ -e "$build_dir/node_modules" ]]; then
     echo "- node_modules"
     mkdir -p "$cache_dir/node/node_modules"
-    cp -a "$build_dir/node_modules" "$(dirname "$cache_dir/node/node_modules")"
+    cp -a "$build_dir/node_modules" "$(dirname "$cache_dir/node/cache/node_modules")"
   else
     # this can happen if there are no dependencies
     mcount "cache.no-node-modules"
@@ -106,8 +107,8 @@ save_default_cache_directories() {
   if [[ -e "$build_dir/bower_components" ]]; then
     mcount "cache.saved-bower-components"
     echo "- bower_components"
-    mkdir -p "$cache_dir/node/bower_components"
-    cp -a "$build_dir/bower_components" "$(dirname "$cache_dir/node/bower_components")"
+    mkdir -p "$cache_dir/node/cache/bower_components"
+    cp -a "$build_dir/bower_components" "$(dirname "$cache_dir/node/cache/bower_components")"
   fi
 }
 
@@ -121,8 +122,8 @@ save_custom_cache_directories() {
   for cachepath in "${cache_directories[@]}"; do
     if [ -e "$build_dir/$cachepath" ]; then
       echo "- $cachepath"
-      mkdir -p "$cache_dir/node/$cachepath"
-      cp -a "$build_dir/$cachepath" "$(dirname "$cache_dir/node/$cachepath")"
+      mkdir -p "$cache_dir/node/cache/$cachepath"
+      cp -a "$build_dir/$cachepath" "$(dirname "$cache_dir/node/cache/$cachepath")"
     else
       echo "- $cachepath (nothing to cache)"
     fi

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -55,7 +55,7 @@ restore_default_cache_directories() {
   fi
 
   # bower_components, should be silent if it is not in the cache
-  if [[ -e "$cache_dir/node/bower_components" ]]; then
+  if [[ -e "$cache_dir/node/cache/bower_components" ]]; then
     echo "- bower_components"
   fi
 }
@@ -95,7 +95,7 @@ save_default_cache_directories() {
   # node_modules
   if [[ -e "$build_dir/node_modules" ]]; then
     echo "- node_modules"
-    mkdir -p "$cache_dir/node/node_modules"
+    mkdir -p "$cache_dir/node/cache/node_modules"
     cp -a "$build_dir/node_modules" "$(dirname "$cache_dir/node/cache/node_modules")"
   else
     # this can happen if there are no dependencies

--- a/test/run
+++ b/test/run
@@ -118,9 +118,14 @@ testYarnCacheDirectory() {
   echo "${cache_dir}/yarn"> "$env_dir"/YARN_CACHE_FOLDER
   compile "yarn" $cache $env_dir
   # These will be created if yarn is using the directory for its cache
+
   assertDirectoryExists ${cache_dir}/yarn
-  assertDirectoryExists ${cache_dir}/yarn/v3
-  assertFileExists ${cache_dir}/yarn/v3/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
+  # yarn frequently bumps the version number used in its cache
+  # so use a wildcard here to prevent frequent CI failures
+  ls ${cache_dir}/yarn/v*/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
+
+  # assert that the above ls command exited successfully, which only happens if the file exists
+  assertEquals "0" "$?"
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -69,7 +69,7 @@ testDisableCache() {
   echo "true" > $env_dir/NODE_VERBOSE
   compile "node-modules-cache-1" $cache $env_dir
   assertCaptured "lodash@1.0.0"
-  assertEquals "1" "$(ls -1 $cache/node/node_modules | grep -c lodash | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/cache/node_modules | grep -c lodash | tr -d ' ')"
   assertCapturedSuccess
 
   compile "node-modules-cache-2" $cache $env_dir
@@ -87,7 +87,7 @@ testNodeModulesCached() {
 
   compile "caching" $cache
   assertCaptured "- node_modules"
-  assertEquals "1" "$(ls -1 $cache/node/node_modules | grep -c express | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/cache/node_modules | grep -c express | tr -d ' ')"
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -115,7 +115,7 @@ testYarnCacheDirectory() {
   local cache=$(mktmpdir)
   local env_dir=$(mktmpdir)
   local cache_dir=$(mktmpdir)
-  echo "${cache_dir}/yarn"> "$env_dir"/YARN_CACHE_FOLDER
+  echo "${cache_dir}/yarn"> "$env_dir/YARN_CACHE_FOLDER"
   compile "yarn" $cache $env_dir
   # These will be created if yarn is using the directory for its cache
 
@@ -146,7 +146,7 @@ testBuildWithCache() {
 
   compile "stable-node" $cache
   assertNotCaptured "Restoring cache"
-  assertEquals "1" "$(ls -1 $cache/node/node_modules | grep -c hashish | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/cache/node_modules | grep -c hashish | tr -d ' ')"
   assertCapturedSuccess
 
   compile "stable-node" $cache
@@ -154,7 +154,7 @@ testBuildWithCache() {
   assertFileContains "${STACK}" "${cache}/node/signature"
   assertCapturedSuccess
 
-  rm -rf "$cache/node/node_modules"
+  rm -rf "$cache/node/cache/node_modules"
   compile "stable-node" $cache
   assertCaptured "- node_modules (not cached - skipping)"
   assertCapturedSuccess
@@ -399,8 +399,8 @@ testBuildWithUserCacheDirectoriesCamel() {
 
   compile "cache-directories-camel" $cache
   assertCaptured "- non/existent (nothing to cache)"
-  assertEquals "1" "$(ls -1 $cache/node/server | grep -c node_modules | tr -d ' ')"
-  assertEquals "1" "$(ls -1 $cache/node/client | grep -c node_modules | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/cache/server | grep -c node_modules | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/cache/client | grep -c node_modules | tr -d ' ')"
   assertCapturedSuccess
 
   compile "cache-directories-camel" $cache
@@ -644,8 +644,8 @@ testBuildWithUserCacheDirectories() {
 
   compile "cache-directories" $cache
   assertCaptured "Saving 2 cacheDirectories"
-  assertEquals "1" "$(ls -1 $cache/node | grep -c bower_components | tr -d ' ')"
-  assertEquals "1" "$(ls -1 $cache/node | grep -c node_modules | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/cache | grep -c bower_components | tr -d ' ')"
+  assertEquals "1" "$(ls -1 $cache/node/cache | grep -c node_modules | tr -d ' ')"
   assertCapturedSuccess
 
   compile "cache-directories" $cache


### PR DESCRIPTION
This is a pre-requisite for making better use of the cache.

The current cache layout puts everything that the Node buildpack wants in the cache at: `$CACHE_DIR/node` including custom directories.

This creates a naming issue, since a user could cache anything. We currently keep a cache signature at: `$CACHE_DIR/node/signature`, but if a user declared a custom cache of a `signature` file, these would conflict and break things. 

Adding anything else to the Node cache would make this problem worse, so let's fix it.

This adds one more level where all of the cached directories can live. Now if a user wants to cache a `signature` file, the cache layout would look like this:

```
node/
  - cache/
    - signature
  - signature
```

so there is no longer a conflict.

Deploying this will cause a cache miss for all users since the new code is looking in a new spot, but this is a common enough occurrence that I don't expect it to be significant for anyone. To ensure that the old cache will be discarded, I've added a version to the signature file.