### PR TITLE
Log out whole build time

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,6 +56,8 @@ export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 LOG_FILE=$(mktemp -t node-build-log.XXXXX)
 echo "" > "$LOG_FILE"
 
+build_start_time=$(nowms)
+
 ### Handle errors
 
 handle_failure() {
@@ -312,6 +314,7 @@ header "Build succeeded!" | output "$LOG_FILE"
 mcount "compile"
 summarize_build | output "$LOG_FILE"
 bd_set "node-build-success" "true"
+bd_time "build-time" "$build_start_time"
 
 warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -9,8 +9,6 @@ log_initial_state() {
     bd_set "has-node-lock-file" "$NPM_LOCK"
   fi
 
-  bd_set "new-build-script-opt-in" "false"
-
   bd_set "stack" "$STACK"
 }
 

--- a/test/run
+++ b/test/run
@@ -1077,6 +1077,7 @@ testBuildMetaData() {
   assertFileContains "has-node-lock-file=false" $log_file
   assertFileContains "cache-status=not-found" $log_file
   assertFileContains "node-build-success=true" $log_file
+  assertFileContains "build_time=" $log_file
 
   # binary versions
   assertFileContains "node-version-request=~0.10.0" $log_file

--- a/test/run
+++ b/test/run
@@ -1077,7 +1077,7 @@ testBuildMetaData() {
   assertFileContains "has-node-lock-file=false" $log_file
   assertFileContains "cache-status=not-found" $log_file
   assertFileContains "node-build-success=true" $log_file
-  assertFileContains "build_time=" $log_file
+  assertFileContains "build-time=" $log_file
 
   # binary versions
   assertFileContains "node-version-request=~0.10.0" $log_file


### PR DESCRIPTION
Currently we're tracking the time spent in parts of the build process, like installing `node_modules` or running the build command, but we're not tracking how long the whole build takes. Let's fix that.

Also removes a stray `new-build-script-opt-in` call that wasn't doing anything