### PR TITLE
npm ci experiment

### DIFF
--- a/experiments
+++ b/experiments
@@ -1,1 +1,1 @@
-test=5
+use-npm-ci=5

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -113,6 +113,25 @@ yarn_prune_devdependencies() {
   fi
 }
 
+should_use_npm_ci() {
+  local build_dir=${1:-}
+  local npm_version
+
+   npm_version=$(npm --version)
+  # major_string will be ex: "4." "5." "10"
+  local major_string=${npm_version:0:2}
+  # strip any "."s from major_string
+  local major=${major_string//.}
+
+  # We should only run `npm ci` if all of the manifest files are there, and we are running at least npm 6.x
+  # `npm ci` was introduced in the 5.x line in 5.7.0, but this sees very little usage, < 5% of builds
+  if [[ -f "$build_dir/package.json" ]] && [[ -f "$build_dir/package-lock.json" ]] && (( major >= 6 )); then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 npm_node_modules() {
   local build_dir=${1:-}
   local production=${NPM_CONFIG_PRODUCTION:-false}
@@ -120,14 +139,22 @@ npm_node_modules() {
   if [ -e "$build_dir/package.json" ]; then
     cd "$build_dir" || return
 
-    if [ -e "$build_dir/package-lock.json" ]; then
-      echo "Installing node modules (package.json + package-lock)"
-    elif [ -e "$build_dir/npm-shrinkwrap.json" ]; then
-      echo "Installing node modules (package.json + shrinkwrap)"
+    if [[ "$(experiments_get "use-npm-ci")" == "true" ]] && [[ "$(should_use_npm_ci "$build_dir")" == "true" ]]; then
+      meta_set "supports-npm-ci" "true"
+      cd "$build_dir" || return
+      echo "Installing node modules"
+      monitor "npm-ci" npm ci --production="$production" --unsafe-perm --userconfig "$build_dir/.npmrc" 2>&1
     else
-      echo "Installing node modules (package.json)"
+      meta_set "supports-npm-ci" "false"
+      if [ -e "$build_dir/package-lock.json" ]; then
+        echo "Installing node modules (package.json + package-lock)"
+      elif [ -e "$build_dir/npm-shrinkwrap.json" ]; then
+        echo "Installing node modules (package.json + shrinkwrap)"
+      else
+        echo "Installing node modules (package.json)"
+      fi
+      monitor "npm-install" npm install --production="$production" --unsafe-perm --userconfig "$build_dir/.npmrc" 2>&1
     fi
-    monitor "npm-install" npm install --production="$production" --unsafe-perm --userconfig "$build_dir/.npmrc" 2>&1
   else
     echo "Skipping (no package.json)"
   fi

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -117,7 +117,7 @@ should_use_npm_ci() {
   local build_dir=${1:-}
   local npm_version
 
-   npm_version=$(npm --version)
+  npm_version=$(npm --version)
   # major_string will be ex: "4." "5." "10"
   local major_string=${npm_version:0:2}
   # strip any "."s from major_string
@@ -143,7 +143,7 @@ npm_node_modules() {
       meta_set "supports-npm-ci" "true"
       cd "$build_dir" || return
       echo "Installing node modules"
-      monitor "npm-ci" npm ci --production="$production" --unsafe-perm --userconfig "$build_dir/.npmrc" 2>&1
+      monitor "npm-install" npm ci --production="$production" --unsafe-perm --userconfig "$build_dir/.npmrc" 2>&1
     else
       meta_set "supports-npm-ci" "false"
       if [ -e "$build_dir/package-lock.json" ]; then

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -141,7 +141,6 @@ npm_node_modules() {
 
     if [[ "$(experiments_get "use-npm-ci")" == "true" ]] && [[ "$(should_use_npm_ci "$build_dir")" == "true" ]]; then
       meta_set "supports-npm-ci" "true"
-      cd "$build_dir" || return
       echo "Installing node modules"
       monitor "npm-install" npm ci --production="$production" --unsafe-perm --userconfig "$build_dir/.npmrc" 2>&1
     else

--- a/test/fixtures/node-10-npm-ci-no-lockfile/heroku-buildpack-experiments
+++ b/test/fixtures/node-10-npm-ci-no-lockfile/heroku-buildpack-experiments
@@ -1,0 +1,1 @@
+use-npm-ci=true

--- a/test/fixtures/node-10-npm-ci-no-lockfile/package.json
+++ b/test/fixtures/node-10-npm-ci-no-lockfile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts": {
+    "heroku-prebuild": "echo heroku-prebuild script",
+    "build": "echo build script",
+    "postinstall": "echo postinstall script",
+    "start": "node foo.js"
+  }
+}

--- a/test/fixtures/node-10-npm-ci/heroku-buildpack-experiments
+++ b/test/fixtures/node-10-npm-ci/heroku-buildpack-experiments
@@ -1,0 +1,1 @@
+use-npm-ci=true

--- a/test/fixtures/node-10-npm-ci/package-lock.json
+++ b/test/fixtures/node-10-npm-ci/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "hashish": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
+      "integrity": "sha1-bWC8b/r3Ebav1g5CbQd5iAFOZVQ=",
+      "requires": {
+        "traverse": ">=0.2.4"
+      }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    }
+  }
+}

--- a/test/fixtures/node-10-npm-ci/package.json
+++ b/test/fixtures/node-10-npm-ci/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts": {
+    "heroku-prebuild": "echo heroku-prebuild script",
+    "build": "echo build script",
+    "postinstall": "echo postinstall script",
+    "start": "node foo.js"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -1,6 +1,49 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testNpmCi() {
+  local log_file cache
+  log_file=$(mktemp)
+  cache=$(mktmpdir)
+
+  BUILDPACK_LOG_FILE="$log_file" compile "node-10-npm-ci" "$cache"
+
+   # make sure that build scripts are being called
+  assertCaptured "heroku-prebuild script"
+  assertCaptured "build script"
+  assertCaptured "postinstall script"
+  assertCapturedSuccess
+
+   # test logging
+  assertFileContains "experiment-use-npm-ci=true" "$log_file"
+  assertFileContains "supports-npm-ci=true" "$log_file"
+  assertFileContains "npm-ci-time=" "$log_file"
+  assertFileContains "npm-ci-memory=" "$log_file"
+
+   # test re-using the cache
+  echo "" > "$log_file"
+  BUILDPACK_LOG_FILE="$log_file" compile "node-10-npm-ci" "$cache"
+  assertCapturedSuccess
+}
+
+testNpmCiFallback() {
+  local log_file cache
+  log_file=$(mktemp)
+
+  # without a lockfile we should use "npm install" instead of "npm ci"
+  BUILDPACK_LOG_FILE="$log_file" compile "node-10-npm-ci-no-lockfile"
+
+  assertCapturedSuccess
+
+   # make sure we're in the experiment
+  assertFileContains "experiment-use-npm-ci=true" "$log_file"
+  # and detecting that we shouldn't use npm ci
+  assertFileContains "supports-npm-ci=false" "$log_file"
+  # and ran "npm install"
+  assertFileContains "npm-install-time=" "$log_file"
+  assertFileContains "npm-install-memory=" "$log_file"
+}
+
 testFlatmapStream() {
   compile "flatmap-stream"
   assertCaptured "flatmap-stream module has been removed from the npm registry"

--- a/test/run
+++ b/test/run
@@ -17,8 +17,8 @@ testNpmCi() {
    # test logging
   assertFileContains "experiment-use-npm-ci=true" "$log_file"
   assertFileContains "supports-npm-ci=true" "$log_file"
-  assertFileContains "npm-ci-time=" "$log_file"
-  assertFileContains "npm-ci-memory=" "$log_file"
+  assertFileContains "npm-install-time=" "$log_file"
+  assertFileContains "npm-install-memory=" "$log_file"
 
    # test re-using the cache
   echo "" > "$log_file"


### PR DESCRIPTION
Starts to resolve https://github.com/heroku/heroku-buildpack-nodejs/issues/522

This adds the new logic to use `npm ci` in place of `npm install` for apps that meet the requirements:

- Using npm 6.x or greater
- Have a `package-lock.json`

Here we're rolling this out to 5% of apps to compare the trade-offs in install time. It's likely that this will not result in much benefit until we also change the caching strategy to save the npm cache directory instead of `node_modules`, but let's start with this and gather real-world data instead of guessing.