### PR TITLE
Avoid proxy issues for version resolution

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -11,7 +11,10 @@ resolve() {
   # retry this up to 5 times in case of spurious failed API requests
   until [ $n -ge 5 ]
   do
-    if output=$($RESOLVE "$binary" "$versionRequirement"); then
+    # if a user sets the HTTP_PROXY ENV var, it could prevent this from making the S3 requests
+    # it needs here. We can ignore this proxy for aws urls with NO_PROXY
+    # see testAvoidHttpProxyVersionResolutionIssue test
+    if output=$(NO_PROXY="amazonaws.com" $RESOLVE "$binary" "$versionRequirement"); then
       echo "$output"
       return 0
     # don't retry if we get a negative result

--- a/test/run
+++ b/test/run
@@ -973,6 +973,14 @@ testNpmPrune56Issue() {
   assertCapturedSuccess
 }
 
+testAvoidHttpProxyVersionResolutionIssue() {
+  env_dir=$(mktmpdir)
+  # Set a non-sense http proxy address. This will cause version resolution to fail
+  echo "http://localhost:5001" > $env_dir/HTTP_PROXY
+  compile "node-10" "$(mktmpdir)" $env_dir
+  assertCapturedSuccess
+}
+
 testPluginInstallationBuildTime() {
   # The plugin should be installed for Node 8, 9, 10
   compile "node-8"


### PR DESCRIPTION
After #667 there were a couple of tickets where user builds were failing to resolve Node versions. This was due to an env var `HTTP_PROXY` which is set by the user and could prevent the API requests to `*.amazonaws.com` to fail.

I think there are two options here:

Move the [binary installation step](https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/compile#L180) before the [create environment step](https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/compile#L119). There are no reasons I can think of that someone would need to set env vars for the binary installation step, but this does run a small risk of breaking someone's build if I'm missing something

or, what this PR does:

set a `NO_PROXY` env var for the version resolution step, which prevents this behavior.