### PR TITLE
Make breaking change warning header brighter

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -330,7 +330,7 @@ warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"
 warn_old_npm_lockfile $NPM_LOCK
 
-warn_build_script_behavior_change "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR" | output "$LOG_FILE"
+warn_build_script_behavior_change "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR"
 warn_build_script_behavior_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" | output "$LOG_FILE"
 log_build_script_opt_in "$NEW_BUILD_SCRIPT_BEHAVIOR" "$BUILD_DIR"
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -80,7 +80,7 @@ warn_build_script_behavior_change() {
   has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
 
   if [[ -z "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]] && [[ "$opted_in" != "true" ]]; then
-    header "Change to Node.js build process"
+    bright_header "Change to Node.js build process"
     echo "On March 11, 2019 Heroku will begin executing the \"build\" script defined in package.json"
     echo "by default. This application may be affected by this change."
     echo ""

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -28,6 +28,11 @@ header() {
   echo "-----> $*" || true
 }
 
+bright_header() {
+  echo "" || true
+  echo -e "\033[1;33m-----> $* \033[0m"
+}
+
 header_skip_newline() {
   echo "-----> $*" || true
 }


### PR DESCRIPTION
Adds a splash of color to the breaking change message to draw attention to it.

![hyper 2019-02-28 17-44-10 2](https://user-images.githubusercontent.com/175496/53610700-a31dc280-3b80-11e9-85b2-f0fb34208141.png)
