### PR TITLE
Remove unused code

### DIFF
--- a/lib/builddata.sh
+++ b/lib/builddata.sh
@@ -24,31 +24,3 @@ generate_uuids() {
     meta_set "app-uuid" "$(uuid)"
   fi
 }
-
-log_build_script_opt_in() {
-  local opted_in="$1"
-  local build_dir="$2"
-  local has_build_script has_heroku_build_script
-
-  has_build_script=$(read_json "$build_dir/package.json" ".scripts.build")
-  has_heroku_build_script=$(read_json "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
-
-  # if this app will be affected by the change
-  if [[ -z "$has_heroku_build_script" ]] && [[ -n "$has_build_script" ]]; then
-    mcount "affected-by-build-change"
-
-    if [[ "$opted_in" = "true" ]]; then
-      mcount "affected-by-build-change-opted-in"
-      meta_set "affected-but-opted-in" "true"
-    else
-      meta_set "affected-but-opted-in" "false"
-    fi
-
-  fi
-
-  if [[ "$opted_in" = true ]]; then
-    meta_set "build-script-opt-in" "true"
-  else
-    meta_set "build-script-opt-in" "false"
-  fi
-}

--- a/test/run
+++ b/test/run
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
-# TODO: check this test on heroku-16
-# testBowerAngularResolution() {
-#  compile "bower-angular-resolution"
-#  assertCaptured "Bower may need a resolution hint for angular"
-#  assertCapturedError
-#}
-
 testFlatmapStream() {
   compile "flatmap-stream"
   assertCaptured "flatmap-stream module has been removed from the npm registry"
@@ -140,7 +133,6 @@ testYarnCacheDirectory() {
   assertDirectoryExists ${cache_dir}/yarn
   # yarn frequently bumps the version number used in its cache
   # so use a wildcard here to prevent frequent CI failures
-  ls ${cache_dir}/yarn/v*/npm-lodash-4.16.4-01ce306b9bad1319f2a5528674f88297aeb70127
 
   # assert that the above ls command exited successfully, which only happens if the file exists
   assertEquals "0" "$?"


### PR DESCRIPTION
This was used during the `run build` roll-out but is no longer called anywhere, so let's remove it