### PR TITLE
Fix hatchet tests due to Node 12.8.0

### DIFF
--- a/spec/fixtures/repos/node-10-metrics/src/index.js
+++ b/spec/fixtures/repos/node-10-metrics/src/index.js
@@ -45,11 +45,11 @@ const server = http.createServer((req, res) => {
     .then(getNextMetricsEvent())
     .then(data => {
       res.setHeader('Content-Type', 'application/json');
-      res.end(data); 
+      res.end(data);
     })
     .catch(() => {
       res.statusCode = 500;
-      res.end("Something went wrong"); 
+      res.end("Something went wrong");
     });
 });
 
@@ -61,9 +61,11 @@ const metricsListener = http.createServer((req, res) => {
   if (req.method == 'POST') {
     let body = '';
     req.on('data', (data) => body += data);
-    req.on('end', () => Events.emit('metrics', body));
-    res.statusCode = 200;
-    res.end();
+    req.on('end', () => {
+      res.statusCode = 200;
+      res.end();
+      Events.emit('metrics', body)
+    });
   }
 });
 

--- a/spec/fixtures/repos/node-11-metrics/src/index.js
+++ b/spec/fixtures/repos/node-11-metrics/src/index.js
@@ -45,11 +45,11 @@ const server = http.createServer((req, res) => {
     .then(getNextMetricsEvent())
     .then(data => {
       res.setHeader('Content-Type', 'application/json');
-      res.end(data); 
+      res.end(data);
     })
     .catch(() => {
       res.statusCode = 500;
-      res.end("Something went wrong"); 
+      res.end("Something went wrong");
     });
 });
 
@@ -61,9 +61,11 @@ const metricsListener = http.createServer((req, res) => {
   if (req.method == 'POST') {
     let body = '';
     req.on('data', (data) => body += data);
-    req.on('end', () => Events.emit('metrics', body));
-    res.statusCode = 200;
-    res.end();
+    req.on('end', () => {
+      res.statusCode = 200;
+      res.end();
+      Events.emit('metrics', body)
+    });
   }
 });
 

--- a/spec/fixtures/repos/node-12-metrics/src/index.js
+++ b/spec/fixtures/repos/node-12-metrics/src/index.js
@@ -45,11 +45,11 @@ const server = http.createServer((req, res) => {
     .then(getNextMetricsEvent())
     .then(data => {
       res.setHeader('Content-Type', 'application/json');
-      res.end(data); 
+      res.end(data);
     })
     .catch(() => {
       res.statusCode = 500;
-      res.end("Something went wrong"); 
+      res.end("Something went wrong");
     });
 });
 
@@ -61,9 +61,11 @@ const metricsListener = http.createServer((req, res) => {
   if (req.method == 'POST') {
     let body = '';
     req.on('data', (data) => body += data);
-    req.on('end', () => Events.emit('metrics', body));
-    res.statusCode = 200;
-    res.end();
+    req.on('end', () => {
+      res.statusCode = 200;
+      res.end();
+      Events.emit('metrics', body)
+    });
   }
 });
 

--- a/spec/fixtures/repos/node-8-metrics/src/index.js
+++ b/spec/fixtures/repos/node-8-metrics/src/index.js
@@ -45,11 +45,11 @@ const server = http.createServer((req, res) => {
     .then(getNextMetricsEvent())
     .then(data => {
       res.setHeader('Content-Type', 'application/json');
-      res.end(data); 
+      res.end(data);
     })
     .catch(() => {
       res.statusCode = 500;
-      res.end("Something went wrong"); 
+      res.end("Something went wrong");
     });
 });
 
@@ -61,9 +61,11 @@ const metricsListener = http.createServer((req, res) => {
   if (req.method == 'POST') {
     let body = '';
     req.on('data', (data) => body += data);
-    req.on('end', () => Events.emit('metrics', body));
-    res.statusCode = 200;
-    res.end();
+    req.on('end', () => {
+      res.statusCode = 200;
+      res.end();
+      Events.emit('metrics', body)
+    });
   }
 });
 

--- a/spec/fixtures/repos/node-9-metrics/src/index.js
+++ b/spec/fixtures/repos/node-9-metrics/src/index.js
@@ -45,11 +45,11 @@ const server = http.createServer((req, res) => {
     .then(getNextMetricsEvent())
     .then(data => {
       res.setHeader('Content-Type', 'application/json');
-      res.end(data); 
+      res.end(data);
     })
     .catch(() => {
       res.statusCode = 500;
-      res.end("Something went wrong"); 
+      res.end("Something went wrong");
     });
 });
 
@@ -61,9 +61,11 @@ const metricsListener = http.createServer((req, res) => {
   if (req.method == 'POST') {
     let body = '';
     req.on('data', (data) => body += data);
-    req.on('end', () => Events.emit('metrics', body));
-    res.statusCode = 200;
-    res.end();
+    req.on('end', () => {
+      res.statusCode = 200;
+      res.end();
+      Events.emit('metrics', body)
+    });
   }
 });
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ RSpec.configure do |config|
 end
 
 def successful_body(app, options = {})
-  retry_limit = options[:retry_limit] || 100 
+  retry_limit = options[:retry_limit] || 100
   path = options[:path] ? "/#{options[:path]}" : ''
   Excon.get("http://#{app.name}.herokuapp.com#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit).body
 end
@@ -68,7 +68,7 @@ def resolve_all_supported_node_versions(options = {})
 end
 
 def version_supports_metrics(version)
-  SemVersion.new(version).satisfies?('>= 8.0.0') && SemVersion.new(version).satisfies?('< 12.0.0')
+  SemVersion.new(version).satisfies?('>= 8.0.0') && SemVersion.new(version).satisfies?('< 13.0.0')
 end
 
 def get_test_versions


### PR DESCRIPTION
Hatchet metrics tests began failing with Node `12.8.0`. This fixes two issues:

- Node `12.x` wasn't being tested with the metrics plugin before being released because it was being filtered out by [this line](https://github.com/heroku/heroku-buildpack-nodejs/blob/master/spec/spec_helper.rb), which wasn't updated when Node 12 came out. This would have caught the regression when `12.8.0` was released.

- Node `12.8.0` is not firing the `request` `end` event when the response is sent immediately as in the following code:

```
let body = '';
req.on('data', (data) => body += data);
req.on('end', () => Events.emit('metrics', body));
res.statusCode = 200;
res.end();
```

Here, `res.end` is called immediately on receiving the request before the body data uploads and is received. In testing this in Node `12.8.0`, we received the `data` event, but `end` would never be called.

Changing it so that we only send the response once the entire request has arrived resolves the issue:

```
let body = '';
req.on('data', (data) => body += data);
req.on('end', () => {
  res.statusCode = 200;
  res.end();
  Events.emit('metrics', body)
});
```