### PR TITLE
Generate UUIDs for the app and build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -44,6 +44,8 @@ source "$BP_DIR/lib/cache.sh"
 source "$BP_DIR/lib/dependencies.sh"
 # shellcheck source=lib/plugin.sh
 source "$BP_DIR/lib/plugin.sh"
+# shellcheck source=lib/uuid.sh
+source "$BP_DIR/lib/uuid.sh"
 # shellcheck source=lib/kvstore.sh
 source "$BP_DIR/lib/kvstore.sh"
 # shellcheck source=lib/metadata.sh
@@ -85,6 +87,7 @@ bd_create "$CACHE_DIR"
 
 ### Save build info
 log_initial_state
+generate_uuids
  
 ### Failures that should be caught immediately
 

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -14,6 +14,18 @@ log_initial_state() {
   bd_set "stack" "$STACK"
 }
 
+generate_uuids() {
+  # generate a unique id for each build
+  bd_set "build-uuid" "$(uuid)"
+
+  # propagate an app-uuid forward unless the cache is cleared
+  if [[ -n "$(bd_prev_get "app-uuid")" ]]; then
+    bd_set "app-uuid" "$(bd_prev_get "app-uuid")"
+  else
+    bd_set "app-uuid" "$(uuid)"
+  fi
+}
+
 log_build_script_opt_in() {
   local opted_in="$1"
   local build_dir="$2"

--- a/test/run
+++ b/test/run
@@ -1085,6 +1085,8 @@ testBuildMetaData() {
   assertFileContains "has-node-lock-file=false" $log_file
   assertFileContains "cache-status=not-found" $log_file
   assertFileContains "node-build-success=true" $log_file
+  assertFileContains "app-uuid=" $log_file
+  assertFileContains "build-uuid=" $log_file
 
   # binary versions
   assertFileContains "node-version-request=~0.10.0" $log_file
@@ -1120,6 +1122,28 @@ testBuildMetaData() {
   assertFileContains "install-yarn-binary-memory=" $log_file
   assertFileContains "install-yarn-binary-time=" $log_file
   assertFileContains "node-build-success=true" $log_file
+}
+
+testPropagateAppUUID() {
+  env_dir=$(mktmpdir)
+  local log_file=$(mktemp)
+  local cache_dir=${2:-$(mktmpdir)}
+  echo "$log_file" > $env_dir/BUILDPACK_LOG_FILE
+
+  # save the generated app-uuid for the first build
+  compile "node-10" $cache_dir $env_dir
+  assertFileContains "app-uuid=" $log_file
+  local uuid=$(cat $log_file | sed -n -e 's/^.*app-uuid=\([^ ]*\).*/\1/p')
+
+  # create a new log file
+  log_file=$(mktemp)
+  echo "$log_file" > $env_dir/BUILDPACK_LOG_FILE
+
+  # recompile with the same cache directory
+  compile "node-10" $cache_dir $env_dir
+  assertFileContains "app-uuid" $log_file
+  # make sure that the app-uuid is the same
+  assertEquals "$uuid" "$(cat $log_file | sed -n -e 's/^.*app-uuid=\([^ ]*\).*/\1/p')"
 }
 
 testBinDetectWarnings() {


### PR DESCRIPTION
Depends on https://github.com/heroku/heroku-buildpack-nodejs/pull/618

This generates random uuids for both each build run, and the app itself. It then propagates the app uuid through each subsequent build by serializing it into the cache.

This isn't completely ideal because PR apps will each get their own app uuid, but it should still allow us to do better analysis on our log data than we currently can.

Questions like "How many apps failed yesterday?" vs "How many builds failed yesterday"?

The build uuid helps make sure that we aren't ever double counting events somehow.