### PR TITLE
Extend bin/report

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -148,10 +148,6 @@ install_bins() {
   meta_set "npm-version-request" "$npm_engine"
   meta_set "yarn-version-request" "$yarn_engine"
 
-  meta_set "node-version-request" "$node_engine"
-  meta_set "npm-version-request" "$npm_engine"
-  meta_set "yarn-version-request" "$yarn_engine"
-
   echo "engines.node (package.json):  ${node_engine:-unspecified}"
   echo "engines.npm (package.json):   ${npm_engine:-unspecified (use default)}"
   if $YARN; then

--- a/bin/report
+++ b/bin/report
@@ -7,8 +7,44 @@ set -o errexit    # always exit on error
 set -o pipefail   # don't ignore exit codes when piping output
 
 BUILD_DIR=${1:-}
+CACHE_DIR=${2:-}
+
+### Load dependencies
+
+# shellcheck source=vendor/stdlib_v7.sh
+source "$BP_DIR/vendor/stdlib_v7.sh"
+# shellcheck source=lib/output.sh
+source "$BP_DIR/lib/output.sh"
+# shellcheck source=lib/monitor.sh
+source "$BP_DIR/lib/monitor.sh"
+# shellcheck source=lib/environment.sh
+source "$BP_DIR/lib/environment.sh"
+# shellcheck source=lib/failure.sh
+source "$BP_DIR/lib/failure.sh"
+# shellcheck source=lib/binaries.sh
+source "$BP_DIR/lib/binaries.sh"
+# shellcheck source=lib/json.sh
+source "$BP_DIR/lib/json.sh"
+# shellcheck source=lib/cache.sh
+source "$BP_DIR/lib/cache.sh"
+# shellcheck source=lib/dependencies.sh
+source "$BP_DIR/lib/dependencies.sh"
+# shellcheck source=lib/plugin.sh
+source "$BP_DIR/lib/plugin.sh"
+# shellcheck source=lib/uuid.sh
+source "$BP_DIR/lib/uuid.sh"
+# shellcheck source=lib/kvstore.sh
+source "$BP_DIR/lib/kvstore.sh"
+# shellcheck source=lib/metadata.sh
+source "$BP_DIR/lib/metadata.sh"
+# shellcheck source=lib/features.sh
+source "$BP_DIR/lib/features.sh"
+# shellcheck source=lib/builddata.sh
+source "$BP_DIR/lib/builddata.sh"
 
 export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
+
+meta_init "$CACHE_DIR"
 
 has_binary_installed() {
   [[ -x "$(command -v "$1")" ]]

--- a/bin/report
+++ b/bin/report
@@ -8,6 +8,7 @@ set -o pipefail   # don't ignore exit codes when piping output
 
 BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
+BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
 ### Load dependencies
 
@@ -55,7 +56,8 @@ kv_pair() {
   key="$1"
   value="$2"
   if [[ -n "$2" ]]; then
-    output="$output$1: $2\n"
+    output="$output
+$1: $2"
   fi
 }
 
@@ -94,11 +96,11 @@ kv_pair "heroku_postbuild_script_memory" "$(meta_get "heroku-postbuild-script-me
 
 # which package manager was used
 if [[ "$YARN" == "true" ]]; then
-  meta_set "node_package_manager" "yarn"
-  meta_set "has_lock_file" "true"
+  kv_pair "package_manager" "yarn"
+  kv_pair "has_lock_file" "true"
 else
-  meta_set "node_package_manager" "npm"
-  meta_set "has_lock_file" "$NPM_LOCK"
+  kv_pair "package_manager" "npm"
+  kv_pair "has_lock_file" "$NPM_LOCK"
 fi
 
 # does this project use "workspaces"?

--- a/bin/report
+++ b/bin/report
@@ -46,18 +46,29 @@ source "$BP_DIR/lib/builddata.sh"
 export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 
 meta_init "$CACHE_DIR"
+features_init "nodejs" "$BUILD_DIR" "$CACHE_DIR" "$BP_DIR/features"
 
 # a place to build up the output YAML structure
-output=""
+output=$(mktemp -t bin-reportXXXXXX)
 
 # append the key / value pair to $output, but skip if the value is empty
 kv_pair() {
   local key value
   key="$1"
   value="$2"
-  if [[ -n "$2" ]]; then
-    output="$output
-$1: $2"
+  if [[ -n "$value" ]]; then
+    echo "$key: $value" >> $output
+  fi
+}
+
+# use to safely quote strings
+kv_pair_string() {
+  local key value
+  key="$1"
+  value="$2"
+  if [[ -n "$value" ]]; then
+    value=$(echo $value | sed 's/"/\\"/g')
+    echo "$1: \"$value\"" >> $output
   fi
 }
 
@@ -65,61 +76,60 @@ has_binary_installed() {
   [[ -x "$(command -v "$1")" ]]
 }
 
-[ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
-[ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
-
-kv_pair "stack" "$STACK"
+kv_pair_string "stack" "$STACK"
 
 # the version of installed binaries
-has_binary_installed "node" && kv_pair "node_version" "$(node --version)"
-has_binary_installed "npm" && kv_pair "npm_version" "$(npm --version)"
-has_binary_installed "yarn" && kv_pair "yarn_version" "$(yarn --version)"
+has_binary_installed "node" && kv_pair_string "node_version" "$(node --version)"
+has_binary_installed "npm" && kv_pair_string "npm_version" "$(npm --version)"
+has_binary_installed "yarn" && kv_pair_string "yarn_version" "$(yarn --version)"
 
 # what versions were requested
-kv_pair "node_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.node")"
-kv_pair "npm_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.npm")"
-kv_pair "yarn_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.yarn")"
+kv_pair_string "node_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.node")"
+kv_pair_string "npm_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.npm")"
+kv_pair_string "yarn_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.yarn")"
 
 # build scripts
-kv_pair "build_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"build\"]")"
+kv_pair_string "start_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"start\"]")"
+kv_pair_string "build_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"build\"]")"
+kv_pair_string "postinstall_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"postinstall\"]")"
+kv_pair_string "heroku_prebuild_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-prebuild\"]")"
+kv_pair_string "heroku_postbuild_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-postbuild\"]")"
 kv_pair "build_script_time" "$(meta_get "build-script-time")"
 kv_pair "build_script_memory" "$(meta_get "build-script-memory")"
-kv_pair "postinstall_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"postinstall\"]")"
 kv_pair "postinstall_script_time" "$(meta_get "postinstall-script-time")"
 kv_pair "postinstall_script_memory" "$(meta_get "postinstall-script-memory")"
-kv_pair "heroku_prebuild_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-prebuild\"]")"
 kv_pair "heroku_prebuild_script_time" "$(meta_get "heroku-prebuild-script-time")"
 kv_pair "heroku_prebuild_script_memory" "$(meta_get "heroku-prebuild-script-memory")"
-kv_pair "heroku_postbuild_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-postbuild\"]")"
 kv_pair "heroku_postbuild_script_time" "$(meta_get "heroku-postbuild-script-time")"
 kv_pair "heroku_postbuild_script_memory" "$(meta_get "heroku-postbuild-script-memory")"
 
 # which package manager was used
 if [[ "$YARN" == "true" ]]; then
-  kv_pair "package_manager" "yarn"
-  kv_pair "has_lock_file" "true"
+  kv_pair_string "package_manager" "yarn"
 else
-  kv_pair "package_manager" "npm"
-  kv_pair "has_lock_file" "$NPM_LOCK"
+  kv_pair_string "package_manager" "npm"
 fi
+
+# We have to get this info from bin/compile since a lockfile will be generated if there wasn't one
+kv_pair "lock_file" "$(meta_get "has-node-lock-file")"
 
 # does this project use "workspaces"?
 kv_pair "uses_workspaces" "$(json_has_key "$BUILD_DIR/package.json" "workspaces")"
 # what workspaces are defined? Logs as: `["packages/*","a","b"]`
-kv_pair "workspaces" "$(read_json "$BUILD_DIR/package.json" ".workspaces")"
+kv_pair_string "workspaces" "$(read_json "$BUILD_DIR/package.json" ".workspaces")"
 # count # of js, jsx, ts, coffee, vue, and html files to approximate project size, exclude any files in node_modules
 kv_pair "num_project_files" "$(find "$BUILD_DIR" -name '*.js' -o -name '*.ts' -o -name '*.jsx' -o -name '*.coffee' -o -name '*.vue' -o -name '*.html' | grep -cv node_modules | tr -d '[:space:]')"
 # measure how large node_modules is on disk
 kv_pair "node_modules_size" "$(measure_size)"
 
 # pull metadata from the build
-kv_pair "build_step" "$(meta_get "build-step")"
+kv_pair_string "build_step" "$(meta_get "build-step")"
+kv_pair_string "failure" "$(meta_get "failure")"
+kv_pair_string "cache_status" "$(meta_get "cache-status")"
 kv_pair "build_time" "$(meta_get "build-time")"
-kv_pair "failure" "$(meta_get "failure")"
-kv_pair "cache_status" "$(meta_get "cache-status")"
 kv_pair "skipped_prune" "$(meta_get "skipped-prune")"
 kv_pair "cached_bower_components" "$(meta_get "cached-bower-components")"
-kv_pair "node_custom_cache_dirs" "$(meta_get "node-custom-cache-dirs")"
+kv_pair "custom_cache_dirs" "$(meta_get "node-custom-cache-dirs")"
 
 # pull execution data from the build
 kv_pair "install_node_binary_time" "$(meta_get "install-node-binary-time")"
@@ -147,4 +157,4 @@ features_list | tr ' ' '\n' | while read -r key; do
 done
 
 # emit the metadata on stdout
-echo "$output"
+cat $output

--- a/bin/report
+++ b/bin/report
@@ -46,19 +46,103 @@ export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 
 meta_init "$CACHE_DIR"
 
+# a place to build up the output YAML structure
+output=""
+
+# append the key / value pair to $output, but skip if the value is empty
+kv_pair() {
+  local key value
+  key="$1"
+  value="$2"
+  if [[ -n "$2" ]]; then
+    output="$output$1: $2\n"
+  fi
+}
+
 has_binary_installed() {
   [[ -x "$(command -v "$1")" ]]
 }
 
-if has_binary_installed "node"; then
-  node_version=$(node --version || echo "")
+[ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
+[ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
+
+kv_pair "stack" "$STACK"
+
+# the version of installed binaries
+has_binary_installed "node" && kv_pair "node_version" "$(node --version)"
+has_binary_installed "npm" && kv_pair "npm_version" "$(npm --version)"
+has_binary_installed "yarn" && kv_pair "yarn_version" "$(yarn --version)"
+
+# what versions were requested
+kv_pair "node_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.node")"
+kv_pair "npm_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.npm")"
+kv_pair "yarn_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.yarn")"
+
+# build scripts
+kv_pair "build_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"build\"]")"
+kv_pair "build_script_time" "$(meta_get "build-script-time")"
+kv_pair "build_script_memory" "$(meta_get "build-script-memory")"
+kv_pair "postinstall_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"postinstall\"]")"
+kv_pair "postinstall_script_time" "$(meta_get "postinstall-script-time")"
+kv_pair "postinstall_script_memory" "$(meta_get "postinstall-script-memory")"
+kv_pair "heroku_prebuild_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-prebuild\"]")"
+kv_pair "heroku_prebuild_script_time" "$(meta_get "heroku-prebuild-script-time")"
+kv_pair "heroku_prebuild_script_memory" "$(meta_get "heroku-prebuild-script-memory")"
+kv_pair "heroku_postbuild_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"heroku-postbuild\"]")"
+kv_pair "heroku_postbuild_script_time" "$(meta_get "heroku-postbuild-script-time")"
+kv_pair "heroku_postbuild_script_memory" "$(meta_get "heroku-postbuild-script-memory")"
+
+# which package manager was used
+if [[ "$YARN" == "true" ]]; then
+  meta_set "node_package_manager" "yarn"
+  meta_set "has_lock_file" "true"
 else
-  node_version=""
+  meta_set "node_package_manager" "npm"
+  meta_set "has_lock_file" "$NPM_LOCK"
 fi
 
-[ -f "$BUILD_DIR/yarn.lock" ] && package_manager="yarn" || package_manager="npm"
+# does this project use "workspaces"?
+kv_pair "uses_workspaces" "$(json_has_key "$BUILD_DIR/package.json" "workspaces")"
+# what workspaces are defined? Logs as: `["packages/*","a","b"]`
+kv_pair "workspaces" "$(read_json "$BUILD_DIR/package.json" ".workspaces")"
+# count # of js, jsx, ts, coffee, vue, and html files to approximate project size, exclude any files in node_modules
+kv_pair "num_project_files" "$(find "$BUILD_DIR" -name '*.js' -o -name '*.ts' -o -name '*.jsx' -o -name '*.coffee' -o -name '*.vue' -o -name '*.html' | grep -cv node_modules | tr -d '[:space:]')"
+# measure how large node_modules is on disk
+kv_pair "node_modules_size" "$(measure_size)"
 
-cat << EOF
-node-version: $node_version
-package-manager: $package_manager
-EOF
+# pull metadata from the build
+kv_pair "build_step" "$(meta_get "build-step")"
+kv_pair "build_time" "$(meta_get "build-time")"
+kv_pair "failure" "$(meta_get "failure")"
+kv_pair "cache_status" "$(meta_get "cache-status")"
+kv_pair "skipped_prune" "$(meta_get "skipped-prune")"
+kv_pair "cached_bower_components" "$(meta_get "cached-bower-components")"
+kv_pair "node_custom_cache_dirs" "$(meta_get "node-custom-cache-dirs")"
+
+# pull execution data from the build
+kv_pair "install_node_binary_time" "$(meta_get "install-node-binary-time")"
+kv_pair "install_node_binary_memory" "$(meta_get "install-node-binary-memory")"
+kv_pair "install_npm_binary_time" "$(meta_get "install-npm-binary-time")"
+kv_pair "install_npm_binary_memory" "$(meta_get "install-npm-binary-memory")"
+kv_pair "install_yarn_binary_time" "$(meta_get "install-yarn-binary-time")"
+kv_pair "install_yarn_binary_memory" "$(meta_get "install-yarn-binary-memory")"
+kv_pair "restore_cache_time" "$(meta_get "restore-cache-time")"
+kv_pair "save_cache_time" "$(meta_get "save-cache-time")"
+kv_pair "npm_install_time" "$(meta_get "npm-install-time")"
+kv_pair "npm_install_memory" "$(meta_get "npm-install-memory")"
+kv_pair "yarn_install_time" "$(meta_get "yarn-install-time")"
+kv_pair "yarn_install_memory" "$(meta_get "yarn-install-memory")"
+kv_pair "npm_prune_time" "$(meta_get "yarn-prune-time")"
+kv_pair "npm_prune_memory" "$(meta_get "yarn-prune-memory")"
+kv_pair "yarn_prune_time" "$(meta_get "yarn-prune-time")"
+kv_pair "yarn_prune_memory" "$(meta_get "yarn-prune-memory")"
+
+# save which features were turned on or off
+features_list | tr ' ' '\n' | while read -r key; do
+  if [[ -n $key ]]; then
+    kv_pair "feature-$key" "$(features_get "$key")"
+  fi
+done
+
+# emit the metadata on stdout
+echo "$output"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -31,11 +31,11 @@ run_if_present() {
       echo "Running $script_name (yarn)"
       # yarn will throw an error if the script is an empty string, so check for this case
       if [[ -n "$script" ]]; then
-        monitor "$script_name" yarn run "$script_name"
+        monitor "${script_name}-script" yarn run "$script_name"
       fi
     else
       echo "Running $script_name"
-      monitor "$script_name" npm run "$script_name" --if-present
+      monitor "${script_name}-script" npm run "$script_name" --if-present
     fi
   fi
 }

--- a/test/fixtures/complex-scripts/README.md
+++ b/test/fixtures/complex-scripts/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/complex-scripts/package.json
+++ b/test/fixtures/complex-scripts/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts": {
+    "start": "\"no closing quote",
+    "build": "concurrently \"npm run build-server\" npm run build-client",
+    "heroku-postbuild": "if [ -z \"${CI}\" ]; then yarn build-assets; fi",
+    "postinstall": "if [ \"${NODE_ENV}\" = \"staging\" ]; then env ASSETS_ENV=production gulp assets:build; else echo \"Skipped heroku-postbuild\"; fi"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -1071,12 +1071,12 @@ testMemoryMetrics() {
   compile "pre-post-build-scripts" "$(mktmpdir)" $env_dir
   assertFileContains "measure#buildpack.nodejs.exec.install-node-binary.time=" $metrics_log
   assertFileContains "measure#buildpack.nodejs.exec.install-npm-binary.time=" $metrics_log
-  assertFileContains "measure#buildpack.nodejs.exec.heroku-prebuild.time=" $metrics_log
-  assertFileContains "measure#buildpack.nodejs.exec.heroku-prebuild.memory=" $metrics_log
+  assertFileContains "measure#buildpack.nodejs.exec.heroku-prebuild-script.time=" $metrics_log
+  assertFileContains "measure#buildpack.nodejs.exec.heroku-prebuild-script.memory=" $metrics_log
   assertFileContains "measure#buildpack.nodejs.exec.npm-install.time=" $metrics_log
   assertFileContains "measure#buildpack.nodejs.exec.npm-install.memory=" $metrics_log
-  assertFileContains "measure#buildpack.nodejs.exec.heroku-postbuild.time=" $metrics_log
-  assertFileContains "measure#buildpack.nodejs.exec.heroku-postbuild.memory=" $metrics_log
+  assertFileContains "measure#buildpack.nodejs.exec.heroku-postbuild-script.time=" $metrics_log
+  assertFileContains "measure#buildpack.nodejs.exec.heroku-postbuild-script.memory=" $metrics_log
 
   # erase the metrics log
   echo "" > $metrics_log
@@ -1086,10 +1086,10 @@ testMemoryMetrics() {
   assertFileContains "measure#buildpack.nodejs.exec.yarn-install.memory=" "$metrics_log"
   assertFileContains "measure#buildpack.nodejs.exec.yarn-install.time=" "$metrics_log"
   # this fixture does not have pre or post-build scripts
-  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-prebuild.time=" $metrics_log
-  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-prebuild.memory=" $metrics_log
-  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-postbuild.time=" $metrics_log
-  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-postbuild.memory=" $metrics_log
+  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-prebuild-script.time=" $metrics_log
+  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-prebuild-script.memory=" $metrics_log
+  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-postbuild-script.time=" $metrics_log
+  assertFileNotContains "measure#buildpack.nodejs.exec.heroku-postbuild-script.memory=" $metrics_log
 }
 
 testBuildMetaData() {
@@ -1125,12 +1125,12 @@ testBuildMetaData() {
   assertFileContains "install-node-binary-time=" $log_file
   assertFileContains "install-npm-binary-time=" $log_file
   assertFileContains "install-npm-binary-memory=" $log_file
-  assertFileContains "heroku-prebuild-time=" $log_file
-  assertFileContains "heroku-prebuild-memory=" $log_file
+  assertFileContains "heroku-prebuild-script-time=" $log_file
+  assertFileContains "heroku-prebuild-script-memory=" $log_file
   assertFileContains "npm-install-time=" $log_file
   assertFileContains "npm-install-memory=" $log_file
-  assertFileContains "heroku-postbuild-time=" $log_file
-  assertFileContains "heroku-postbuild-memory=" $log_file
+  assertFileContains "heroku-postbuild-script-time=" $log_file
+  assertFileContains "heroku-postbuild-script-memory=" $log_file
   assertFileContains "npm-prune-memory=" $log_file
   assertFileContains "npm-prune-time=" $log_file
   assertFileContains "restore-cache-time=" $log_file

--- a/test/run
+++ b/test/run
@@ -1226,19 +1226,39 @@ testBinReportEmptyDirectory() {
   local empty_dir=$(mktmpdir)
   # running bin/report on an empty directory should not fail
   report "$empty_dir"
-  echo $STD_OUT
-  wc -l $STD_OUT
-  echo '---'
-  echo $(cat $STD_OUT)
-  echo '---'
   assertCapturedSuccess
 }
 
 testBinReportSuccess() {
   compile_and_report "node-10"
   assertCapturedSuccess
-  assertCaptured "package_manager: npm"
-  assertCaptured "node_version: v10"
+
+  assertCaptured "package_manager: \"npm\""
+  assertCaptured "node_version: \"v10"
+  assertCaptured "node_version_request: \"10.x\""
+  assertCaptured "lock_file: false"
+  assertCaptured "start_script: \"node foo.js\""
+  assertCaptured "num_project_files: 1"
+  assertCaptured "cache_status: \"not-found\""
+  assertCaptured "build_step: \"finished\""
+  assertCaptured "build_time:"
+  assertCaptured "install_node_binary_time:"
+
+  # there are no scripts in the fixture
+  assertNotCaptured "build_script:"
+  assertNotCaptured "heroku_postbuild_script:"
+  assertNotCaptured "heroku_prebuild_script:"
+}
+
+testBinReportScriptsWithQuotes() {
+  compile_and_report "complex-scripts"
+  assertCapturedSuccess
+
+  # quotes and escaped quotes are tricky, but should be escaped correctly
+  assertCaptured "start_script: \"\\\"no closing quote\""
+  assertCaptured "build_script: \"concurrently \\\"npm run build-server\\\" npm run build-client\""
+  assertCaptured "heroku_postbuild_script: \"if [ -z \\\"\${CI}\\\" ]; then yarn build-assets; fi\""
+  assertCaptured "postinstall_script: \"if [ \\\"\${NODE_ENV}\\\" = \\\"staging\\\" ]; then env ASSETS_ENV=production gulp assets:build; else echo \\\"Skipped heroku-postbuild\\\"; fi\""
 }
 
 # Utils
@@ -1300,8 +1320,8 @@ compile() {
 # that the output of bin/compile will not be captured
 compile_and_report() {
   default_process_types_cleanup
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
+  cache_dir=${2:-$(mktmpdir)}
+  env_dir=${3:-$(mktmpdir)}
 
   bp_dir=$(mktmpdir)
   cp -a "$(pwd)"/* ${bp_dir}
@@ -1316,8 +1336,8 @@ compile_and_report() {
     touch "${compile_dir}/heroku-buildpack-features"
   fi
 
-  ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3 > /dev/null 2>/dev/null
-  capture ${bp_dir}/bin/report ${compile_dir} ${2:-$(mktmpdir)} $3
+  ${bp_dir}/bin/compile ${compile_dir} $cache_dir $env_dir > /dev/null 2>/dev/null
+  capture ${bp_dir}/bin/report ${compile_dir} $cache_dir $env_dir
 }
 
 # Run bin/report on a set of given directories without first invoking bin/compile

--- a/test/run
+++ b/test/run
@@ -1226,14 +1226,19 @@ testBinReportEmptyDirectory() {
   local empty_dir=$(mktmpdir)
   # running bin/report on an empty directory should not fail
   report "$empty_dir"
+  echo $STD_OUT
+  wc -l $STD_OUT
+  echo '---'
+  echo $(cat $STD_OUT)
+  echo '---'
   assertCapturedSuccess
 }
 
 testBinReportSuccess() {
   compile_and_report "node-10"
   assertCapturedSuccess
-  assertCaptured "package-manager: npm"
-  assertCaptured "node-version: v10"
+  assertCaptured "package_manager: npm"
+  assertCaptured "node_version: v10"
 }
 
 # Utils

--- a/test/run
+++ b/test/run
@@ -1222,7 +1222,6 @@ testBinDetectWarnings() {
   assertCapturedError "src/"
 }
 
-
 testBinReportEmptyDirectory() {
   local empty_dir=$(mktmpdir)
   # running bin/report on an empty directory should not fail


### PR DESCRIPTION
Extends the `bin/report` output with all of the existing metadata we're capturing by looking at project files and pulling stored metadata from the cache