### PR TITLE
Add new make rule for smaller go binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ make test-heroku-16
 The tests are run via the vendored
 [shunit2](https://github.com/kward/shunit2)
 test framework.
+
+## Updating go binaries
+
+If you would like to develop and update the go binaries you will need to install 
+[go 1.12](https://golang.org/doc/install#install) and [upx](https://upx.github.io/)

--- a/makefile
+++ b/makefile
@@ -4,6 +4,14 @@ build:
 	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-darwin ./cmd/resolve-version
 	@GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-linux ./cmd/resolve-version
 
+build-production:
+	# build go binaries and then compress them
+	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-darwin ./cmd/resolve-version
+	@GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -v -o ./vendor/resolve-version-linux ./cmd/resolve-version
+	# https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/
+	upx --brute vendor/resolve-version-linux
+	upx --brute vendor/resolve-version-darwin
+
 test-binary:
 	go test -v ./cmd/... -tags=integration
 


### PR DESCRIPTION
Since we're checking the binaries into source, it's important that they are as small as possible. Following the instructions at https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/ we run `upx --brute` over each of the binaries

We see savings of ~70%

Before:
```
❯ ls -lh vendor/resolve-version-*
-rwxr-xr-x  1 jmorrell  SFDC\Domain Users   5.8M Apr 25 16:41 vendor/resolve-version-darwin
-rwxr-xr-x  1 jmorrell  SFDC\Domain Users   5.3M Apr 25 16:41 vendor/resolve-version-linux
```

After:
```
❯ ls -lh vendor/resolve-version-*
-rwxr-xr-x  1 jmorrell  SFDC\Domain Users   1.7M Apr 25 16:33 vendor/resolve-version-darwin
-rwxr-xr-x  1 jmorrell  SFDC\Domain Users   1.6M Apr 25 16:33 vendor/resolve-version-linux
```