### PR TITLE
Compare new semver logic for node binaries

### DIFF
--- a/test/run
+++ b/test/run
@@ -1085,6 +1085,7 @@ testBuildMetaData() {
 
   # log resolve logic dark-launch
   assertFileContains "resolve-matches-nodebin-yarn=true" $log_file
+  assertFileContains "resolve-matches-nodebin-node=true" $log_file
 }
 
 testFailingBuildMetaData() {


### PR DESCRIPTION
Follow-up to #661 

This dark-launches the new semver matching logic for determining which Node version to install. The new logic is run alongside the existing logic and it logs out if they return different results.