### PR TITLE
Make Node 12 the default installed version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## master
+- Update default Node version to 12.x
 
 ## v164 (2019-10-17)
 - Avoid issues in environments requiring proxies for all connections (#708)

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -66,7 +66,7 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version=${1:-10.x}
+  local version=${1:-12.x}
   local dir="${2:?}"
   local code os cpu resolve_result
 

--- a/test/run
+++ b/test/run
@@ -110,8 +110,8 @@ testYarnRun() {
 testNoVersion() {
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "Resolving node version 10.x"
-  assertCaptured "Downloading and installing node 10."
+  assertCaptured "Resolving node version 12.x"
+  assertCaptured "Downloading and installing node 12."
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
In line with Node 12 being the active version, this makes the latest version of Node 12 installed unless specified by `.engines.node` from the `package.json`.