### PR TITLE
Stub out go binary build and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TEST=cedar-14 STACK=cedar-14
   - TEST=hatchet
   - TEST=unit
+  - TEST=test-binary
 install:
   - if [[ -n $STACK ]]; then
       docker pull "heroku/${STACK/-/:}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: bash
+language: go
+go:
+  - "1.12"
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - TEST=cedar-14 STACK=cedar-14
   - TEST=hatchet
   - TEST=unit
-  - TEST=test-binary
+  - TEST=test-binary GO111MODULE=on
 install:
   - if [[ -n $STACK ]]; then
       docker pull "heroku/${STACK/-/:}";

--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello world")
+}

--- a/cmd/resolve-version/main_test.go
+++ b/cmd/resolve-version/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseObject(t *testing.T) {
+	assert.Equal(t, 0, 0)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/heroku/heroku-buildpack-nodejs
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/makefile
+++ b/makefile
@@ -1,5 +1,12 @@
 test: heroku-18 heroku-16 cedar-14
 
+build:
+	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-darwin ./cmd/resolve-version
+	@GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-linux ./cmd/resolve-version
+
+test-binary:
+	go test -v ./cmd/...
+
 shellcheck:
 	@shellcheck -x bin/compile bin/detect bin/release bin/test bin/test-compile
 	@shellcheck -x lib/**

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ build:
 	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-darwin ./cmd/resolve-version
 	@GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-linux ./cmd/resolve-version
 
-test-binary:
+test-binary: build
 	go test -v ./cmd/...
 
 shellcheck:

--- a/makefile
+++ b/makefile
@@ -4,10 +4,7 @@ build:
 	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-darwin ./cmd/resolve-version
 	@GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-linux ./cmd/resolve-version
 
-go-install:
-	go install -v ./cmd/...
-
-test-binary: go-install
+test-binary:
 	go test -v ./cmd/...
 
 shellcheck:

--- a/makefile
+++ b/makefile
@@ -4,7 +4,10 @@ build:
 	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-darwin ./cmd/resolve-version
 	@GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-linux ./cmd/resolve-version
 
-test-binary: build
+go-install:
+	go install -v ./cmd/...
+
+test-binary: go-install
 	go test -v ./cmd/...
 
 shellcheck:


### PR DESCRIPTION
This PR stubs out a go binary and tests. Actual logic will come in later PRs, this just tries to get the machinery in place.

- Adds `cmd` directory for go commands
- Adds `test-binary` and `build` subcommands to `Makefile`
- Makes sure that Travis is running the go tests

```
heroku-buildpack-nodejs git/go-binary-1*  
❯ make build      
github.com/heroku/heroku-buildpack-nodejs/cmd/resolve-version
github.com/heroku/heroku-buildpack-nodejs/cmd/resolve-version
                                                                                                                                                                                                                 
heroku-buildpack-nodejs git/go-binary-1*  
❯ ./vendor/resolve-version-darwin            
hello world
```