### PR TITLE
Make sure that failing builds in CI actually fail

### DIFF
--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
+# bin/test-compile <build-dir> <cache-dir> <env-dir>
+
+### Configure environment
+
+set -o errexit    # always exit on error
+set -o pipefail   # don't ignore exit codes when piping output
+
+### Configure directories
 
 BP_DIR=$(cd "$(dirname "${0:-}")" || exit; cd ..; pwd)
 
+### Load dependencies
 # shellcheck source=lib/environment.sh
 source "$BP_DIR/lib/environment.sh"
 
+### Set up test Node environment
+
 export NPM_CONFIG_PRODUCTION=${NPM_CONFIG_PRODUCTION:-false}
 export NODE_ENV=${NODE_ENV:-test}
-"$BP_DIR/bin/compile" "$1" "$2" "$3"
 
+### Compile the app
+
+"$BP_DIR/bin/compile" "$1" "$2" "$3"
 write_ci_profile "$BP_DIR" "$1"

--- a/test/fixtures/failing-build/package.json
+++ b/test/fixtures/failing-build/package.json
@@ -10,9 +10,9 @@
     "hashish": "*"
   },
   "engines": {
-    "node": "0.10.38"
+    "node": "8.x"
   },
   "scripts": {
-    "postinstall": "exit 1"
+    "heroku-postbuild": "exit 1"
   }
 }

--- a/test/run
+++ b/test/run
@@ -874,6 +874,12 @@ testCIEnvVars() {
   assertCapturedSuccess
 }
 
+# If compile fails, test-compile should also fail
+testCICompileFails() {
+  testCompile "failing-build"
+  assertCapturedError
+}
+
 testCIEnvVarsOverride() {
   env_dir=$(mktmpdir)
   echo "banana" > $env_dir/NODE_ENV
@@ -1091,6 +1097,15 @@ compile() {
   cp -a "$(pwd)"/* ${bp_dir}
   cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
   capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
+}
+
+testCompile() {
+  default_process_types_cleanup
+  bp_dir=$(mktmpdir)
+  compile_dir=$(mktmpdir)
+  cp -a "$(pwd)"/* ${bp_dir}
+  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
+  capture ${bp_dir}/bin/test-compile ${compile_dir} ${2:-$(mktmpdir)} $3
 }
 
 # This is meant to be run after `compile`. `cleanupStartup` must be run

--- a/test/run
+++ b/test/run
@@ -562,11 +562,6 @@ testOldNpm() {
   assertCapturedError
 }
 
-testOldNpm2() {
-  compile "failing-build"
-  assertCaptured "This version of npm (1.4.28) has several known issues"
-}
-
 testNonexistentNpm() {
   compile "nonexistent-npm"
   assertCaptured "Unable to install npm 1.1.65"


### PR DESCRIPTION
Raised in a support ticket

Currently, if `bin/compile` fails in CI, the `bin/test-compile` script ignores this error return value and continues on to try running the tests.

To fix this, we copy the `set -o errexit` config from `bin/compile` which ensures that the failing command kills execution.

cc and thanks to @ys for raising this concern