### PR TITLE
Deprecate iojs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -99,6 +99,7 @@ fail_dot_heroku "$BUILD_DIR"
 fail_dot_heroku_node "$BUILD_DIR"
 fail_invalid_package_json "$BUILD_DIR"
 fail_multiple_lockfiles "$BUILD_DIR"
+fail_iojs_unsupported "$BUILD_DIR"
 warn_prebuilt_modules "$BUILD_DIR"
 warn_missing_package_json "$BUILD_DIR"
 
@@ -128,7 +129,6 @@ install_bins() {
   local node_engine iojs_engine npm_engine yarn_engine npm_version node_version
 
   node_engine=$(read_json "$BUILD_DIR/package.json" ".engines.node")
-  iojs_engine=$(read_json "$BUILD_DIR/package.json" ".engines.iojs")
   npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
   yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
 
@@ -140,32 +140,19 @@ install_bins() {
   meta_set "npm-version-request" "$npm_engine"
   meta_set "yarn-version-request" "$yarn_engine"
 
-  if [ -n "$iojs_engine" ]; then
-    echo "engines.iojs (package.json):  $iojs_engine (iojs)"
-  else
-    echo "engines.node (package.json):  ${node_engine:-unspecified}"
-  fi
+  echo "engines.node (package.json):  ${node_engine:-unspecified}"
   echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
   if $YARN; then
     echo "engines.yarn (package.json):  ${yarn_engine:-unspecified (use default)}"
   fi
   echo ""
 
-  if [ -n "$iojs_engine" ]; then
-    warn_node_engine "$iojs_engine"
-    install_iojs "$iojs_engine" "$BUILD_DIR/.heroku/node" "$(get_platform)"
-    npm_version="$(npm --version)"
-    node_version="$(node --version)"
-    echo "Using bundled npm version for iojs compatibility: $npm_version"
-    mcount "version.iojs.$node_version"
-  else
-    warn_node_engine "$node_engine"
-    monitor "install-node-binary" install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node" "$(get_platform)"
-    monitor "install-npm-binary" install_npm "$npm_engine" "$BUILD_DIR/.heroku/node" $NPM_LOCK
-    node_version="$(node --version)"
-    mcount "version.node.$node_version"
-    meta_set "node-version" "$node_version"
-  fi
+  warn_node_engine "$node_engine"
+  monitor "install-node-binary" install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node" "$(get_platform)"
+  monitor "install-npm-binary" install_npm "$npm_engine" "$BUILD_DIR/.heroku/node" $NPM_LOCK
+  node_version="$(node --version)"
+  mcount "version.node.$node_version"
+  meta_set "node-version" "$node_version"
 
   # Download yarn if there is a yarn.lock file or if the user
   # has specified a version of yarn under "engines". We'll still

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -53,30 +53,6 @@ install_nodejs() {
   chmod +x "$dir"/bin/*
 }
 
-install_iojs() {
-  local version="$1"
-  local dir="$2"
-  local platform="$3"
-  local code os cpu
-
-  os=$(get_os)
-  cpu=$(get_cpu)
-
-  echo "Resolving iojs version ${version:-(latest stable)}..."
-  if ! read -r number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/iojs/$platform/latest.txt"); then
-    fail_bin_install iojs "$version" "$platform";
-  fi
-
-  echo "Downloading and installing iojs $number..."
-  code=$(curl "$url" --silent --fail --retry 5 --retry-max-time 15 -o /tmp/iojs.tar.gz --write-out "%{http_code}")
-  if [ "$code" != "200" ]; then
-    echo "Unable to download iojs: $code" && false
-  fi
-  tar xzf /tmp/iojs.tar.gz -C /tmp
-  mv /tmp/iojs-v"$number"-"$os"-"$cpu"/* "$dir"
-  chmod +x "$dir"/bin/*
-}
-
 install_npm() {
   local npm_version
   local version="$1"

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -85,8 +85,9 @@ fail_dot_heroku_node() {
 }
 
 fail_iojs_unsupported() {
+  local build_dir="$1"
   local iojs_engine
-  iojs_engine=$(read_json "$BUILD_DIR/package.json" ".engines.iojs")
+  iojs_engine=$(read_json "$build_dir/package.json" ".engines.iojs")
 
   if [ -n "$iojs_engine" ]; then
     mcount "failures.iojs-unsupported"

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -84,6 +84,34 @@ fail_dot_heroku_node() {
   fi
 }
 
+fail_iojs_unsupported() {
+  local iojs_engine
+  iojs_engine=$(read_json "$BUILD_DIR/package.json" ".engines.iojs")
+
+  if [ -n "$iojs_engine" ]; then
+    mcount "failures.iojs-unsupported"
+    meta_set "failure" "iojs-unsupported"
+    warn "io.js no longer supported
+
+       You are specifying an io.js version in your package.json:
+
+       \"engines\": {
+         ...
+         \"iojs\": \"${iojs_engine}\"
+       }
+
+       io.js merged back into Nodejs.org in 2015 and has been unsupported
+       for many years. It is likely to contain several large security 
+       vulnerabilities that have been patched in Node.
+
+       You can update your app to use the official Node.js release by 
+       removing the version specfication under \"engines\" in your
+       package.json.
+       "
+    fail
+  fi
+}
+
 fail_multiple_lockfiles() {
   local has_modern_lockfile=false
   if [ -f "${1:-}/yarn.lock" ] || [ -f "${1:-}/package-lock.json" ]; then

--- a/test/run
+++ b/test/run
@@ -490,13 +490,6 @@ testInvalidNodeSemver() {
   assertCapturedError
 }
 
-testInvalidIo() {
-  compile "invalid-io"
-  assertCaptured "Resolving iojs version 2.0.99"
-  assertCaptured "Could not find Iojs version corresponding to version requirement: 2.0.99"
-  assertCapturedError
-}
-
 testSignatureInvalidation() {
   cache=$(mktmpdir)
   env_dir=$(mktmpdir)
@@ -538,10 +531,8 @@ testDetectWithoutPackageJson() {
 
 testIoJs() {
   compile "iojs"
-  assertCaptured "engines.iojs (package.json):  1.0."
-  assertCaptured "Downloading and installing iojs 1.0."
-  assertNotCaptured "Downloading and installing npm"
-  assertCapturedSuccess
+  assertCaptured "io.js no longer supported"
+  assertCapturedError
 }
 
 testSpecificVersion() {


### PR DESCRIPTION
This removes support for apps still deploying with io.js. Most weeks see zero deploys of io.js so the impact here is expected to be very small. Those few apps that do deploy with io.js are opening themselves up to very significant security vulnerabilities and should update.

![Hyper 2019-04-23 16-08-14](https://user-images.githubusercontent.com/175496/56621761-93e84d80-65e2-11e9-8ae3-c1ecc6ac9265.png)
