### PR TITLE
Don't suppress curl errors

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,7 +23,7 @@ STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 
 ### Load dependencies
 
-curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh' > "$STDLIB_FILE"
+curl --silent --show-error --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh' > "$STDLIB_FILE"
 # shellcheck source=/dev/null
 source "$STDLIB_FILE"
 # shellcheck source=lib/output.sh


### PR DESCRIPTION
Unfortunately, `--silent` suppresses not only output but also errors. `--silent --show-error` will suppress output but still show errors.

I ran into this with a build that was silently failing.

For comparison, before this fix:

```
$ podman run -it --rm -v $(pwd):/tmp/app gliderlabs/herokuish:latest bash
root@1c76891f2133:/# /bin/herokuish buildpack test
-----> Node.js app detected
root@1c76891f2133:/# curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh'
root@1c76891f2133:/#
```

After:

```
root@1c76891f2133:/# /bin/herokuish buildpack test
-----> Node.js app detected
curl: (6) Could not resolve host: lang-common.s3.amazonaws.com
root@1c76891f2133:/# curl --silent --show-error --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh'
curl: (6) Could not resolve host: lang-common.s3.amazonaws.com
```

Thanks!