### PR TITLE
Save build metadata

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -326,4 +326,4 @@ warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"
 warn_old_npm_lockfile $NPM_LOCK
 
-log_build_data
+log_build_data >> $BUILDPACK_LOG_FILE

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,6 @@ STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh' > "$STDLIB_FILE"
 # shellcheck source=/dev/null
 source "$STDLIB_FILE"
-<<<<<<< HEAD
 # shellcheck source=lib/output.sh
 source "$BP_DIR/lib/output.sh"
 # shellcheck source=lib/monitor.sh
@@ -45,20 +44,10 @@ source "$BP_DIR/lib/cache.sh"
 source "$BP_DIR/lib/dependencies.sh"
 # shellcheck source=lib/plugin.sh
 source "$BP_DIR/lib/plugin.sh"
-=======
-source $BP_DIR/lib/output.sh
-source $BP_DIR/lib/monitor.sh
-source $BP_DIR/lib/json.sh
-source $BP_DIR/lib/failure.sh
-source $BP_DIR/lib/environment.sh
-source $BP_DIR/lib/binaries.sh
-source $BP_DIR/lib/cache.sh
-source $BP_DIR/lib/dependencies.sh
-source $BP_DIR/lib/plugin.sh
-source $BP_DIR/lib/metadata.sh
-source $BP_DIR/lib/kvstore.sh
-source $BP_DIR/lib/build-data.sh
->>>>>>> Add some build data calls
+# shellcheck source=lib/metadata.sh
+source "$BP_DIR/lib/metadata.sh"
+# shellcheck source=lib/build-data.sh
+source "$BP_DIR/lib/build-data.sh"
 
 export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 
@@ -107,10 +96,7 @@ warn_missing_package_json "$BUILD_DIR"
 ### Behavior flags
 [ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=$(read_json "$BUILD_DIR/package.json" ".[\"heroku-run-build-script\"]")
 warn_build_script_behavior_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" | output "$LOG_FILE"
-<<<<<<< HEAD
-=======
 log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR"
->>>>>>> Add some build data calls
 
 ### Compile
 

--- a/bin/compile
+++ b/bin/compile
@@ -312,4 +312,4 @@ warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"
 warn_old_npm_lockfile $NPM_LOCK
 
-log_build_data >> $BUILDPACK_LOG_FILE
+log_build_data >> "$BUILDPACK_LOG_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -44,6 +44,8 @@ source "$BP_DIR/lib/cache.sh"
 source "$BP_DIR/lib/dependencies.sh"
 # shellcheck source=lib/plugin.sh
 source "$BP_DIR/lib/plugin.sh"
+# shellcheck source=lib/kvstore.sh
+source "$BP_DIR/lib/kvstore.sh"
 # shellcheck source=lib/metadata.sh
 source "$BP_DIR/lib/metadata.sh"
 # shellcheck source=lib/build-data.sh

--- a/bin/compile
+++ b/bin/compile
@@ -26,6 +26,7 @@ STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh' > "$STDLIB_FILE"
 # shellcheck source=/dev/null
 source "$STDLIB_FILE"
+<<<<<<< HEAD
 # shellcheck source=lib/output.sh
 source "$BP_DIR/lib/output.sh"
 # shellcheck source=lib/monitor.sh
@@ -44,6 +45,20 @@ source "$BP_DIR/lib/cache.sh"
 source "$BP_DIR/lib/dependencies.sh"
 # shellcheck source=lib/plugin.sh
 source "$BP_DIR/lib/plugin.sh"
+=======
+source $BP_DIR/lib/output.sh
+source $BP_DIR/lib/monitor.sh
+source $BP_DIR/lib/json.sh
+source $BP_DIR/lib/failure.sh
+source $BP_DIR/lib/environment.sh
+source $BP_DIR/lib/binaries.sh
+source $BP_DIR/lib/cache.sh
+source $BP_DIR/lib/dependencies.sh
+source $BP_DIR/lib/plugin.sh
+source $BP_DIR/lib/metadata.sh
+source $BP_DIR/lib/kvstore.sh
+source $BP_DIR/lib/build-data.sh
+>>>>>>> Add some build data calls
 
 export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 
@@ -68,12 +83,18 @@ handle_failure() {
 }
 trap 'handle_failure' ERR
 
+### Initalize metadata store
+bd_create "$CACHE_DIR"
+
 ### Check initial state
 
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
 
+### Save build info
+log_initial_state
+ 
 ### Failures that should be caught immediately
 
 fail_dot_heroku "$BUILD_DIR"
@@ -86,6 +107,10 @@ warn_missing_package_json "$BUILD_DIR"
 ### Behavior flags
 [ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=$(read_json "$BUILD_DIR/package.json" ".[\"heroku-run-build-script\"]")
 warn_build_script_behavior_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" | output "$LOG_FILE"
+<<<<<<< HEAD
+=======
+log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR"
+>>>>>>> Add some build data calls
 
 ### Compile
 
@@ -117,6 +142,10 @@ install_bins() {
   npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
   yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
 
+  bd_set "node-version-request" "$node_engine"
+  bd_set "npm-version-request" "$npm_engine"
+  bd_set "yarn-version-request" "$yarn_engine"
+
   if [ -n "$iojs_engine" ]; then
     echo "engines.iojs (package.json):  $iojs_engine (iojs)"
   else
@@ -141,6 +170,7 @@ install_bins() {
     monitor "install-npm-binary" install_npm "$npm_engine" "$BUILD_DIR/.heroku/node" $NPM_LOCK
     node_version="$(node --version)"
     mcount "version.node.$node_version"
+    bd_set "node-version" "$node_version"
   fi
 
   # Download yarn if there is a yarn.lock file or if the user
@@ -152,8 +182,10 @@ install_bins() {
 
   if $YARN; then
     mcount "version.yarn.$(yarn --version)"
+    bd_set "yarn-version" "$(yarn --version)"
   else
     mcount "version.npm.$(npm --version)"
+    bd_set "npm-version" "$(npm --version)"
   fi
 
   warn_old_npm
@@ -204,6 +236,7 @@ restore_cache() {
   fi
 
   mcount "cache.$cache_status"
+  bd_set "cache-status" "$cache_status"
 }
 
 restore_cache | output "$LOG_FILE"
@@ -279,6 +312,7 @@ summarize_build() {
   fi
 
   mmeasure 'modules.size' "$(measure_size)"
+  bd_set "node-modules-size" "$(measure_size)"
 }
 
 install_plugin "$BP_DIR" "$BUILD_DIR"
@@ -286,7 +320,10 @@ install_plugin "$BP_DIR" "$BUILD_DIR"
 header "Build succeeded!" | output "$LOG_FILE"
 mcount "compile"
 summarize_build | output "$LOG_FILE"
+bd_set "node-build-success" "true"
 
 warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"
 warn_old_npm_lockfile $NPM_LOCK
+
+log_build_data

--- a/lib/build-data.sh
+++ b/lib/build-data.sh
@@ -27,6 +27,15 @@ bd_time() {
   kv_set "$BUILD_DATA_FILE" "$key" "$time"
 }
 
+# similar to mtime from stdlib
+bd_time() {
+  local key="$1"
+  local start="$2"
+  local end="${3:-$(nowms)}"
+  local time="$(echo ${start} ${end} | awk '{ printf "%.3f", ($2 - $1)/1000 }')"
+  kv_set $BUILD_DATA_FILE $1 "$time"
+}
+
 log_build_data() {
   # print all values on one line in logfmt format
   # https://brandur.org/logfmt

--- a/lib/build-data.sh
+++ b/lib/build-data.sh
@@ -29,15 +29,6 @@ bd_time() {
   kv_set "$BUILD_DATA_FILE" "$key" "$time"
 }
 
-# similar to mtime from stdlib
-bd_time() {
-  local key="$1"
-  local start="$2"
-  local end="${3:-$(nowms)}"
-  local time="$(echo ${start} ${end} | awk '{ printf "%.3f", ($2 - $1)/1000 }')"
-  kv_set $BUILD_DATA_FILE $1 "$time"
-}
-
 log_build_data() {
   # print all values on one line in logfmt format
   # https://brandur.org/logfmt

--- a/lib/build-data.sh
+++ b/lib/build-data.sh
@@ -6,6 +6,10 @@ BUILD_DATA_FILE=""
 bd_create() {
   local cache_dir="$1"
   BUILD_DATA_FILE="$cache_dir/build-data/node"
+
+  # if this build data file already exists clear it
+  echo "" > "$BUILD_DATA_FILE"
+
   kv_create "$BUILD_DATA_FILE"
 }
 

--- a/lib/build-data.sh
+++ b/lib/build-data.sh
@@ -6,11 +6,9 @@ BUILD_DATA_FILE=""
 bd_create() {
   local cache_dir="$1"
   BUILD_DATA_FILE="$cache_dir/build-data/node"
-
-  # if this build data file already exists clear it
-  echo "" > "$BUILD_DATA_FILE"
-
   kv_create "$BUILD_DATA_FILE"
+  # make sure this doesnt grow over time
+  kv_clear "$BUILD_DATA_FILE"
 }
 
 bd_get() {

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -114,10 +114,13 @@ save_default_cache_directories() {
   # bower_components
   if [[ -e "$build_dir/bower_components" ]]; then
     mcount "cache.saved-bower-components"
+    bd_set "cached-bower-components" "true"
     echo "- bower_components"
     mkdir -p "$cache_dir/node/cache/bower_components"
     cp -a "$build_dir/bower_components" "$(dirname "$cache_dir/node/cache/bower_components")"
   fi
+
+  bd_set "node-custom-cache-dirs" "false"
 }
 
 save_custom_cache_directories() {
@@ -138,4 +141,6 @@ save_custom_cache_directories() {
       echo "- $cachepath (nothing to cache)"
     fi
   done
+
+  bd_set "node-custom-cache-dirs" "true"
 }

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -513,6 +513,9 @@ warn_prebuilt_modules() {
   if [ -e "$build_dir/node_modules" ]; then
     warning "node_modules checked into source control" "https://blog.heroku.com/node-habits-2016#9-only-git-the-important-bits"
     mcount 'warnings.modules.prebuilt'
+    bd_set "checked-in-node-modules" "true"
+  else
+    bd_set "checked-in-node-modules" "false"
   fi
 }
 

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -1,0 +1,21 @@
+
+log_initial_state() {
+  if "$YARN"; then
+    bd_set "node-package-manager" "yarn"
+    bd_set "has-node-lock-file" "true"
+  else
+    bd_set "node-package-manager" "npm"
+    bd_set "has-node-lock-file" "$NPM_LOCK"
+  fi
+
+  bd_set "new-build-script-opt-in" "false"
+}
+
+log_build_script_opt_in() {
+  local opted_in="$1"
+  if [[ "$opted_in" = true ]]; then
+    bd_set "build-script-opt-in" "true"
+  else
+    bd_set "build-script-opt-in" "false"
+  fi
+}

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -9,6 +9,8 @@ log_initial_state() {
   fi
 
   bd_set "new-build-script-opt-in" "false"
+
+  bd_set "stack" "$STACK"
 }
 
 log_build_script_opt_in() {

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 log_initial_state() {
   if "$YARN"; then

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -58,4 +58,7 @@ monitor() {
 
   mtime "exec.$command_name.time" "${start}"
   mmeasure "exec.$command_name.memory" "$(cat "$peak_mem_output")"
+
+  bd_time "$command_name-time" "$start"
+  bd_set "$command_name-memory" "$(cat "$peak_mem_output")"
 }

--- a/test/run
+++ b/test/run
@@ -1052,7 +1052,7 @@ testBuildMetaData() {
   # log build scripts
   assertFileContains "heroku-prebuild-script=\"echo heroku-prebuild hook message\"" $log_file
   assertFileContains "heroku-postbuild-script=\"echo heroku-prebuild hook message\"" $log_file
-  assertFileContains "heroku-build-script= " $log_file
+  assertFileContains "build-script= " $log_file
 
   # monitor calls
   assertFileContains "install-node-binary-memory=" $log_file

--- a/test/run
+++ b/test/run
@@ -1065,8 +1065,8 @@ testBuildMetaData() {
   assertFileContains "npm-install-memory=" $log_file
   assertFileContains "heroku-postbuild-time=" $log_file
   assertFileContains "heroku-postbuild-memory=" $log_file
-  assertFileContains "npm-prune-memory=49" $log_file
-  assertFileContains "npm-prune-time=0.010" $log_file
+  assertFileContains "npm-prune-memory=" $log_file
+  assertFileContains "npm-prune-time=" $log_file
 }
 
 testBinDetectWarnings() {

--- a/test/run
+++ b/test/run
@@ -1067,6 +1067,18 @@ testBuildMetaData() {
   assertFileContains "heroku-postbuild-memory=" $log_file
   assertFileContains "npm-prune-memory=" $log_file
   assertFileContains "npm-prune-time=" $log_file
+
+  # erase the log file
+  echo "" > $log_file
+  compile "yarn" "$(mktmpdir)" $env_dir
+
+  assertFileContains "node-package-manager=yarn" $log_file
+  assertFileContains "has-node-lock-file=true" $log_file
+  assertFileContains "yarn-version-request=1.x" $log_file
+  assertFileContains "yarn-version=1." $log_file
+  assertFileContains "install-yarn-binary-memory=" $log_file
+  assertFileContains "install-yarn-binary-time=" $log_file
+  assertFileContains "node-build-success=true" $log_file
 }
 
 testBinDetectWarnings() {

--- a/test/run
+++ b/test/run
@@ -1031,6 +1031,44 @@ testMemoryMetrics() {
   assertFileNotContains "measure#buildpack.nodejs.exec.heroku-postbuild.memory=" $metrics_log
 }
 
+testBuildMetaData() {
+  env_dir=$(mktmpdir)
+  local log_file=$(mktemp)
+  echo "$log_file" > $env_dir/BUILDPACK_LOG_FILE
+
+  compile "pre-post-build-scripts" "$(mktmpdir)" $env_dir
+
+  # build info
+  assertFileContains "node-package-manager=npm" $log_file
+  assertFileContains "checked-in-node-modules=false" $log_file
+  assertFileContains "has-node-lock-file=false" $log_file
+  assertFileContains "cache-status=not-found" $log_file
+  assertFileContains "node-build-success=true" $log_file
+
+  # binary versions
+  assertFileContains "node-version-request=~0.10.0" $log_file
+  assertFileContains "npm-version-request= " $log_file
+
+  # log build scripts
+  assertFileContains "heroku-prebuild-script=\"echo heroku-prebuild hook message\"" $log_file
+  assertFileContains "heroku-postbuild-script=\"echo heroku-prebuild hook message\"" $log_file
+  assertFileContains "heroku-build-script= " $log_file
+
+  # monitor calls
+  assertFileContains "install-node-binary-memory=" $log_file
+  assertFileContains "install-node-binary-time=" $log_file
+  assertFileContains "install-npm-binary-time=" $log_file
+  assertFileContains "install-npm-binary-memory=" $log_file
+  assertFileContains "heroku-prebuild-time=" $log_file
+  assertFileContains "heroku-prebuild-memory=" $log_file
+  assertFileContains "npm-install-time=" $log_file
+  assertFileContains "npm-install-memory=" $log_file
+  assertFileContains "heroku-postbuild-time=" $log_file
+  assertFileContains "heroku-postbuild-memory=" $log_file
+  assertFileContains "npm-prune-memory=49" $log_file
+  assertFileContains "npm-prune-time=0.010" $log_file
+}
+
 testBinDetectWarnings() {
   detect "slugignore-package-json"
   assertCapturedError "'package.json' listed in '.slugignore' file"


### PR DESCRIPTION
This is the first pass at saving build metadata. There are two goals:

- Make the data available in the cache
- output all of the key / value pairs that describe the build onto a single log line in logfmt format

Example use case:
Check how much memory was used in the build step using `bd_get`, and warn users who are getting close to maxing out our build machines so that they are not surprised when they suddenly hit it.