### PR TITLE
Deprecate nodebin in favor of go binary

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -148,7 +148,7 @@ install_bins() {
   echo ""
 
   warn_node_engine "$node_engine"
-  monitor "install-node-binary" install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node" "$(get_platform)"
+  monitor "install-node-binary" install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
   monitor "install-npm-binary" install_npm "$npm_engine" "$BUILD_DIR/.heroku/node" $NPM_LOCK
   node_version="$(node --version)"
   mcount "version.node.$node_version"
@@ -158,7 +158,7 @@ install_bins() {
   # has specified a version of yarn under "engines". We'll still
   # only install using yarn if there is a yarn.lock file
   if $YARN || [ -n "$yarn_engine" ]; then
-    monitor "install-yarn-binary" install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine" "$(get_platform)"
+    monitor "install-yarn-binary" install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
   fi
 
   if $YARN; then

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -12,12 +12,17 @@ resolve() {
   until [ $n -ge 5 ]
   do
     if output=$($RESOLVE "$binary" "$versionRequirement"); then
-        echo "$output"
-        return 0
+      echo "$output"
+      return 0
+    # don't retry if we get a negative result
+    elif [[ $output = "No result" ]]; then
+      return 1
+    elif [[ $output =~ ^Could\snot\sparse.* ]]; then
+      return 1
     else
-        n=$((n+1))
-        # break for a second with a linear backoff
-        sleep $((n+1))
+      n=$((n+1))
+      # break for a second with a linear backoff
+      sleep $((n+1))
     fi
   done
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -27,30 +27,16 @@ resolve() {
 install_yarn() {
   local dir="$1"
   local version=${2:-1.x}
-  local platform="$3"
-  local number url code nodebin_result resolve_result
+  local number url code resolve_result
 
   echo "Resolving yarn version $version..."
-  nodebin_result=$(curl --fail --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/yarn/$platform/latest.txt" || echo "failed")
   resolve_result=$(resolve yarn "$version" || echo "failed")
 
-  if [[ "$nodebin_result" == "failed" ]]; then
-    fail_bin_install yarn "$version" "$platform"
-  fi
-
-  read -r number url < <(echo "$nodebin_result")
-
-  # log out whether the new logic matches the old logic
-  if [[ "$nodebin_result" != "$resolve_result" ]]; then
-    meta_set "resolve-matches-nodebin-yarn" "false"
-  else
-    meta_set "resolve-matches-nodebin-yarn" "true"
-  fi
-
-  # log out when the new logic fails
   if [[ "$resolve_result" == "failed" ]]; then
-    meta_set "resolve-failed-yarn" "true"
+    fail_bin_install yarn "$version"
   fi
+
+  read -r number url < <(echo "$resolve_result")
 
   echo "Downloading and installing yarn ($number)..."
   code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
@@ -72,32 +58,18 @@ install_yarn() {
 install_nodejs() {
   local version=${1:-10.x}
   local dir="${2:?}"
-  local platform="$3"
-  local code os cpu nodebin_result resolve_result
+  local code os cpu resolve_result
 
   os=$(get_os)
   cpu=$(get_cpu)
 
   echo "Resolving node version $version..."
-  nodebin_result=$(curl --silent --fail --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt" || echo "failed")
   resolve_result=$(resolve node "$version" || echo "failed")
 
-  read -r number url < <(echo "$nodebin_result")
+  read -r number url < <(echo "$resolve_result")
 
-  if [[ "$nodebin_result" == "failed" ]]; then
-    fail_bin_install node "$version" "$platform"
-  fi
-
-  # log out whether the new logic matches the old logic
-  if [[ "$nodebin_result" != "$resolve_result" ]]; then
-    meta_set "resolve-matches-nodebin-node" "false"
-  else
-    meta_set "resolve-matches-nodebin-node" "true"
-  fi
-
-  # log out when the new logic fails
   if [[ "$resolve_result" == "failed" ]]; then
-    meta_set "resolve-failed-node" "true"
+    fail_bin_install node "$version"
   fi
 
   echo "Downloading and installing node $number..."

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -17,7 +17,7 @@ resolve() {
     # don't retry if we get a negative result
     elif [[ $output = "No result" ]]; then
       return 1
-    elif [[ $output =~ ^Could\snot\sparse.* ]]; then
+    elif [[ $output == "Could not parse"* ]] || [[ $output == "Could not get"* ]]; then
       return 1
     else
       n=$((n+1))

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -220,10 +220,9 @@ fail_bin_install() {
   local error
   local bin="$1"
   local version="$2"
-  local platform="$3"
 
-  # re-curl the result, saving off the reason for the failure this time
-  error=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$version" "https://nodebin.herokai.com/v1/$bin/$platform/latest.txt")
+  # re-request the result, saving off the reason for the failure this time
+  error=$(resolve "$bin" "$version")
 
   if [[ $error = "No result" ]]; then
     case $bin in

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -240,7 +240,7 @@ fail_bin_install() {
       yarn)
         echo "Could not find Yarn version corresponding to version requirement: $version";;
     esac
-  elif [[ $error == "Could not parse"* ]]; then
+  elif [[ $error == "Could not parse"* ]] || [[ $error == "Could not get"* ]]; then
     echo "Error: Invalid semantic version \"$version\""
   else
     echo "Error: Unknown error installing \"$version\" of $bin"

--- a/test/run
+++ b/test/run
@@ -1082,10 +1082,6 @@ testBuildMetaData() {
   assertFileContains "install-yarn-binary-memory=" $log_file
   assertFileContains "install-yarn-binary-time=" $log_file
   assertFileContains "node-build-success=true" $log_file
-
-  # log resolve logic dark-launch
-  assertFileContains "resolve-matches-nodebin-yarn=true" $log_file
-  assertFileContains "resolve-matches-nodebin-node=true" $log_file
 }
 
 testFailingBuildMetaData() {


### PR DESCRIPTION
The dark launched go binary logic is now matching the output of the nodebin service logic. 

This change removes the calls to the nodebin service and switches to the new logic.