### PR TITLE
Log out number of js, jsx, and ts files

### DIFF
--- a/lib/builddata.sh
+++ b/lib/builddata.sh
@@ -30,6 +30,9 @@ log_project_info() {
   meta_set "uses-workspaces" "$(json_has_key "$build_dir/package.json" "workspaces")"
   # What workspaces are defined? Logs as: `["packages/*","a","b"]`
   meta_set "workspaces" "$(read_json "$build_dir/package.json" ".workspaces")"
+
+  # Count # of js, jsx, ts files to approximate project size, exclude any files in node_modules
+  meta_set "num_project_files" "$(find "$build_dir" -name '*.js' -o -name '*.ts' -o -name '*.jsx' | grep -v node_modules | wc -l | tr -d '[:space:]')"
 }
 
 generate_uuids() {

--- a/lib/builddata.sh
+++ b/lib/builddata.sh
@@ -32,7 +32,7 @@ log_project_info() {
   meta_set "workspaces" "$(read_json "$build_dir/package.json" ".workspaces")"
 
   # Count # of js, jsx, ts files to approximate project size, exclude any files in node_modules
-  meta_set "num_project_files" "$(find "$build_dir" -name '*.js' -o -name '*.ts' -o -name '*.jsx' | grep -v node_modules | wc -l | tr -d '[:space:]')"
+  meta_set "num-project-files" "$(find "$build_dir" -name '*.js' -o -name '*.ts' -o -name '*.jsx' | grep -cv node_modules | tr -d '[:space:]')"
 }
 
 generate_uuids() {

--- a/lib/builddata.sh
+++ b/lib/builddata.sh
@@ -24,6 +24,7 @@ log_initial_state() {
 
 # Log out information about the build that we can read from package.json
 log_project_info() {
+  local time
   local build_dir="$1"
 
   # Does this project use "workspaces"?
@@ -31,8 +32,12 @@ log_project_info() {
   # What workspaces are defined? Logs as: `["packages/*","a","b"]`
   meta_set "workspaces" "$(read_json "$build_dir/package.json" ".workspaces")"
 
+  # just to be sure this isn't disruptive, let's time it. This can be removed later once we've
+  # established that this is quick for all projects.
+  time=$(nowms)
   # Count # of js, jsx, ts files to approximate project size, exclude any files in node_modules
   meta_set "num-project-files" "$(find "$build_dir" -name '*.js' -o -name '*.ts' -o -name '*.jsx' | grep -cv node_modules | tr -d '[:space:]')"
+  meta_time "count-file-time" "$time"
 }
 
 generate_uuids() {

--- a/test/run
+++ b/test/run
@@ -1093,6 +1093,7 @@ testBuildMetaData() {
   assertFileContains "build-step=finished" $log_file
   assertFileContains "uses-workspaces=false" $log_file
   assertFileContains "workspaces=" $log_file
+  assertFileContains "num-project-files=0" $log_file
 
   # binary versions
   assertFileContains "node-version-request=10.x" $log_file


### PR DESCRIPTION
When looking at aggregate builds, it can be hard to know which builds correspond to "toy" apps vs "real" or even "large" apps

One proxy for this can be the # of individual files in the repo. This adds up all of the javascript, typescript, and jsx files and adds that to the build info. This is not expected to be a definitive metric, but to understand approximately how build times change as projects grow.