### PR TITLE
Add function for pulling out an exact version of an array of releases

### DIFF
--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -46,7 +46,7 @@ func matchReleaseExact(releases []release, version string) (release, error) {
 			return release, nil
 		}
 	}
-	return release{}, errors.New("No matching version")
+	return release{}, fmt.Errorf("No matching version for: %s", version)
 }
 
 // Parses an S3 key into a struct of information about that release

--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -40,13 +40,27 @@ type release struct {
 	version  *semver.Version
 }
 
-func matchReleaseExact(releases []release, version string) (release, error) {
+type matchResult struct {
+	versionRequirement string
+	release            release
+	matched            bool
+}
+
+func matchReleaseExact(releases []release, version string) matchResult {
 	for _, release := range releases {
 		if release.version.String() == version {
-			return release, nil
+			return matchResult{
+				versionRequirement: version,
+				release:            release,
+				matched:            true,
+			}
 		}
 	}
-	return release{}, fmt.Errorf("No matching version for: %s", version)
+	return matchResult{
+		versionRequirement: version,
+		release:            release{},
+		matched:            false,
+	}
 }
 
 // Parses an S3 key into a struct of information about that release

--- a/cmd/resolve-version/main.go
+++ b/cmd/resolve-version/main.go
@@ -40,6 +40,15 @@ type release struct {
 	version  *semver.Version
 }
 
+func matchReleaseExact(releases []release, version string) (release, error) {
+	for _, release := range releases {
+		if release.version.String() == version {
+			return release, nil
+		}
+	}
+	return release{}, errors.New("No matching version")
+}
+
 // Parses an S3 key into a struct of information about that release
 // Example input: node/release/linux-x64/node-v6.2.2-linux-x64.tar.gz
 func parseObject(key string) (release, error) {

--- a/cmd/resolve-version/main_test.go
+++ b/cmd/resolve-version/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 
+	"github.com/Masterminds/semver"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,4 +40,34 @@ func TestParseObject(t *testing.T) {
 	release, err = parseObject("something/weird")
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), "Failed to parse key: something/weird")
+}
+
+func genReleasesFromArray(versions []string) []release {
+	out := []release{}
+	for _, version := range versions {
+		out = append(out, release{
+			binary:   "node",
+			stage:    "release",
+			platform: "linux-x64",
+			url:      "https://heroku.com",
+			version:  semver.MustParse(version),
+		})
+	}
+	return out
+}
+
+func TestMatchReleaseExact(t *testing.T) {
+	releases := genReleasesFromArray([]string{"1.0.0", "1.0.1", "1.0.2"})
+
+	release, err := matchReleaseExact(releases, "1.0.1")
+	assert.Nil(t, err)
+	assert.Equal(t, release.version.String(), "1.0.1")
+
+	release, err = matchReleaseExact(releases, "1.0.2")
+	assert.Nil(t, err)
+	assert.Equal(t, release.version.String(), "1.0.2")
+
+	release, err = matchReleaseExact(releases, "1.0.3")
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "No matching version")
 }

--- a/cmd/resolve-version/main_test.go
+++ b/cmd/resolve-version/main_test.go
@@ -59,15 +59,15 @@ func genReleasesFromArray(versions []string) []release {
 func TestMatchReleaseExact(t *testing.T) {
 	releases := genReleasesFromArray([]string{"1.0.0", "1.0.1", "1.0.2"})
 
-	release, err := matchReleaseExact(releases, "1.0.1")
-	assert.Nil(t, err)
-	assert.Equal(t, release.version.String(), "1.0.1")
+	result := matchReleaseExact(releases, "1.0.1")
+	assert.True(t, result.matched)
+	assert.Equal(t, result.release.version.String(), "1.0.1")
 
-	release, err = matchReleaseExact(releases, "1.0.2")
-	assert.Nil(t, err)
-	assert.Equal(t, release.version.String(), "1.0.2")
+	result = matchReleaseExact(releases, "1.0.2")
+	assert.True(t, result.matched)
+	assert.Equal(t, result.release.version.String(), "1.0.2")
 
-	release, err = matchReleaseExact(releases, "1.0.3")
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "No matching version for: 1.0.3")
+	result = matchReleaseExact(releases, "1.0.3")
+	assert.False(t, result.matched)
+	assert.Equal(t, result.versionRequirement, "1.0.3")
 }

--- a/cmd/resolve-version/main_test.go
+++ b/cmd/resolve-version/main_test.go
@@ -69,5 +69,5 @@ func TestMatchReleaseExact(t *testing.T) {
 
 	release, err = matchReleaseExact(releases, "1.0.3")
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "No matching version")
+	assert.Equal(t, err.Error(), "No matching version for: 1.0.3")
 }


### PR DESCRIPTION
Depends on #651 

Adds a helper function that will select only an exact version match from a set of `release` structs