### PR TITLE
Add uuid utility

### DIFF
--- a/lib/uuid.sh
+++ b/lib/uuid.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+uuid-fallback()
+{
+    local N B C='89ab'
+
+    for (( N=0; N < 16; ++N ))
+    do
+        B=$(( RANDOM%256 ))
+
+        case $N in
+            6)
+                printf '4%x' $(( B%16 ))
+                ;;
+            8)
+                printf '%c%x' ${C:$RANDOM%${#C}:1} $(( B%16 ))
+                ;;
+            3 | 5 | 7 | 9)
+                printf '%02x-' $B
+                ;;
+            *)
+                printf '%02x' $B
+                ;;
+        esac
+    done
+
+    echo
+}
+
+uuid() {
+  # On Heroku's stack, there is a uuid command
+  if [[ -f /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+  # on macOS there is also a command
+  elif [[ -x "$(command -v uuidgen)" ]]; then
+    uuidgen | tr "[:upper:]" "[:lower:]"
+  # fallback just to be sure
+  else
+    uuid-fallback
+  fi
+}

--- a/lib/uuid.sh
+++ b/lib/uuid.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-uuid-fallback()
+uuid_fallback()
 {
     local N B C='89ab'
 
@@ -36,6 +36,6 @@ uuid() {
     uuidgen | tr "[:upper:]" "[:lower:]"
   # fallback just to be sure
   else
-    uuid-fallback
+    uuid_fallback
   fi
 }

--- a/lib/uuid.sh
+++ b/lib/uuid.sh
@@ -34,7 +34,13 @@ uuid() {
   # on macOS there is also a command
   elif [[ -x "$(command -v uuidgen)" ]]; then
     uuidgen | tr "[:upper:]" "[:lower:]"
-  # fallback just to be sure
+  # If you are running this buildpack on an image without either of the above binaries
+  # then let's provide something that approximates this functionality, but beware that
+  # we can make no guarantees of true randomness or uniqueness of this ID. However it is
+  # likely only being piped to /dev/null
+  #
+  # If that's not true for you, please file an issue and let us know: 
+  # https://github.com/heroku/heroku-buildpack-nodejs/issues
   else
     uuid_fallback
   fi

--- a/test/unit
+++ b/test/unit
@@ -260,10 +260,39 @@ testWebConcurrencyProfileScript() {
   assertEquals "1" "$(calculate_concurrency 512 1)"
 }
 
+isUUID() {
+  if [[ ${1//-/} =~ ^[[:xdigit:]]{32}$ ]]; then
+    echo true
+  else
+    echo false
+  fi
+}
+
+testUUID() {
+  local first second
+  first=$(uuid)
+  second=$(uuid)
+
+  assertNotEquals "$first" "$second"
+  assertEquals "true" "$(isUUID "$first")"
+  assertEquals "true" "$(isUUID "$second")"
+}
+
+testUUIDFallback() {
+  local first second
+  first=$(uuid-fallback)
+  second=$(uuid-fallback)
+
+  assertNotEquals "$first" "$second"
+  assertEquals "true" "$(isUUID "$first")"
+  assertEquals "true" "$(isUUID "$second")"
+}
+
 # mocks
 source "$(pwd)"/test/mocks/stdlib.sh
 
 # the modules to be tested
+source "$(pwd)"/lib/uuid.sh
 source "$(pwd)"/lib/monitor.sh
 source "$(pwd)"/lib/output.sh
 source "$(pwd)"/lib/kvstore.sh

--- a/test/unit
+++ b/test/unit
@@ -280,8 +280,8 @@ testUUID() {
 
 testUUIDFallback() {
   local first second
-  first=$(uuid-fallback)
-  second=$(uuid-fallback)
+  first=$(uuid_fallback)
+  second=$(uuid_fallback)
 
   assertNotEquals "$first" "$second"
   assertEquals "true" "$(isUUID "$first")"


### PR DESCRIPTION
Adds a cross-platform compatible command to generate `uuid`s. 

Will eventually move this into https://github.com/heroku/buildpack-stdlib after some time in prod