### PR TITLE
make minor upgrades to gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## master
+- Make minor upgrades to gems ([#735](https://github.com/heroku/heroku-buildpack-nodejs/pull/735))
 
 ## V166 (2019-12-16)
 - Add Node 13 metrics plugin ([#731](https://github.com/heroku/heroku-buildpack-nodejs/pull/731), [#732](https://github.com/heroku/heroku-buildpack-nodejs/pull/732))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     erubis (2.7.0)
-    excon (0.62.0)
-    heroics (0.0.24)
+    excon (0.71.0)
+    heroics (0.0.25)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (4.0.5)
+    heroku_hatchet (4.0.13)
       excon (~> 0)
       minitest-retry (~> 0.1.9)
       platform-api (~> 2)
@@ -23,19 +23,19 @@ GEM
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (1.1.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.11.3)
+    minitest (5.13.0)
     minitest-retry (0.1.9)
       minitest (>= 5.0)
-    moneta (0.8.1)
-    multi_json (1.13.1)
+    moneta (1.0.0)
+    multi_json (1.14.1)
     parallel (1.12.1)
     parallel_tests (2.22.0)
       parallel
-    platform-api (2.1.0)
-      heroics (~> 0.0.23)
-      moneta (~> 0.8.1)
+    platform-api (2.2.0)
+      heroics (~> 0.0.25)
+      moneta (~> 1.0.0)
     rake (12.3.1)
     repl_runner (0.0.3)
       activesupport
@@ -49,7 +49,7 @@ GEM
       rspec-core (> 3.3)
     rspec-support (3.8.0)
     sem_version (2.0.1)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     threaded (0.0.4)
     tzinfo (1.2.5)
@@ -67,4 +67,4 @@ DEPENDENCIES
   sem_version
 
 BUNDLED WITH
-   1.16.4
+   1.17.2


### PR DESCRIPTION
Mainly a delayed reaction to [this Excon CVE](https://github.com/heroku/heroku-buildpack-nodejs/network/alert/Gemfile.lock/excon/closed), but also running minor updates to gems for the Ruby tests.