### PR TITLE
Also print the change warning when the build fails

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -63,6 +63,13 @@ build_start_time=$(nowms)
 ### Handle errors
 
 handle_failure() {
+  bright_header "Change to Node.js build process"
+  echo "       Heroku has begun executing the \"build\" script defined in package.json"
+  echo "       during Node.js builds."
+  echo ""
+  echo "       Read more: https://devcenter.heroku.com/changelog-items/1573"
+  echo ""
+
   header "Build failed"
   fail_yarn_outdated "$LOG_FILE"
   fail_yarn_lockfile_outdated "$LOG_FILE"


### PR DESCRIPTION
Similar to #636 

#636 will only print the warning on a successful build. This will print the warning if the build fails, such as if the `build` script does not succeed.

Before:
![Hyper 2019-03-11 09-55-14](https://user-images.githubusercontent.com/175496/54141911-d6afe680-43e3-11e9-92d6-be186ff63d8a.png)

After:
![Hyper 2019-03-11 09-55-30](https://user-images.githubusercontent.com/175496/54141927-dd3e5e00-43e3-11e9-9e16-ffcac1947768.png)
