### PR TITLE
Resolve node versions

### DIFF
--- a/cmd/resolve-version/main_test.go
+++ b/cmd/resolve-version/main_test.go
@@ -179,3 +179,129 @@ func TestResolveYarn(t *testing.T) {
 		}
 	}
 }
+
+func genNodeS3ObjectList(releaseVersions []string, stagingVersions []string, platform string) []s3Object {
+	out := []s3Object{}
+	for _, version := range releaseVersions {
+		out = append(out, s3Object{
+			Key:          fmt.Sprintf("node/release/%s/node-v%s-%s.tar.gz", platform, version, platform),
+			LastModified: time.Time{},
+			ETag:         "abcdef",
+			Size:         0,
+			StorageClass: "normal",
+		})
+	}
+	for _, version := range stagingVersions {
+		out = append(out, s3Object{
+			Key:          fmt.Sprintf("node/staging/%s/node-v%s-%s.tar.gz", platform, version, platform),
+			LastModified: time.Time{},
+			ETag:         "abcdef",
+			Size:         0,
+			StorageClass: "normal",
+		})
+	}
+	return out
+}
+
+func TestResolveNode(t *testing.T) {
+	releasedVersions := []string{
+		"10.0.0", "10.1.0", "10.10.0", "10.11.0", "10.12.0", "10.13.0", "10.14.0", "10.14.1", "10.14.2", "10.15.0",
+		"10.15.1", "10.15.2", "10.15.3", "10.2.0", "10.2.1", "10.3.0", "10.4.0", "10.4.1", "10.5.0", "10.6.0",
+		"10.7.0", "10.8.0", "10.9.0", "11.0.0", "11.1.0", "11.10.0", "11.10.1", "11.11.0", "11.12.0", "11.13.0",
+		"11.14.0", "11.2.0", "11.3.0", "11.4.0", "11.5.0", "11.6.0", "11.7.0", "11.8.0", "11.9.0", "6.0.0",
+		"6.1.0", "6.10.0", "6.10.1", "6.10.2", "6.10.3", "6.11.0", "6.11.1", "6.11.2", "6.11.3", "6.11.4",
+		"6.11.5", "6.12.0", "6.12.1", "6.12.2", "6.12.3", "6.13.0", "6.13.1", "6.14.0", "6.14.1", "6.14.2",
+		"6.14.3", "6.14.4", "6.15.0", "6.15.1", "6.16.0", "6.17.0", "6.17.1", "6.2.0", "6.2.1", "6.2.2",
+		"6.3.0", "6.3.1", "6.4.0", "6.5.0", "6.6.0", "6.7.0", "6.8.0", "6.8.1", "6.9.0", "6.9.1", "6.9.2",
+		"6.9.3", "6.9.4", "6.9.5", "8.0.0", "8.1.0", "8.1.1", "8.1.2", "8.1.3", "8.1.4", "8.10.0", "8.11.0",
+		"8.11.1", "8.11.2", "8.11.3", "8.11.4", "8.12.0", "8.13.0", "8.14.0", "8.14.1", "8.15.0", "8.15.1",
+		"8.16.0", "8.2.0", "8.2.1", "8.3.0", "8.4.0", "8.5.0", "8.6.0", "8.7.0", "8.8.0", "8.8.1", "8.9.0",
+		"8.9.1", "8.9.2", "8.9.3", "8.9.4",
+	}
+
+	objects := genNodeS3ObjectList(releasedVersions, []string{}, "linux-x64")
+
+	// Semver requirements pulled from real apps
+	cases := []Case{
+		Case{input: "10.x", output: "10.15.3"},
+		Case{input: "10.*", output: "10.15.3"},
+		Case{input: "10", output: "10.15.3"},
+		Case{input: "8.x", output: "8.16.0"},
+		Case{input: "^8.11.3", output: "8.16.0"},
+		Case{input: "~8.11.3", output: "8.11.4"},
+		Case{input: ">= 6.0.0", output: "11.14.0"},
+		Case{input: "^6.9.0 || ^8.9.0 || ^10.13.0", output: "10.15.3"},
+		Case{input: "6.* || 8.* || >= 10.*", output: "11.14.0"},
+		// TODO: these fail to parse with the library
+		// Case{input: ">= 6.11.1 <= 10", output: "8.16.0"},
+		// Case{input: ">=8.10 <11", output: "10.15.3"},
+	}
+
+	for _, c := range cases {
+		result, err := resolveNode(objects, "linux-x64", c.input)
+		assert.Nil(t, err)
+		assert.True(t, result.matched)
+		assert.Equal(t, result.release.version.String(), c.output)
+	}
+
+	for _, c := range cases {
+		result, err := resolveNode(objects, "darwin-x64", c.input)
+		assert.Nil(t, err)
+		assert.False(t, result.matched)
+		assert.Equal(t, result.versionRequirement, c.input)
+	}
+}
+
+func TestResolveNodeStaging(t *testing.T) {
+	releasedVersions := []string{
+		"10.0.0", "10.1.0", "10.10.0", "10.11.0", "10.12.0", "10.13.0", "10.14.0", "10.14.1", "10.14.2", "10.15.0",
+		"10.15.1", "10.15.2", "10.15.3", "10.2.0", "10.2.1", "10.3.0", "10.4.0", "10.4.1", "10.5.0", "10.6.0",
+		"10.7.0", "10.8.0", "10.9.0", "11.0.0", "11.1.0", "11.10.0", "11.10.1", "11.11.0", "11.12.0", "11.13.0",
+		"11.14.0", "11.2.0", "11.3.0", "11.4.0", "11.5.0", "11.6.0", "11.7.0", "11.8.0", "11.9.0", "6.0.0",
+		"6.1.0", "6.10.0", "6.10.1", "6.10.2", "6.10.3", "6.11.0", "6.11.1", "6.11.2", "6.11.3", "6.11.4",
+		"6.11.5", "6.12.0", "6.12.1", "6.12.2", "6.12.3", "6.13.0", "6.13.1", "6.14.0", "6.14.1", "6.14.2",
+		"6.14.3", "6.14.4", "6.15.0", "6.15.1", "6.16.0", "6.17.0", "6.17.1", "6.2.0", "6.2.1", "6.2.2",
+		"6.3.0", "6.3.1", "6.4.0", "6.5.0", "6.6.0", "6.7.0", "6.8.0", "6.8.1", "6.9.0", "6.9.1", "6.9.2",
+		"6.9.3", "6.9.4", "6.9.5", "8.0.0", "8.1.0", "8.1.1", "8.1.2", "8.1.3", "8.1.4", "8.10.0", "8.11.0",
+		"8.11.1", "8.11.2", "8.11.3", "8.11.4", "8.12.0", "8.13.0", "8.14.0", "8.14.1", "8.15.0", "8.15.1",
+		"8.16.0", "8.2.0", "8.2.1", "8.3.0", "8.4.0", "8.5.0", "8.6.0", "8.7.0", "8.8.0", "8.8.1", "8.9.0",
+		"8.9.1", "8.9.2", "8.9.3", "8.9.4",
+	}
+
+	platforms := []string{"linux-x64", "darwin-x64"}
+
+	for _, platform := range platforms {
+		// staging has a few releases that were already released, but one: 10.15.4 that has not been
+		objects := genNodeS3ObjectList(releasedVersions, []string{"10.15.1", "10.15.2", "10.15.3", "10.15.4"}, platform)
+
+		result, err := resolveNode(objects, platform, "10.15.1")
+		if assert.Nil(t, err) {
+			assert.True(t, result.matched)
+			assert.Equal(t, result.release.version.String(), "10.15.1")
+			assert.Equal(t, result.versionRequirement, "10.15.1")
+			if platform == "linux-x64" {
+				assert.Equal(t, result.release.url, "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.15.1-linux-x64.tar.gz")
+			} else {
+				assert.Equal(t, result.release.url, "https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.15.1-darwin-x64.tar.gz")
+			}
+		}
+
+		result, err = resolveNode(objects, platform, "10.15.4")
+		if assert.Nil(t, err) {
+			assert.True(t, result.matched)
+			assert.Equal(t, result.release.version.String(), "10.15.4")
+			assert.Equal(t, result.versionRequirement, "10.15.4")
+			if platform == "linux-x64" {
+				assert.Equal(t, result.release.url, "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.15.4-linux-x64.tar.gz")
+			} else {
+				assert.Equal(t, result.release.url, "https://s3.amazonaws.com/heroku-nodebin/node/staging/darwin-x64/node-v10.15.4-darwin-x64.tar.gz")
+			}
+		}
+
+		result, err = resolveNode(objects, platform, "10.15.5")
+		if assert.Nil(t, err) {
+			assert.False(t, result.matched)
+			assert.Equal(t, result.versionRequirement, "10.15.5")
+		}
+	}
+}


### PR DESCRIPTION
Similar to https://github.com/heroku/heroku-buildpack-nodejs/pull/654 but a bit more complicated:

- Node must match the correct platform: `linux-x64` or `darwin-x64`
- Node has special logic around staging releases to enable integration testing

```
heroku-buildpack-nodejs 
❯ curl https://nodebin.herokai.com/v1/node/darwin-x64/latest.txt\?range\=10.x
10.15.3 https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.15.3-darwin-x64.tar.gz
                                                                                                                                                                                                                                          
heroku-buildpack-nodejs
❯ ./vendor/resolve-version-darwin                                
10.15.3 https://s3.amazonaws.com/heroku-nodebin/node/release/darwin-x64/node-v10.15.3-darwin-x64.tar.gz
                                                                                                                                                                                                                                          
heroku-buildpack-nodejs  
❯ curl https://nodebin.herokai.com/v1/node/darwin-x64/latest.txt\?range\=99.x
No result%                                                                                                                                                                                                                                         
heroku-buildpack-nodejs
❯ ./vendor/resolve-version-darwin node "99.x"                                
No result
                                                                                                                                                                                                                                          
heroku-buildpack-nodejs 
❯ curl https://nodebin.herokai.com/v1/node/darwin-x64/latest.txt\?range\=99.x.x.x
Invalid semver range%                                                                                                                                                                                                                                         
heroku-buildpack-nodejs 
❯ ./vendor/resolve-version-darwin node "99.x.x.x"                                
improper constraint: 99.x.x.x
```