### PR TITLE
Blacklist env vars with dots

### DIFF
--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -56,7 +56,7 @@ export_env_dir() {
   local env_dir=$1
   if [ -d "$env_dir" ]; then
     local whitelist_regex=${2:-''}
-    local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG|BUILD_DIR)$'}
+    local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG|BUILD_DIR|.*\..*)$'}
     # shellcheck disable=SC2164
     pushd "$env_dir" >/dev/null
     for e in *; do

--- a/test/run
+++ b/test/run
@@ -357,6 +357,14 @@ testEnvBlacklist() {
   assertCapturedSuccess
 }
 
+testDotEnvVarsBlacklist() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  echo "secret" > "$env_dir/KPI_HTTP_GATEWAY_URL_EU_HEROKU.COM"
+  compile "node-10" $cache $env_dir
+  assertCapturedSuccess
+}
+
 testWarningsOnFailure() {
   compile "many-warnings"
   assertCaptured "troubleshooting-node-deploys"


### PR DESCRIPTION
This adds a test for ENV vars with dots to the blacklist

The Heroku platform allows you to set env vars with dots, and if you `heroku run bash` you will see them:

```
❯ heroku run bash -a afternoon-caverns-79038
Running bash on ⬢ afternoon-caverns-79038... up, run.3267 (Free)
~ $ env
...
KPI_HTTP_GATEWAY_URL_EU_HEROKU.COM=test
```

but exporting these are not supported by bash, so if you try to run a build it will fail when the buildpack tries to export them.

This change makes it so that the buildpack will skip these ENV vars during build. This means that they won't be available to Node build scripts, but they will still be available at runtime.

If there is a better way of dealing with this situation, I'm certainly open to suggestions.

cc @ys 