### PR TITLE
Roll out native yarn caching to a small test group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+## v160 (2019-08-06)
+- Roll out A/B test of native yarn caching to a small set of apps
+
 ## v159 (2019-08-01)
 - Updates to metadata saved (#689, #690)
 - Add native yarn cache caching behind a flag (#691)

--- a/features
+++ b/features
@@ -1,2 +1,2 @@
 use-npm-ci=0
-cache-native-yarn-cache=0
+cache-native-yarn-cache=5


### PR DESCRIPTION
This rolls the changes in #691 out to 5% of apps