### PR TITLE
Avoid issues in environments requiring proxies for all connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,32 @@ test framework.
 
 If you would like to develop and update the go binaries you will need to install 
 [go 1.12](https://golang.org/doc/install#install) and [upx](https://upx.github.io/)
+
+## Proxy Issues
+
+If your builds are not completing and have errors you may need to examine your build environment for `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. A few examples of build output that may indicate issues with these values are below.
+
+```
+// ... 
+-----> Installing binaries
+       engines.node (package.json):  10
+       engines.npm (package.json):   unspecified (use default)
+
+       Resolving node version 10...
+       Error: Unknown error installing "10" of node
+
+-----> Build failed
+// ... 
+```
+
+```
+// ... 
+-----> Node.js app detected
+curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to lang-common.s3.amazonaws.com:443
+// ... 
+```
+
+If the environment where you are running the buildpack does not require a proxy to be used for HTTP connections you should try setting
+the `NO_PROXY` environment variable to `amazonaws.com`, i.e. running the command `export NO_PROXY=amazonaws.com` immediatly before executing
+the buildpack or by setting that environment value inside the buildpack. If you find `HTTP_PROXY` and `HTTPS_PROXY` environment variables and do not need a proxy in your build environment then the environment
+variables should be removed.

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -12,9 +12,11 @@ resolve() {
   until [ $n -ge 5 ]
   do
     # if a user sets the HTTP_PROXY ENV var, it could prevent this from making the S3 requests
-    # it needs here. We can ignore this proxy for aws urls with NO_PROXY
-    # see testAvoidHttpProxyVersionResolutionIssue test
-    if output=$(NO_PROXY="amazonaws.com" $RESOLVE "$binary" "$versionRequirement"); then
+    # it needs here. We can ignore this proxy for aws urls with NO_PROXY. Some environments
+    # require a proxy for all HTTP requests, so the NO_PROXY ENV var should be set outside the
+    # script by the user
+    # see testAvoidHttpProxyVersionResolutionIssue test and README
+    if output=$($RESOLVE "$binary" "$versionRequirement"); then
       echo "$output"
       return 0
     # don't retry if we get a negative result

--- a/test/run
+++ b/test/run
@@ -990,6 +990,9 @@ testAvoidHttpProxyVersionResolutionIssue() {
   env_dir=$(mktmpdir)
   # Set a non-sense http proxy address. This will cause version resolution to fail
   echo "http://localhost:5001" > $env_dir/HTTP_PROXY
+  # Set the NO_PROXY value, as described in documentation. This will exclude the domain
+  #  from the proxy
+  echo "amazonaws.com" > $env_dir/NO_PROXY
   compile "node-10" "$(mktmpdir)" $env_dir
   assertCapturedSuccess
 }


### PR DESCRIPTION
Closes #703

In environments requiring a proxy for all HTTP requests the `NO_PROXY` variable breaks all builds. Because it is being set inline for the command execution there is nothing a user can do to override the value. The issue can be resolved by removing the variable from the script and instead encouraging users to set their environment variables correctly.

I have updated the test to verify that having a proxy and setting the `NO_PROXY` environment variable still allows resolution to occur. I have also added a section to the README detail some of the error messages one might see and what steps they can try.