### PR TITLE
Add monitoring for binary installations

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -122,8 +122,8 @@ install_bins() {
     mcount "version.iojs.$node_version"
   else
     warn_node_engine "$node_engine"
-    install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
-    install_npm "$npm_engine" "$BUILD_DIR/.heroku/node" $NPM_LOCK
+    monitor "install-node-binary" install_nodejs "$BUILD_DIR/.heroku/node" "$node_engine"
+    monitor "install-npm-binary" install_npm "$BUILD_DIR/.heroku/node" $NPM_LOCK "$npm_engine"
     local node_version="$(node --version)"
     mcount "version.node.$node_version"
   fi
@@ -132,7 +132,7 @@ install_bins() {
   # has specified a version of yarn under "engines". We'll still
   # only install using yarn if there is a yarn.lock file
   if $YARN || [ -n "$yarn_engine" ]; then
-    install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
+    monitor "install-yarn-binary" install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
   fi
 
   if $YARN; then

--- a/bin/compile
+++ b/bin/compile
@@ -122,8 +122,8 @@ install_bins() {
     mcount "version.iojs.$node_version"
   else
     warn_node_engine "$node_engine"
-    monitor "install-node-binary" install_nodejs "$BUILD_DIR/.heroku/node" "$node_engine"
-    monitor "install-npm-binary" install_npm "$BUILD_DIR/.heroku/node" $NPM_LOCK "$npm_engine"
+    monitor "install-node-binary" install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
+    monitor "install-npm-binary" install_npm "$npm_engine" "$BUILD_DIR/.heroku/node" $NPM_LOCK
     local node_version="$(node --version)"
     mcount "version.node.$node_version"
   fi

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -27,8 +27,8 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version=${1:-10.x}
-  local dir="${2:?}"
+  local dir="${1:?}"
+  local version=${2:-10.x}
 
   echo "Resolving node version $version..."
   if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
@@ -66,9 +66,9 @@ install_iojs() {
 }
 
 install_npm() {
-  local version="$1"
-  local dir="$2"
-  local npm_lock="$3"
+  local dir="$1"
+  local npm_lock="$2"
+  local version="$3"
   local npm_version="$(npm --version)"
 
   # If the user has not specified a version of npm, but has an npm lockfile

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -27,8 +27,8 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local dir="${1:?}"
-  local version=${2:-10.x}
+  local version=${1:-10.x}
+  local dir="${2:?}"
 
   echo "Resolving node version $version..."
   if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
@@ -66,9 +66,9 @@ install_iojs() {
 }
 
 install_npm() {
-  local dir="$1"
-  local npm_lock="$2"
-  local version="$3"
+  local version="$1"
+  local dir="$2"
+  local npm_lock="$3"
   local npm_version="$(npm --version)"
 
   # If the user has not specified a version of npm, but has an npm lockfile

--- a/test/run
+++ b/test/run
@@ -1008,6 +1008,8 @@ testMemoryMetrics() {
   echo "$metrics_log" > $env_dir/BUILDPACK_LOG_FILE
 
   compile "pre-post-build-scripts" "$(mktmpdir)" $env_dir
+  assertFileContains "measure#buildpack.nodejs.exec.install-node-binary.time=" $metrics_log
+  assertFileContains "measure#buildpack.nodejs.exec.install-npm-binary.time=" $metrics_log
   assertFileContains "measure#buildpack.nodejs.exec.heroku-prebuild.time=" $metrics_log
   assertFileContains "measure#buildpack.nodejs.exec.heroku-prebuild.memory=" $metrics_log
   assertFileContains "measure#buildpack.nodejs.exec.npm-install.time=" $metrics_log
@@ -1018,6 +1020,8 @@ testMemoryMetrics() {
   # erase the metrics log
   echo "" > $metrics_log
   compile "yarn" "$(mktmpdir)" $env_dir
+  assertFileContains "measure#buildpack.nodejs.exec.install-node-binary.time=" $metrics_log
+  assertFileContains "measure#buildpack.nodejs.exec.install-yarn-binary.time=" $metrics_log
   assertFileContains "measure#buildpack.nodejs.exec.yarn-install.memory=" "$metrics_log"
   assertFileContains "measure#buildpack.nodejs.exec.yarn-install.time=" "$metrics_log"
   # this fixture does not have pre or post-build scripts


### PR DESCRIPTION
We almost certainly don't care about the memory usage, but we're not currently tracking the amount of time this takes, and we should be. Re-uses the existing `monitor` command for consistency.