### PR TITLE
[kvstore] wrap string with spaces

### DIFF
--- a/lib/kvstore.sh
+++ b/lib/kvstore.sh
@@ -14,7 +14,12 @@ kv_set() {
   if [[ $# -eq 3 ]]; then
     local f=$1
     if [[ -f $f ]]; then
-      echo "$2=$3" >> $f
+      # if the value has any spaces, wrap it in quotes
+      if [[ $3 =~ [[:space:]]+ ]]; then
+        echo "$2=\"$3\"" >> $f
+      else
+        echo "$2=$3" >> $f
+      fi
     fi
   fi
 }

--- a/lib/kvstore.sh
+++ b/lib/kvstore.sh
@@ -24,12 +24,24 @@ kv_set() {
   fi
 }
 
-kv_get() {
+# get the value, but don't unwrap quotes
+kv_get_literal() {
   if [[ $# -eq 2 ]]; then
     local f=$1
     if [[ -f $f ]]; then
       grep "^$2=" $f | sed -e "s/^$2=//" | tail -n 1
     fi
+  fi
+}
+
+kv_get() {
+  local value=$(kv_get_literal $1 $2 $3)
+
+  # if the value has been wrapped in quotes, unwrap it
+  if [[ $value =~ ^\".+\"$ ]]; then
+    echo "${value:1:${#value}-2}"
+  else
+    echo $value
   fi
 }
 
@@ -52,7 +64,7 @@ kv_list() {
 
   kv_keys $f | tr ' ' '\n' | while read -r key; do
     if [[ -n $key ]]; then
-      echo "$key=$(kv_get $f $key)"
+      echo "$key=$(kv_get_literal $f $key)"
     fi
   done
 }

--- a/lib/kvstore.sh
+++ b/lib/kvstore.sh
@@ -14,18 +14,13 @@ kv_set() {
   if [[ $# -eq 3 ]]; then
     local f=$1
     if [[ -f $f ]]; then
-      # if the value has any spaces, wrap it in quotes
-      if [[ $3 =~ [[:space:]]+ ]]; then
-        echo "$2=\"$3\"" >> $f
-      else
-        echo "$2=$3" >> $f
-      fi
+      echo "$2=$3" >> $f
     fi
   fi
 }
 
 # get the value, but don't unwrap quotes
-kv_get_literal() {
+kv_get() {
   if [[ $# -eq 2 ]]; then
     local f=$1
     if [[ -f $f ]]; then
@@ -34,12 +29,10 @@ kv_get_literal() {
   fi
 }
 
-kv_get() {
-  local value=$(kv_get_literal $1 $2 $3)
-
-  # if the value has been wrapped in quotes, unwrap it
-  if [[ $value =~ ^\".+\"$ ]]; then
-    echo "${value:1:${#value}-2}"
+kv_get_escaped() {
+  local value=$(kv_get $1 $2 $3)
+  if [[ $value =~ [[:space:]]+ ]]; then
+    echo "\"$value\""
   else
     echo $value
   fi
@@ -64,7 +57,7 @@ kv_list() {
 
   kv_keys $f | tr ' ' '\n' | while read -r key; do
     if [[ -n $key ]]; then
-      echo "$key=$(kv_get_literal $f $key)"
+      echo "$key=$(kv_get_escaped $f $key)"
     fi
   done
 }

--- a/test/unit
+++ b/test/unit
@@ -81,6 +81,15 @@ testKeyValue() {
   assertEquals "" "$(kv_list $store)"
 }
 
+testKeyValueEscaping() {
+  local store=$(mktemp)
+
+  kv_create $store
+
+  kv_set $store "key" "value with a space"
+  assertEquals "key=\"value with a space\"" "$(kv_list $store)"
+}
+
 # if the file doesn't exist, everything should be a no-op
 testKeyValueNoFile() {
   # empty file argument

--- a/test/unit
+++ b/test/unit
@@ -88,6 +88,7 @@ testKeyValueEscaping() {
 
   kv_set $store "key" "value with a space"
   assertEquals "key=\"value with a space\"" "$(kv_list $store)"
+  assertEquals "value with a space" "$(kv_get $store "key")"
 }
 
 # if the file doesn't exist, everything should be a no-op


### PR DESCRIPTION
Allows you to save strings to the `kvstore` without worrying whether they may contain spaces or not

Before:
```
key=value with spaces
```

After:
```
key="value with spaces"
```