### PR TITLE
Clean up script metrics and logging

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -256,9 +256,9 @@ build_dependencies() {
 
   header "Build"
   run_build_script "$BUILD_DIR"
-  log_build_scripts "$BUILD_DIR"
 }
 
+log_build_scripts "$BUILD_DIR"
 header "Installing dependencies" | output "$LOG_FILE"
 build_dependencies | output "$LOG_FILE"
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -64,7 +64,7 @@ log_build_scripts() {
   local build_dir=${1:-}
 
   meta_set "build-script" "$(read_json "$build_dir/package.json" ".scripts[\"build\"]")"
-  meta_set "postinstall-script" "$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")"
+  meta_set "postinstall-script" "$(read_json "$build_dir/package.json" ".scripts[\"postinstall\"]")"
   meta_set "heroku-prebuild-script" "$(read_json "$build_dir/package.json" ".scripts[\"heroku-prebuild\"]")"
   meta_set "heroku-postbuild-script" "$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")"
 }

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -61,72 +61,12 @@ run_build_script() {
 }
 
 log_build_scripts() {
-  local build heroku_prebuild heroku_postbuild postinstall
   local build_dir=${1:-}
 
-  build=$(read_json "$build_dir/package.json" ".scripts[\"build\"]")
-  heroku_prebuild=$(read_json "$build_dir/package.json" ".scripts[\"heroku-prebuild\"]")
-  heroku_postbuild=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
-  postinstall=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
-
-  meta_set "build-script" "$build"
-  meta_set "postinstall-script" "$postinstall"
-  meta_set "heroku-prebuild-script" "$heroku_prebuild"
-  meta_set "heroku-postbuild-script" "$heroku_prebuild"
-
-  meta_set "build-script" "$build"
-  meta_set "postinstall-script" "$postinstall"
-  meta_set "heroku-prebuild-script" "$heroku_prebuild"
-  meta_set "heroku-postbuild-script" "$heroku_prebuild"
-
-  if [ -n "$build" ]; then
-    mcount "scripts.build"
-
-    if [ -z "$heroku_postbuild" ]; then
-      mcount "scripts.build-without-heroku-postbuild"
-    fi
-
-    if [ -z "$postinstall" ]; then
-      mcount "scripts.build-without-postinstall"
-    fi
-
-    if [ -z "$postinstall" ] && [ -z "$heroku_postbuild" ]; then
-      mcount "scripts.build-without-other-hooks"
-    fi
-  fi
-
-  if [ -n "$postinstall" ]; then
-    mcount "scripts.postinstall"
-
-    if [ "$postinstall" == "npm run build" ] ||
-       [ "$postinstall" == "yarn run build" ] ||
-       [ "$postinstall" == "yarn build" ]; then
-      mcount "scripts.postinstall-is-npm-build"
-    fi
-
-  fi
-
-  if [ -n "$heroku_prebuild" ]; then
-    mcount "scripts.heroku-prebuild"
-  fi
-
-  if [ -n "$heroku_postbuild" ]; then
-    mcount "scripts.heroku-postbuild"
-
-    if [ "$heroku_postbuild" == "npm run build" ] ||
-       [ "$heroku_postbuild" == "yarn run build" ] ||
-       [ "$heroku_postbuild" == "yarn build" ]; then
-      mcount "scripts.heroku-postbuild-is-npm-build"
-    fi
-  fi
-
-  if [ -n "$heroku_postbuild" ] && [ -n "$build" ]; then
-    mcount "scripts.build-and-heroku-postbuild"
-
-    if [ "$heroku_postbuild" != "$build" ]; then
-      mcount "scripts.different-build-and-heroku-postbuild"
-    fi
-  fi
+  meta_set "build-script" "$(read_json "$build_dir/package.json" ".scripts[\"build\"]")"
+  meta_set "postinstall-script" "$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")"
+  meta_set "heroku-prebuild-script" "$(read_json "$build_dir/package.json" ".scripts[\"heroku-prebuild\"]")"
+  meta_set "heroku-postbuild-script" "$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")"
 }
 
 yarn_node_modules() {

--- a/test/run
+++ b/test/run
@@ -1063,7 +1063,7 @@ testBuildMetaData() {
 
   # log build scripts
   assertFileContains "heroku-prebuild-script=\"echo heroku-prebuild hook message\"" $log_file
-  assertFileContains "heroku-postbuild-script=\"echo heroku-prebuild hook message\"" $log_file
+  assertFileContains "heroku-postbuild-script=\"echo heroku-postbuild hook message\"" $log_file
   assertFileContains "build-script= " $log_file
 
   # monitor calls


### PR DESCRIPTION
These metrics were used to gauge difficulty of the run build breaking change: https://github.com/heroku/heroku-buildpack-nodejs/issues/583 and are no longer useful

Storing them in the metadata so that they get logged out is still useful, so let's keep that.

This also changes the ordering so that it logs out the scripts before they are run, so that if the build fails, the command that failed will also be captured.