### PR TITLE
Add logic for parsing s3 paths

### DIFF
--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -1,6 +1,59 @@
 package main
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/Masterminds/semver"
+)
+
+type release struct {
+	binary   string
+	stage    string
+	platform string
+	url      string
+	version  *semver.Version
+}
+
+// Parses an S3 key into a struct of information about that release
+// Example input: node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz
+func parseObject(key string) (release, error) {
+	nodeRegex := regexp.MustCompile("node\\/([^\\/]+)\\/([^\\/]+)\\/node-v([0-9]+.[0-9]+.[0-9]+)-([^.]*)(.*).tar.gz")
+	yarnRegex := regexp.MustCompile("yarn\\/([^\\/]+)\\/yarn-v([0-9]+.[0-9]+.[0-9]+).tar.gz")
+
+	if nodeRegex.MatchString(key) {
+		match := nodeRegex.FindStringSubmatch(key)
+		version, err := semver.NewVersion(match[3])
+		if err != nil {
+			return release{}, errors.New("Failed to parse version as semver")
+		}
+		return release{
+			binary:   "node",
+			stage:    match[1],
+			platform: match[2],
+			version:  version,
+			url:      fmt.Sprintf("https://s3.amazonaws.com/%s/node/%s/%s/node-v%s-%s.tar.gz", "heroku-nodebin", match[1], match[2], match[3], match[2]),
+		}, nil
+	}
+
+	if yarnRegex.MatchString(key) {
+		match := yarnRegex.FindStringSubmatch(key)
+		version, err := semver.NewVersion(match[2])
+		if err != nil {
+			return release{}, errors.New("Failed to parse version as semver")
+		}
+		return release{
+			binary:   "yarn",
+			stage:    match[1],
+			platform: "",
+			url:      fmt.Sprintf("https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v%s.tar.gz", version),
+			version:  version,
+		}, nil
+	}
+
+	return release{}, errors.New("Failed to parse key")
+}
 
 func main() {
 	fmt.Println("hello world")

--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -19,14 +19,14 @@ type release struct {
 // Parses an S3 key into a struct of information about that release
 // Example input: node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz
 func parseObject(key string) (release, error) {
-	nodeRegex := regexp.MustCompile("node\\/([^\\/]+)\\/([^\\/]+)\\/node-v([0-9]+.[0-9]+.[0-9]+)-([^.]*)(.*).tar.gz")
-	yarnRegex := regexp.MustCompile("yarn\\/([^\\/]+)\\/yarn-v([0-9]+.[0-9]+.[0-9]+).tar.gz")
+	nodeRegex := regexp.MustCompile("node\\/([^\\/]+)\\/([^\\/]+)\\/node-v([0-9]+\\.[0-9]+\\.[0-9]+)-([^.]*)(.*)\\.tar\\.gz")
+	yarnRegex := regexp.MustCompile("yarn\\/([^\\/]+)\\/yarn-v([0-9]+\\.[0-9]+\\.[0-9]+)\\.tar\\.gz")
 
 	if nodeRegex.MatchString(key) {
 		match := nodeRegex.FindStringSubmatch(key)
 		version, err := semver.NewVersion(match[3])
 		if err != nil {
-			return release{}, errors.New("Failed to parse version as semver")
+			return release{}, fmt.Errorf("Failed to parse version as semver:%s\n%s", match[3], err.Error())
 		}
 		return release{
 			binary:   "node",
@@ -52,7 +52,7 @@ func parseObject(key string) (release, error) {
 		}, nil
 	}
 
-	return release{}, errors.New("Failed to parse key")
+	return release{}, fmt.Errorf("Failed to parse key: %s", key)
 }
 
 func main() {

--- a/cmd/resolve-version/main_test.go
+++ b/cmd/resolve-version/main_test.go
@@ -37,5 +37,5 @@ func TestParseObject(t *testing.T) {
 
 	release, err = parseObject("something/weird")
 	assert.NotNil(t, err)
-	assert.Errorf(t, err, "Failed to parse key")
+	assert.Equal(t, err.Error(), "Failed to parse key: something/weird")
 }

--- a/cmd/resolve-version/main_test.go
+++ b/cmd/resolve-version/main_test.go
@@ -7,5 +7,35 @@ import (
 )
 
 func TestParseObject(t *testing.T) {
-	assert.Equal(t, 0, 0)
+	release, err := parseObject("node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz")
+	assert.Nil(t, err)
+	assert.Equal(t, release.binary, "node")
+	assert.Equal(t, release.stage, "release")
+	assert.Equal(t, release.platform, "linux-x64")
+	assert.Equal(t, release.version.String(), "6.2.2")
+
+	release, err = parseObject("node/release/darwin-x64/node-v8.14.1-darwin-x64.tar.gz")
+	assert.Nil(t, err)
+	assert.Equal(t, release.binary, "node")
+	assert.Equal(t, release.stage, "release")
+	assert.Equal(t, release.platform, "darwin-x64")
+	assert.Equal(t, release.version.String(), "8.14.1")
+
+	release, err = parseObject("node/staging/darwin-x64/node-v6.17.0-darwin-x64.tar.gz")
+	assert.Nil(t, err)
+	assert.Equal(t, release.binary, "node")
+	assert.Equal(t, release.stage, "staging")
+	assert.Equal(t, release.platform, "darwin-x64")
+	assert.Equal(t, release.version.String(), "6.17.0")
+
+	release, err = parseObject("yarn/release/yarn-v1.9.1.tar.gz")
+	assert.Nil(t, err)
+	assert.Equal(t, release.binary, "yarn")
+	assert.Equal(t, release.stage, "release")
+	assert.Equal(t, release.platform, "")
+	assert.Equal(t, release.version.String(), "1.9.1")
+
+	release, err = parseObject("something/weird")
+	assert.NotNil(t, err)
+	assert.Errorf(t, err, "Failed to parse key")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/heroku/heroku-buildpack-nodejs
 
 go 1.12
 
-require github.com/stretchr/testify v1.3.0
+require (
+	github.com/Masterminds/semver v1.4.2
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
+github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Depends on #649 

Adds logic and tests for parsing an S3 url into information about the release.

Example:

input: 
```
node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz
```

output: 
```
{
  binary: "node",
  stage: "release",
  platform: "linux-x64",
  url: "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz",
  version: semver.NewVersion("6.2.2")
}
```