### PR TITLE
Replace broken kb.heroku.com links with help.heroku.com shortlinks

### DIFF
--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -139,7 +139,7 @@ fail_multiple_lockfiles() {
          the package-lock.json file.
 
          $ git rm package-lock.json
-    " https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-conflicting-lock-files
+    " https://help.heroku.com/0KU2EM53
     fail
   fi
 
@@ -163,7 +163,7 @@ fail_multiple_lockfiles() {
        - yarn.lock
        - package-lock.json
        - npm-shrinkwrap.json
-    " https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-conflicting-lock-files
+    " https://help.heroku.com/0KU2EM53
     fail
   fi
 }
@@ -211,7 +211,7 @@ fail_yarn_lockfile_outdated() {
        $ git add yarn.lock
        $ git commit -m \"Updated Yarn lockfile\"
        $ git push heroku master
-    " https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-an-outdated-yarn-lockfile
+    " https://help.heroku.com/TXYS53YJ
     fail
   fi
 }
@@ -278,7 +278,7 @@ fail_node_install() {
        \"engines\": {
          \"node\": \"6.11.1\"
        }
-    " https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-no-matching-node-versions
+    " https://help.heroku.com/6235QYN4/
     fail
   fi
 }
@@ -314,7 +314,7 @@ fail_yarn_install() {
        \"engines\": {
          \"yarn\": \"1.x\"
        }
-    " https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-no-matching-yarn-versions
+    " https://help.heroku.com/8MEL050H
     fail
   fi
 }
@@ -334,7 +334,7 @@ fail_invalid_semver() {
 
        However you have specified a version requirement that is not a valid
        semantic version.
-    " https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-an-invalid-semver-requirement
+    " https://help.heroku.com/0ZIOF3ST
     fail
   fi
 }
@@ -466,7 +466,7 @@ log_other_failures() {
        way into event-stream, a popular npm package. After triaging the malware,
        npm responded by removing flatmap-stream and event-stream@3.3.6 from the Registry
        and taking ownership of the event-stream package to prevent further abuse.
-      " https://kb.heroku.com/4OM7X18J/why-am-i-seeing-npm-404-errors-for-event-stream-flatmap-stream-in-my-build-logs
+      " https://help.heroku.com/4OM7X18J
       fail
     fi
 

--- a/test/run
+++ b/test/run
@@ -47,7 +47,6 @@ testNpmCiFallback() {
 testFlatmapStream() {
   compile "flatmap-stream"
   assertCaptured "flatmap-stream module has been removed from the npm registry"
-  assertCaptured "why-am-i-seeing-npm-404-errors"
   assertCapturedError
 }
 

--- a/test/run
+++ b/test/run
@@ -270,7 +270,7 @@ testYarnInvalid() {
   assertCaptured "Resolving yarn version 0.171"
   assertCaptured "Could not find Yarn version corresponding to version requirement: 0.171"
   assertCaptured "No matching version found for Yarn: 0.171"
-  assertCaptured "https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-no-matching-yarn-versions"
+  assertCaptured "https://help.heroku.com/8MEL050H"
   assertCapturedError
 }
 
@@ -279,7 +279,7 @@ testYarnSemverInvalid() {
   assertCaptured "Resolving yarn version 0.17q"
   assertCaptured "Error: Invalid semantic version \"0.17q\""
   assertCaptured "Invalid semver requirement"
-  assertCaptured "https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-an-invalid-semver-requirement"
+  assertCaptured "https://help.heroku.com/0ZIOF3ST"
   assertCapturedError
 }
 
@@ -303,7 +303,7 @@ testErrorYarnAndNpmLockfiles() {
   assertNotCaptured "Creating runtime environment"
   assertCaptured "Two different lockfiles found: package-lock.json and yarn.lock"
   assertCaptured "Both npm and yarn have created lockfiles"
-  assertCaptured "https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-conflicting-lock-files"
+  assertCaptured "https://help.heroku.com/0KU2EM53"
   assertCapturedError
 }
 
@@ -312,7 +312,7 @@ testErrorYarnAndNpmShrinkwrap() {
   assertNotCaptured "Creating runtime environment"
   assertCaptured "Two different lockfiles found"
   assertCaptured "Please make sure there is only one of the following files"
-  assertCaptured "https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-conflicting-lock-files"
+  assertCaptured "https://help.heroku.com/0KU2EM53"
   assertCapturedError
 }
 
@@ -320,7 +320,7 @@ testYarnLockfileOutOfDate() {
   compile "yarn-lockfile-out-of-date"
   assertCaptured "Your lockfile needs to be updated"
   assertCaptured "Outdated Yarn lockfile"
-  assertCaptured "https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-an-outdated-yarn-lockfile"
+  assertCaptured "https://help.heroku.com/TXYS53YJ"
   assertCapturedError
 }
 
@@ -527,7 +527,7 @@ testInvalidNode() {
   assertCaptured "Resolving node version 0.11.333"
   assertCaptured "Could not find Node version corresponding to version requirement: 0.11.333"
   assertCaptured "No matching version found for Node: 0.11.333"
-  assertCaptured "https://kb.heroku.com/why-is-my-node-js-build-failing-because-of-no-matching-node-versions"
+  assertCaptured "https://help.heroku.com/6235QYN4"
   assertCapturedError
 }
 


### PR DESCRIPTION
The `kb.heroku.come` url schema has changed since these were added. Let's replace them with the short `help.heroku.com` urls which shouldn't change.