### PR TITLE
Cache yarn cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Cache `$YARN_CACHE_FOLDER` (#615)
+
 ## v134 (2018-12-20)
 
 - Internal changes (#593, #591)

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -59,6 +59,17 @@ restore_default_cache_directories() {
     echo "- node_modules (not cached - skipping)"
   fi
 
+  # $YARN_CACHE_FOLDER
+  if $YARN; then
+    if [[ -e "$cache_dir/node/cache/yarn_cache_dir" ]]; then
+      echo "- $YARN_CACHE_FOLDER"
+      mkdir -p "$(dirname "$YARN_CACHE_FOLDER")"
+      mv "$cache_dir/node/cache/yarn_cache_dir" "$YARN_CACHE_FOLDER"
+    else
+      echo "- $YARN_CACHE_FOLDER (not cached - skipping)"
+    fi
+  fi
+
   # bower_components, should be silent if it is not in the cache
   if [[ -e "$cache_dir/node/cache/bower_components" ]]; then
     echo "- bower_components"
@@ -109,6 +120,17 @@ save_default_cache_directories() {
     # this can happen if there are no dependencies
     mcount "cache.no-node-modules"
     echo "- node_modules (nothing to cache)"
+  fi
+
+  # $YARN_CACHE_FOLDER
+  if $YARN; then
+    if [[ -e "$YARN_CACHE_FOLDER" ]]; then
+      echo "- $YARN_CACHE_FOLDER"
+      mkdir -p "$cache_dir/node/cache/yarn_cache_dir"
+      cp -a "$YARN_CACHE_FOLDER" "$(dirname "$cache_dir/node/cache/yarn_cache_dir")"
+    else
+      echo "- $YARN_CACHE_FOLDER (nothing to cache)"
+    fi
   fi
 
   # bower_components


### PR DESCRIPTION
This caches the yarn cache (`$YARN_CACHE_FOLDER`), similarly to `node_modules`, to speed up build time.

I conducted some experiments by running `yarn install` with and without a cached cache. I managed to get a repo which was taking `~1m16s` to `yarn install` to only take `~20s`. I am guessing this is because with an empty cache Yarn still fetches the packages, before being able to check if `node_modules` already contains them.

As far as I can tell, caching the Yarn cache should be fine, but perhaps someone with more in depth knowledge of Yarn can chime in 🤞