### PR TITLE
Turn off npm ci experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+## v156 (2019-06-12)
+- Turn off npm ci experiment
+
 ## v155 (2019-06-06)
 - Add metadata for build steps (#677)
 

--- a/experiments
+++ b/experiments
@@ -1,1 +1,1 @@
-use-npm-ci=5
+use-npm-ci=0


### PR DESCRIPTION
Follow-up to #676 

This turns off the CI experiment by changing the rollout to 0% of apps, but keeps the logic in place for further development.