### PR TITLE
Add check for CLI plugin to publish script

### DIFF
--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -4,6 +4,18 @@ set -e
 
 BP_NAME=${1:-"heroku/nodejs"}
 
+# if buildpack-registry CLI plugin is not installed, show a help message and exit
+if heroku plugins | grep -qv "buildpack-registry"; then
+  echo "Releasing the buildpack requires the buildpack-registry CLI plugin."
+  echo "https://github.com/heroku/languages-team/blob/master/languages/nodejs/buildpack.md"
+  echo ""
+  echo "heroku plugins:install buildpack-registry"
+  echo ""
+  echo "Current CLI plugins:"
+  echo "$(heroku plugins)"
+  exit 1
+fi
+
 curVersion=$(heroku buildpacks:versions "$BP_NAME" | awk 'FNR == 3 { print $1 }')
 newVersion="v$((curVersion + 1))"
 

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -5,7 +5,7 @@ set -e
 BP_NAME=${1:-"heroku/nodejs"}
 
 # if buildpack-registry CLI plugin is not installed, show a help message and exit
-if heroku plugins | grep -qv "buildpack-registry"; then
+if heroku plugins | grep -q --invert-match "buildpack-registry"; then
   echo "Releasing the buildpack requires the buildpack-registry CLI plugin."
   echo "https://github.com/heroku/languages-team/blob/master/languages/nodejs/buildpack.md"
   echo ""

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -5,7 +5,7 @@ set -e
 BP_NAME=${1:-"heroku/nodejs"}
 
 # if buildpack-registry CLI plugin is not installed, show a help message and exit
-if heroku plugins | grep -q --invert-match "buildpack-registry"; then
+if ! heroku plugins | grep -q "buildpack-registry"; then
   echo "Releasing the buildpack requires the buildpack-registry CLI plugin."
   echo "https://github.com/heroku/languages-team/blob/master/languages/nodejs/buildpack.md"
   echo ""

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -12,7 +12,7 @@ if ! heroku plugins | grep -q "buildpack-registry"; then
   echo "heroku plugins:install buildpack-registry"
   echo ""
   echo "Current CLI plugins:"
-  echo "$(heroku plugins)"
+  heroku plugins
   exit 1
 fi
 


### PR DESCRIPTION
Extends the publish script to check to make sure that the `buildpack-registry` plugin is installed

If you don't have it installed, it looks like:

```
heroku-buildpack-nodejs git/check-node-plugins-before-publish*  
❯ bash etc/publish.sh                        
Releasing the buildpack requires the buildpack-registry CLI plugin.
https://github.com/heroku/languages-team/blob/master/languages/nodejs/buildpack.md

heroku plugins:install buildpack-registry

Current CLI plugins:
no plugins installed
```