### PR TITLE
Detect build scripts even when they are empty

### DIFF
--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -24,7 +24,7 @@ run_if_present() {
 
   has_script=$(has_script "$build_dir/package.json" "$script_name")
 
-  if [ -n "$has_script" ]; then
+  if [[ "$has_script" == "true" ]]; then
     if $YARN; then
       echo "Running $script_name (yarn)"
       monitor "$script_name" yarn run "$script_name"
@@ -42,14 +42,14 @@ run_build_script() {
   has_build_script=$(has_script "$build_dir/package.json" "build")
   has_heroku_build_script=$(has_script "$build_dir/package.json" "heroku-postbuild")
 
-  if [[ -n "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]]; then
+  if [[ "$has_heroku_build_script" == "true" ]] && [[ "$has_build_script" == "true" ]]; then
     echo "Detected both \"build\" and \"heroku-postbuild\" scripts"
     mcount "scripts.heroku-postbuild-and-build"
     run_if_present "$build_dir" 'heroku-postbuild'
-  elif [[ -n "$has_heroku_build_script" ]]; then
+  elif [[ "$has_heroku_build_script" == "true" ]]; then
     mcount "scripts.heroku-postbuild"
     run_if_present "$build_dir" 'heroku-postbuild'
-  elif [[ -n "$has_build_script" ]]; then
+  elif [[ "$has_build_script" == "true" ]]; then
     mcount "scripts.build"
     run_if_present "$build_dir" 'build'
   fi

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -22,7 +22,7 @@ run_if_present() {
   local script_name=${2:-}
   local has_script
 
-  has_script=$(read_json "$build_dir/package.json" ".scripts[\"$script_name\"]")
+  has_script=$(has_script "$build_dir/package.json" "$script_name")
 
   if [ -n "$has_script" ]; then
     if $YARN; then
@@ -39,8 +39,11 @@ run_build_script() {
   local build_dir=${1:-}
   local has_build_script has_heroku_build_script
 
-  has_build_script=$(read_json "$build_dir/package.json" ".scripts.build")
-  has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
+  # has_build_script=$(read_json "$build_dir/package.json" ".scripts.build")
+  # has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
+
+  has_build_script=$(has_script "$build_dir/package.json" "build")
+  has_heroku_build_script=$(has_script "$build_dir/package.json" "heroku-postbuild")
 
   if [[ -n "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]]; then
     echo "Detected both \"build\" and \"heroku-postbuild\" scripts"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -20,11 +20,11 @@ list_dependencies() {
 run_if_present() {
   local build_dir=${1:-}
   local script_name=${2:-}
-  local has_script
+  local has_script_name
 
-  has_script=$(has_script "$build_dir/package.json" "$script_name")
+  has_script_name=$(has_script "$build_dir/package.json" "$script_name")
 
-  if [[ "$has_script" == "true" ]]; then
+  if [[ "$has_script_name" == "true" ]]; then
     if $YARN; then
       echo "Running $script_name (yarn)"
       monitor "$script_name" yarn run "$script_name"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -62,6 +62,7 @@ warn_build_script_behavior_opt_in() {
     echo "You have set \"heroku-run-build-script\"=true in your package.json"
     echo "Your app will be unaffected by the change on March 11, 2019"
     echo ""
+    mcount "build-change-opt-in"
   fi
 }
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -39,9 +39,6 @@ run_build_script() {
   local build_dir=${1:-}
   local has_build_script has_heroku_build_script
 
-  # has_build_script=$(read_json "$build_dir/package.json" ".scripts.build")
-  # has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
-
   has_build_script=$(has_script "$build_dir/package.json" "build")
   has_heroku_build_script=$(has_script "$build_dir/package.json" "heroku-postbuild")
 

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -14,6 +14,17 @@ read_json() {
   fi
 }
 
+has_script() {
+  local file="$1"
+  local key="$2"
+
+  if test -f "$file"; then
+    cat "$file" | $JQ ".[\"scripts\"] | has(\"$key\")"
+  else
+    echo "false"
+  fi
+}
+
 is_invalid_json_file() {
   local file="$1"
   # shellcheck disable=SC2002

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -19,6 +19,7 @@ has_script() {
   local key="$2"
 
   if test -f "$file"; then
+    # shellcheck disable=SC2002
     cat "$file" | $JQ ".[\"scripts\"] | has(\"$key\")"
   else
     echo "false"

--- a/test/fixtures/empty-heroku-postbuild/README.md
+++ b/test/fixtures/empty-heroku-postbuild/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/empty-heroku-postbuild/package.json
+++ b/test/fixtures/empty-heroku-postbuild/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts" : {
+    "build" : "echo build hook message",
+    "heroku-postbuild": ""
+  },
+  "heroku-run-build-script": true
+}

--- a/test/fixtures/has-script-fixtures/package.json
+++ b/test/fixtures/has-script-fixtures/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts" : {
+    "build" : "echo build hook message",
+    "heroku-postbuild": "",
+    "random-script-name": ""
+  },
+  "heroku-run-build-script": true
+}

--- a/test/run
+++ b/test/run
@@ -72,6 +72,14 @@ testBuildScriptOptIn() {
   assertCapturedSuccess
 }
 
+testPreferEmptyHerokuPostbuildOverBuild() {
+  compile "empty-heroku-postbuild"
+  assertCaptured "Detected both \"build\" and \"heroku-postbuild\" scripts"
+  assertCaptured "Running heroku-postbuild"
+  assertNotCaptured "build hook message"
+  assertCapturedSuccess
+}
+
 testPrePostBuildScripts() {
   compile "pre-post-build-scripts"
   assertCaptured "Running heroku-prebuild"

--- a/test/unit
+++ b/test/unit
@@ -260,10 +260,23 @@ testWebConcurrencyProfileScript() {
   assertEquals "1" "$(calculate_concurrency 512 1)"
 }
 
+testHasScript() {
+  local file="$(pwd)/test/fixtures/has-script-fixtures/package.json"
+  assertEquals "true" "$(has_script "$file" "build")"
+  assertEquals "true" "$(has_script "$file" "heroku-postbuild")"
+  assertEquals "false" "$(has_script "$file" "postinstall")"
+  assertEquals "true" "$(has_script "$file" "random-script-name")"
+}
+
+BP_DIR="$(pwd)"
+
 # mocks
 source "$(pwd)"/test/mocks/stdlib.sh
 
 # the modules to be tested
+source "$(pwd)"/lib/environment.sh
+source "$(pwd)"/lib/json.sh
+source "$(pwd)"/lib/json.sh
 source "$(pwd)"/lib/monitor.sh
 source "$(pwd)"/lib/output.sh
 source "$(pwd)"/lib/kvstore.sh


### PR DESCRIPTION
Because of https://github.com/heroku/heroku-buildpack-nodejs/issues/583 it's more important that we can properly detect the presence of a particular build script. Our past method looked at the contents of the script, and would discard empty contents.

This makes sure that even in the case where a `heroku-postbuild` script is completely empty, it will still be preferred over the `build` script.

```
  "scripts" : {
    "build" : "echo build hook message",
    "heroku-postbuild": ""
  },
```