### PR TITLE
Fix some bugs in the monitor function

### DIFF
--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -45,12 +45,13 @@ monitor_memory_usage() {
 monitor() {
   local command_name=$1
   shift
-  local command="${@:-}"
+
+  local command=( "$@" )
   local peak_mem_output=$(mktemp)
   local start=$(nowms)
 
   # execute the subcommand and save the peak memory usage
-  monitor_memory_usage $peak_mem_output $command
+  monitor_memory_usage $peak_mem_output "${command[@]}"
 
   mtime "exec.$command_name.time" "${start}"
   mmeasure "exec.$command_name.memory" "$(cat $peak_mem_output)"

--- a/test/mocks/stdlib.sh
+++ b/test/mocks/stdlib.sh
@@ -1,0 +1,13 @@
+# mock these functions from the stdlib
+
+nowms() {
+  :
+}
+
+mtime() {
+  :
+}
+
+mmeasure() {
+  :
+}

--- a/test/unit
+++ b/test/unit
@@ -19,6 +19,10 @@ print_args() {
   done
 }
 
+print_number_args() {
+  echo "$#"
+}
+
 testMonitorMemory() {
   local mem_output=$(mktemp)
   local stdout_capture=$(mktemp)
@@ -34,6 +38,29 @@ testMonitorMemory() {
   assertTrue "should output 2 lines" "[[ $(wc -l < $stdout_capture) -eq 2 ]]"
   assertEquals "first line" "--foo" "$(head -n 1 $stdout_capture)"
   assertEquals "second line" "--bar=baz lol hi" "$(tail -n 1 $stdout_capture)"
+}
+
+testMonitor() {
+  local out
+
+  # test that we're forwarding empty arguments correctly
+  out=$(monitor "command-name" print_number_args "" "" "" "")
+  assertEquals "4" "$out"
+
+  # Don't expand *
+  out=$(monitor "command-name" echo "*")
+  assertEquals "*" "$out"
+
+  out=$(monitor "command-name" print_number_args "*")
+  assertEquals "1" "$out"
+
+  # # Don't split arguments with a space
+  out=$(monitor "command-name" echo "1  3")
+  assertEquals "1  3" "$out"
+
+  # # Test everything with an empty arg
+  out=$(monitor "command-name" echo 1 "" 2 "3   4" "*")
+  assertEquals "1  2 3   4 *" "$out"
 }
 
 testOutput() {
@@ -110,6 +137,9 @@ testKeyValueNoFile() {
   assertEquals "$(kv_keys $space)" ""
   assertEquals "$(kv_list $space)" ""
 }
+
+# mocks
+source "$(pwd)"/test/mocks/stdlib.sh
 
 # the modules to be tested
 source "$(pwd)"/lib/monitor.sh


### PR DESCRIPTION
There were some issues with using the `monitor` utility discovered in https://github.com/heroku/heroku-buildpack-nodejs/pull/591#discussion_r241261856

`monitor` was collapsing empty arguments and expanding wildcard `*` arguments, leading to some odd behavior. This adds tests and fixes those issues.