### PR TITLE
Add warning for flatmap-stream 404 failure

### DIFF
--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -368,7 +368,7 @@ log_other_failures() {
   if grep -i -e "npm ERR! code E404" -e "error An unexpected error occurred: .* Request failed \"404 Not Found\"" "$log_file"; then
 
     if grep -qi "flatmap-stream" "$log_file"; then
-      mcount "failures.flatmap-stream-404"
+      mcount "flatmap-stream-404"
       warn "The flatmap-stream module has been removed from the npm registry
 
        On November 26th, npm was notified of a malicious package that had made its

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -365,7 +365,8 @@ log_other_failures() {
     return 0
   fi
 
-  if grep -i -e "npm ERR! code E404" -e "error An unexpected error occurred: .* Request failed \"404 Not Found\"" "$log_file"; then
+  if grep -qi -e "npm ERR! code E404" -e "error An unexpected error occurred: .* Request failed \"404 Not Found\"" "$log_file"; then
+    mcount "failures.module-404"
 
     if grep -qi "flatmap-stream" "$log_file"; then
       mcount "flatmap-stream-404"
@@ -376,9 +377,9 @@ log_other_failures() {
        npm responded by removing flatmap-stream and event-stream@3.3.6 from the Registry
        and taking ownership of the event-stream package to prevent further abuse.
       " https://kb.heroku.com/4OM7X18J/why-am-i-seeing-npm-404-errors-for-event-stream-flatmap-stream-in-my-build-logs
+      exit 1
     fi
 
-    mcount "failures.module-404"
     return 0
   fi
 

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -366,6 +366,18 @@ log_other_failures() {
   fi
 
   if grep -i -e "npm ERR! code E404" -e "error An unexpected error occurred: .* Request failed \"404 Not Found\"" "$log_file"; then
+
+    if grep -qi "flatmap-stream" "$log_file"; then
+      mcount "failures.flatmap-stream-404"
+      warn "The flatmap-stream module has been removed from the npm registry
+
+       On November 26th, npm was notified of a malicious package that had made its
+       way into event-stream, a popular npm package. After triaging the malware,
+       npm responded by removing flatmap-stream and event-stream@3.3.6 from the Registry
+       and taking ownership of the event-stream package to prevent further abuse.
+      " https://kb.heroku.com/4OM7X18J/why-am-i-seeing-npm-404-errors-for-event-stream-flatmap-stream-in-my-build-logs
+    fi
+
     mcount "failures.module-404"
     return 0
   fi

--- a/test/fixtures/flatmap-stream/package-lock.json
+++ b/test/fixtures/flatmap-stream/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "flatmap-stream",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "flatmap-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
+      "integrity": "sha1-mDxroZk7WOroWZmKpof/6I34TBc="
+    }
+  }
+}

--- a/test/fixtures/flatmap-stream/package.json
+++ b/test/fixtures/flatmap-stream/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "flatmap-stream",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "flatmap-stream": "0.1.1"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -8,6 +8,13 @@
 #  assertCapturedError
 #}
 
+testFlatmapStream() {
+  compile "flatmap-stream"
+  assertCaptured "flatmap-stream module has been removed from the npm registry"
+  assertCaptured "why-am-i-seeing-npm-404-errors"
+  assertCapturedError
+}
+
 testBuildScriptBehavior() {
   # opt in to new build script behavior
   cache=$(mktmpdir)


### PR DESCRIPTION
We've seen a large increase in 404 errors failing builds due to the `flatmap-stream` security issue. Let's add a warning for the users that are hitting this.

![hyper 2018-11-28 09-16-39](https://user-images.githubusercontent.com/175496/49169455-a50c8700-f2ee-11e8-8fc9-c844567dcb34.png)
