### PR TITLE
Separate prebuild step in log output

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -238,8 +238,6 @@ restore_cache | output "$LOG_FILE"
 build_dependencies() {
   local cache_status start
 
-  run_if_present "$BUILD_DIR" 'heroku-prebuild'
-
   cache_status="$(get_cache_status "$CACHE_DIR")"
   start=$(nowms)
 
@@ -258,6 +256,8 @@ build_dependencies() {
   run_build_script "$BUILD_DIR"
   log_build_scripts "$BUILD_DIR"
 }
+
+run_prebuild_script "$BUILD_DIR" | output "$LOG_FILE"
 
 header "Installing dependencies" | output "$LOG_FILE"
 build_dependencies | output "$LOG_FILE"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -40,6 +40,19 @@ run_if_present() {
   fi
 }
 
+run_prebuild_script() {
+  local build_dir=${1:-}
+  local has_heroku_prebuild_script
+
+  has_heroku_prebuild_script=$(has_script "$build_dir/package.json" "heroku-prebuild")
+
+  if [[ "$has_heroku_prebuild_script" == "true" ]]; then
+    mcount "script.heroku-prebuild"
+    header "Prebuild"
+    run_if_present "$build_dir" 'heroku-prebuild'
+  fi
+}
+
 run_build_script() {
   local build_dir=${1:-}
   local has_build_script has_heroku_build_script

--- a/test/fixtures/pre-post-build-scripts/package.json
+++ b/test/fixtures/pre-post-build-scripts/package.json
@@ -7,7 +7,7 @@
     "url" : "http://github.com/example/example.git"
   },
   "engines": {
-    "node": "~0.10.0"
+    "node": "10.x"
   },
   "scripts" : {
     "heroku-prebuild" : "echo heroku-prebuild hook message",

--- a/test/run
+++ b/test/run
@@ -1058,7 +1058,7 @@ testBuildMetaData() {
   assertFileContains "build-uuid=" $log_file
 
   # binary versions
-  assertFileContains "node-version-request=~0.10.0" $log_file
+  assertFileContains "node-version-request=10.x" $log_file
   assertFileContains "npm-version-request= " $log_file
 
   # log build scripts


### PR DESCRIPTION
Follow-up to https://github.com/heroku/heroku-buildpack-nodejs/pull/625

The prebuild output currently gets lumped in with the `npm install` output:

![Hyper 2019-04-09 12-52-23](https://user-images.githubusercontent.com/175496/55831305-a3867300-5ac7-11e9-84f2-4dfa9a8ac9f4.png)

This separates it out into a new section if it exists:

![Hyper 2019-04-09 12-59-24](https://user-images.githubusercontent.com/175496/55831327-b00acb80-5ac7-11e9-9d78-a44a33ec9e4f.png)

and skips printing that section if the script is not present:

![Hyper 2019-04-09 13-02-56](https://user-images.githubusercontent.com/175496/55831394-d9c3f280-5ac7-11e9-8b4b-051a81404867.png)
