### PR TITLE
WIP: cloudbuilds based steps artefact copying

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -340,16 +340,10 @@ warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"
 warn_old_npm_lockfile $NPM_LOCK
 
-header "PWD $(pwd)!" | output "$LOG_FILE"
-target_src=$(read_json "$BUILD_DIR/package.json" ".pipeline.src")
-target_dest=$(read_json "$BUILD_DIR/package.json" ".pipeline.dest")
-cp -Rf  "$target_src" "$target_dest"
-cp "$BUILDPACK_LOG_FILE" "$target_dest"
-
 meta_set "build-step" "finished"
 log_meta_data >> "$BUILDPACK_LOG_FILE"
 
-
+header "PWD $(pwd)!" | output "$LOG_FILE"
 if json_has_key "$BUILD_DIR/package.json" ".pipeline"; then
   target_src=$(read_json "$BUILD_DIR/package.json" ".pipeline.src")
   target_dest=$(read_json "$BUILD_DIR/package.json" ".pipeline.dest")

--- a/bin/compile
+++ b/bin/compile
@@ -341,6 +341,7 @@ warn_old_npm_lockfile $NPM_LOCK
 meta_set "build-step" "finished"
 log_meta_data >> "$BUILDPACK_LOG_FILE"
 
+header "PWD $(pwd)!" | output "$LOG_FILE"
 if json_has_key "$BUILD_DIR/package.json" ".pipeline"; then
   target_src=$(read_json "$BUILD_DIR/package.json" ".pipeline.src")
   target_dest=$(read_json "$BUILD_DIR/package.json" ".pipeline.dest")

--- a/bin/compile
+++ b/bin/compile
@@ -347,5 +347,6 @@ if json_has_key "$BUILD_DIR/package.json" ".pipeline"; then
   if [[ -d "$target_src" ]] && [[ -d "$target_dest" ]]; then
     header "Publishing build for future stages: From $target_src to $target_dest" | output "$LOG_FILE"
     cp -Rf  "$target_src" "$target_dest"
+    cp "$BUILDPACK_LOG_FILE" "$target_dest"
   fi
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -329,7 +329,6 @@ install_plugin "$BP_DIR" "$BUILD_DIR"
 
 meta_set "build-step" "summarize"
 header "Build succeeded!" | output "$LOG_FILE"
-header "PWD $(pwd)!"
 
 mcount "compile"
 summarize_build | output "$LOG_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -340,10 +340,16 @@ warn_no_start "$BUILD_DIR"
 warn_unmet_dep "$LOG_FILE"
 warn_old_npm_lockfile $NPM_LOCK
 
+header "PWD $(pwd)!" | output "$LOG_FILE"
+target_src=$(read_json "$BUILD_DIR/package.json" ".pipeline.src")
+target_dest=$(read_json "$BUILD_DIR/package.json" ".pipeline.dest")
+cp -Rf  "$target_src" "$target_dest"
+cp "$BUILDPACK_LOG_FILE" "$target_dest"
+
 meta_set "build-step" "finished"
 log_meta_data >> "$BUILDPACK_LOG_FILE"
 
-header "PWD $(pwd)!" | output "$LOG_FILE"
+
 if json_has_key "$BUILD_DIR/package.json" ".pipeline"; then
   target_src=$(read_json "$BUILD_DIR/package.json" ".pipeline.src")
   target_dest=$(read_json "$BUILD_DIR/package.json" ".pipeline.dest")

--- a/bin/compile
+++ b/bin/compile
@@ -340,3 +340,12 @@ warn_old_npm_lockfile $NPM_LOCK
 
 meta_set "build-step" "finished"
 log_meta_data >> "$BUILDPACK_LOG_FILE"
+
+if json_has_key "$BUILD_DIR/package.json" ".pipeline"; then
+  target_src=$(read_json "$BUILD_DIR/package.json" ".pipeline.src")
+  target_dest=$(read_json "$BUILD_DIR/package.json" ".pipeline.dest")
+  if [[ -d "$target_src" ]] && [[ -d "$target_dest" ]]; then
+    header "Publishing build for future stages: From $target_src to $target_dest" | output "$LOG_FILE"
+    cp -Rf  "$target_src" "$target_dest"
+  fi
+fi

--- a/bin/compile
+++ b/bin/compile
@@ -329,6 +329,8 @@ install_plugin "$BP_DIR" "$BUILD_DIR"
 
 meta_set "build-step" "summarize"
 header "Build succeeded!" | output "$LOG_FILE"
+header "PWD $(pwd)!"
+
 mcount "compile"
 summarize_build | output "$LOG_FILE"
 meta_set "node-build-success" "true"


### PR DESCRIPTION
The intention of these changes are to allow for GCP Cloudbuilds copy steps.

package.json
```
{
   "name": "node application",
   "version": "0.1.0",
   "private": true,
   "pipeline": {
      "src": "/tmp/build",
      "dest": "/tmp/target"
   }
```

I would like to have a transparent copy of the build output to enable buildpacks to be used on GCP Cloudbuilds.

when I execute my heroku build, I do not manage to copy the build output and the code in the pull request does not run.

However the following works, but is not desired.
```json
"scripts": {
     "postbuild": "echo $(pwd) && cp -r build /tmp/target",
}
```

