### PR TITLE
Fix issue with too many registered ssh keys

### DIFF
--- a/etc/ci-cleanup.sh
+++ b/etc/ci-cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [[ -n "$HEROKU_API_KEY" ]]; then 
+  heroku keys:remove "$USER@$(hostname)"
+fi

--- a/makefile
+++ b/makefile
@@ -40,6 +40,7 @@ hatchet:
 	@echo "Running hatchet integration tests..."
 	@bash etc/ci-setup.sh
 	@bash etc/hatchet.sh spec/ci/
+	@bash etc/ci-cleanup.sh
 	@echo ""
 
 nodebin-test:


### PR DESCRIPTION
When cribbing off of @jkutner for my CI setup, I neglected to copy this cleanup line: https://github.com/heroku/heroku-buildpack-java/blob/master/.travis.yml#L8

which results in hatchet tests occasionally failing in CI due to account limits on number of SSH keys 🙈 

This change adds a cleanup step that should resolve this issue