### PR TITLE
Add a minimal version of bin/report + tests

### DIFF
--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# bin/report <build-dir> <cache-dir> <env-dir>
+
+### Configure environment
+
+set -o errexit    # always exit on error
+set -o pipefail   # don't ignore exit codes when piping output
+
+BUILD_DIR=${1:-}
+
+export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
+
+has_binary_installed() {
+  [[ -x "$(command -v "$1")" ]]
+}
+
+if has_binary_installed "node"; then
+  node_version=$(node --version || echo "")
+else
+  node_version=""
+fi
+
+[ -f "$BUILD_DIR/yarn.lock" ] && package_manager="yarn" || package_manager="npm"
+
+cat << EOF
+node-version: $node_version
+package-manager: $package_manager
+EOF

--- a/test/run
+++ b/test/run
@@ -1219,6 +1219,21 @@ testBinDetectWarnings() {
   assertCapturedError "src/"
 }
 
+
+testBinReportEmptyDirectory() {
+  local empty_dir=$(mktmpdir)
+  # running bin/report on an empty directory should not fail
+  report "$empty_dir"
+  assertCapturedSuccess
+}
+
+testBinReportSuccess() {
+  compile_and_report "node-10"
+  assertCapturedSuccess
+  assertCaptured "package-manager: npm"
+  assertCaptured "node-version: v10"
+}
+
 # Utils
 
 pushd "$(dirname 0)" >/dev/null
@@ -1271,6 +1286,48 @@ compile() {
   fi
 
   capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
+}
+
+# run compile on a fixture and then capture the output of bin/report
+# ran after bin/compile completes, reusing the cache and env dirs. Note
+# that the output of bin/compile will not be captured
+compile_and_report() {
+  default_process_types_cleanup
+  cache_dir=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  bp_dir=$(mktmpdir)
+  cp -a "$(pwd)"/* ${bp_dir}
+
+  compile_dir=$(mktmpdir)
+  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
+
+  # if there isn't a features override, add an empty one to ensure
+  # that any features will not influence tests unless they are
+  # explicitly defined
+  if [[ ! -f "${compile_dir}/heroku-buildpack-features" ]]; then
+    touch "${compile_dir}/heroku-buildpack-features"
+  fi
+
+  ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3 > /dev/null 2>/dev/null
+  capture ${bp_dir}/bin/report ${compile_dir} ${2:-$(mktmpdir)} $3
+}
+
+# Run bin/report on a set of given directories without first invoking bin/compile
+# This is useful because in the case of a buildpack bug, you cannot trust that
+# any binaries will be installed or any part of the cache available, and bin/report
+# should be resilient in that case.
+report() {
+  default_process_types_cleanup
+
+  compile_dir=${1:-$(mktmpdir)}
+  cache_dir=${2:-$(mktmpdir)}
+  env_dir=${3:-$(mktmpdir)}
+
+  bp_dir=$(mktmpdir)
+  cp -a "$(pwd)"/* ${bp_dir}
+
+  capture ${bp_dir}/bin/report ${compile_dir} ${cache_dir} ${env_dir}
 }
 
 testCompile() {


### PR DESCRIPTION
This adds a minimal prototype `bin/report`. I expect `bin/report` itself will evolve rapidly, so the main focus was adding some way of testing this new script.