### PR TITLE
Add warning for the upcoming run build change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+- Add warning for the upcoming run build change (#616)
+
+## v135 (2018-02-06)
+
+- Fix bug where failing builds on CI would not fail CI (#613)
+- Internal logging changes (#596, #600)
+
 ## v134 (2018-12-20)
 
 - Internal changes (#593, #591)

--- a/bin/compile
+++ b/bin/compile
@@ -97,6 +97,7 @@ warn_missing_package_json "$BUILD_DIR"
 
 ### Behavior flags
 [ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=$(read_json "$BUILD_DIR/package.json" ".[\"heroku-run-build-script\"]")
+warn_build_script_behavior_change "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR" | output "$LOG_FILE"
 warn_build_script_behavior_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" | output "$LOG_FILE"
 log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR"
 

--- a/bin/compile
+++ b/bin/compile
@@ -99,7 +99,6 @@ warn_missing_package_json "$BUILD_DIR"
 [ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=$(read_json "$BUILD_DIR/package.json" ".[\"heroku-run-build-script\"]")
 warn_build_script_behavior_change "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR" | output "$LOG_FILE"
 warn_build_script_behavior_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" | output "$LOG_FILE"
-log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR"
 
 ### Compile
 
@@ -117,6 +116,8 @@ cd "$BUILD_DIR"
 create_env # can't pipe the whole thing because piping causes subshells, preventing exports
 list_node_config | output "$LOG_FILE"
 create_build_env
+
+log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR"
 
 ### Configure package manager cache directories
 [ ! "$YARN_CACHE_FOLDER" ] && YARN_CACHE_FOLDER=$(mktemp -d -t yarncache.XXXXX)

--- a/bin/compile
+++ b/bin/compile
@@ -97,8 +97,7 @@ warn_missing_package_json "$BUILD_DIR"
 
 ### Behavior flags
 [ ! "$NEW_BUILD_SCRIPT_BEHAVIOR" ] && NEW_BUILD_SCRIPT_BEHAVIOR=$(read_json "$BUILD_DIR/package.json" ".[\"heroku-run-build-script\"]")
-warn_build_script_behavior_change "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR" | output "$LOG_FILE"
-warn_build_script_behavior_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" | output "$LOG_FILE"
+
 
 ### Compile
 
@@ -116,8 +115,6 @@ cd "$BUILD_DIR"
 create_env # can't pipe the whole thing because piping causes subshells, preventing exports
 list_node_config | output "$LOG_FILE"
 create_build_env
-
-log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR"
 
 ### Configure package manager cache directories
 [ ! "$YARN_CACHE_FOLDER" ] && YARN_CACHE_FOLDER=$(mktemp -d -t yarncache.XXXXX)
@@ -319,5 +316,9 @@ bd_set "node-build-success" "true"
 warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"
 warn_old_npm_lockfile $NPM_LOCK
+
+warn_build_script_behavior_change "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR" | output "$LOG_FILE"
+warn_build_script_behavior_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" | output "$LOG_FILE"
+log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR"
 
 log_build_data >> "$BUILDPACK_LOG_FILE"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -59,9 +59,9 @@ warn_build_script_behavior_opt_in() {
   local opted_in="$1"
   if [[ "$opted_in" = true ]]; then
     header "Opting in to new default build script behavior"
-    echo "You have set \"heroku-run-build-script\" = true in your package.json"
-    echo ""
+    echo "You have set \"heroku-run-build-script\"=true in your package.json"
     echo "Your app will be unaffected by the change on March 11, 2019"
+    echo ""
   fi
 }
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -63,6 +63,31 @@ warn_build_script_behavior_opt_in() {
     echo ""
     echo "- If a \"build\" script is defined in package.json it will be executed by default"
     echo "- The \"heroku-postbuild\" script will be executed instead if present"
+    echo ""
+    echo "Your app will be unaffected by the change on March 11, 2019"
+  fi
+}
+
+warn_build_script_behavior_change() {
+  local opted_in="$1"
+  local build_dir="$2"
+  local has_build_script has_heroku_build_script
+
+  has_build_script=$(read_json "$build_dir/package.json" ".scripts.build")
+  has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
+
+  if [[ -z "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]] && [[ "$opted_in" != "true" ]]; then
+    header "Change to Node.js build process"
+    echo "On March 11, 2019 Heroku will begin executing the \"build\" script defined in package.json"
+    echo "by default. This application may be affected by this change."
+    echo ""
+    echo "To make this transition easier, we've published a tool that will automatically" 
+    echo "update your app for you. You can run it with one command in your app's"
+    echo "root directory:"
+    echo ""
+    echo "$ npx @heroku/update-node-build-script"
+    echo ""
+    echo "Please see https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq for more information"
   fi
 }
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -43,7 +43,7 @@ run_build_script() {
   has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
 
   if [[ -n "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]]; then
-    echo "Detected both 'build' and 'heroku-postbuild' scripts"
+    echo "Detected both \"build\" and \"heroku-postbuild\" scripts"
     mcount "scripts.heroku-postbuild-and-build"
     run_if_present "$build_dir" 'heroku-postbuild'
   elif [[ -n "$has_heroku_build_script" ]]; then
@@ -60,9 +60,6 @@ warn_build_script_behavior_opt_in() {
   if [[ "$opted_in" = true ]]; then
     header "Opting in to new default build script behavior"
     echo "You have set \"heroku-run-build-script\" = true in your package.json"
-    echo ""
-    echo "- If a \"build\" script is defined in package.json it will be executed by default"
-    echo "- The \"heroku-postbuild\" script will be executed instead if present"
     echo ""
     echo "Your app will be unaffected by the change on March 11, 2019"
   fi
@@ -88,6 +85,7 @@ warn_build_script_behavior_change() {
     echo "$ npx @heroku/update-node-build-script"
     echo ""
     echo "Please see https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq for more information"
+    echo ""
   fi
 }
 

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -22,8 +22,6 @@ log_build_script_opt_in() {
   has_build_script=$(read_json "$build_dir/package.json" ".scripts.build")
   has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
 
-  echo $BUILDPACK_LOG_FILE
-
   # if this app will be affected by the change
   if [[ -z "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]]; then
     mcount "affected-by-build-change"

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -16,6 +16,27 @@ log_initial_state() {
 
 log_build_script_opt_in() {
   local opted_in="$1"
+  local build_dir="$2"
+  local has_build_script has_heroku_build_script
+
+  has_build_script=$(read_json "$build_dir/package.json" ".scripts.build")
+  has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
+
+  echo $BUILDPACK_LOG_FILE
+
+  # if this app will be affected by the change
+  if [[ -z "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]]; then
+    mcount "affected-by-build-change"
+
+    if [[ "$opted_in" = "true" ]]; then
+      mcount "affected-by-build-change-opted-in"
+      bd_set "affected-but-opted-in" "true"
+    else
+      bd_set "affected-but-opted-in" "false"
+    fi
+
+  fi
+
   if [[ "$opted_in" = true ]]; then
     bd_set "build-script-opt-in" "true"
   else

--- a/test/fixtures/build-script-override/package.json
+++ b/test/fixtures/build-script-override/package.json
@@ -7,10 +7,11 @@
     "url": "http://github.com/example/example.git"
   },
   "engines": {
-    "node": "~0.10.0"
+    "node": "10.x"
   },
   "scripts" : {
     "build": "echo build hook message",
     "heroku-postbuild": "echo heroku-postbuild hook message"
-  }
+  },
+  "heroku-run-build-script": true
 }

--- a/test/fixtures/build-script/package.json
+++ b/test/fixtures/build-script/package.json
@@ -7,7 +7,7 @@
     "url" : "http://github.com/example/example.git"
   },
   "engines": {
-    "node": "~0.10.0"
+    "node": "10.x"
   },
   "scripts" : {
     "build" : "echo build hook message"

--- a/test/run
+++ b/test/run
@@ -15,6 +15,18 @@ testFlatmapStream() {
   assertCapturedError
 }
 
+testBuildScriptWarning() {
+  compile "build-script"
+
+  # Without opting in, having a build script will display a warning
+  assertCaptured "Warning: On March 11, 2019 Heroku will begin executing the \"build\" script defined in package.json by default"
+  assertCaptured "https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq"
+
+  # We shouldn't see the opt-in success message
+  assertNotCaptured "Opting in to new default build script behavior"
+  assertCapturedSuccess
+}
+
 testBuildScriptBehavior() {
   # opt in to new build script behavior
   cache=$(mktmpdir)
@@ -37,6 +49,9 @@ testBuildScriptOptIn() {
   compile "build-script-opt-in"
   assertCaptured "Running build"
   assertCaptured "Opting in to new default build script behavior"
+  # We shouldn't see this warning once they opt-in
+  assertNotCaptured "Warning: On March 11, 2019 Heroku will begin executing the \"build\" script defined in package.json by default"
+  assertNotCaptured "https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq"
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -16,11 +16,19 @@ testFlatmapStream() {
 }
 
 testBuildScriptWarning() {
-  compile "build-script"
+  local env_dir=$(mktmpdir)
+  local metrics_log=$(mktemp)
+  echo "$metrics_log" > $env_dir/BUILDPACK_LOG_FILE
+
+  compile "build-script" "$(mktmpdir)" $env_dir
 
   # Without opting in, having a build script will display a warning
-  assertCaptured "Warning: On March 11, 2019 Heroku will begin executing the \"build\" script defined in package.json by default"
+  assertCaptured "On March 11, 2019 Heroku will begin executing the \"build\" script defined in package.json"
   assertCaptured "https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq"
+
+  # make sure metrics are being captured as we expect
+  assertFileContains "count#buildpack.nodejs.affected-by-build-change=1" "$metrics_log"
+  assertFileNotContains "affected-by-build-change-opted-in" "$metrics_log"
 
   # We shouldn't see the opt-in success message
   assertNotCaptured "Opting in to new default build script behavior"
@@ -46,12 +54,21 @@ testBuildScriptBehavior() {
 }
 
 testBuildScriptOptIn() {
-  compile "build-script-opt-in"
+  local env_dir=$(mktmpdir)
+  local metrics_log=$(mktemp)
+  echo "$metrics_log" > $env_dir/BUILDPACK_LOG_FILE
+
+  compile "build-script-opt-in" "$(mktmpdir)" $env_dir
   assertCaptured "Running build"
   assertCaptured "Opting in to new default build script behavior"
   # We shouldn't see this warning once they opt-in
   assertNotCaptured "Warning: On March 11, 2019 Heroku will begin executing the \"build\" script defined in package.json by default"
   assertNotCaptured "https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq"
+
+  # make sure metrics are being captured as we expect
+  assertFileContains "count#buildpack.nodejs.affected-by-build-change=1" "$metrics_log"
+  assertFileContains "count#buildpack.nodejs.affected-by-build-change-opted-in=1" "$metrics_log"
+
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -47,8 +47,8 @@ testBuildScriptBehavior() {
   assertCapturedSuccess
 
   # the 'heroku-postbuild' script takes precedence over the 'build' script
-  compile "build-script-override" $cache $env_dir
-  assertCaptured "Detected both 'build' and 'heroku-postbuild' scripts"
+  compile "build-script-override"
+  assertCaptured "Detected both \"build\" and \"heroku-postbuild\" scripts"
   assertCaptured "Running heroku-postbuild"
   assertCapturedSuccess
 }


### PR DESCRIPTION
To be deployed on next Monday (March 11) as part of #583 rollout

Users that will not be affected by this change shouldn't see anything. Those that have a `build` script without a `heroku-postbuild` script will now see a warning at the top of the build log:

<img width="1078" alt="hyper 2019-02-07 10-02-01" src="https://user-images.githubusercontent.com/175496/52432502-6b5eb600-2abf-11e9-880c-dd58cdb13ebf.png">

Link: https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq

Once they opt-in by setting `heroku-run-build-script` to `true` in their `package.json` (which the `npx` command will do for them) they will see a successful opt-in message

```
"scripts": {
    "start": "node src/index.js",
    "build": "webpack"
},
"heroku-run-build-script": true
```

<img width="610" alt="hyper 2019-02-07 19-46-32" src="https://user-images.githubusercontent.com/175496/52457933-31b69b00-2b11-11e9-9e6d-ee333ef1b410.png">
