### PR TITLE
Fix missing key when marking failure reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 - Make minor upgrades to gems ([#735](https://github.com/heroku/heroku-buildpack-nodejs/pull/735))
+- Fix typo in failure metadata call ([#737](https://github.com/heroku/heroku-buildpack-nodejs/pull/737))
 
 ## V166 (2019-12-16)
 - Add Node 13 metrics plugin ([#731](https://github.com/heroku/heroku-buildpack-nodejs/pull/731), [#732](https://github.com/heroku/heroku-buildpack-nodejs/pull/732))

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -323,7 +323,7 @@ fail_invalid_semver() {
   local log_file="$1"
   if grep -qi 'Error: Invalid semantic version' "$log_file"; then
     mcount "failures.invalid-semver-requirement"
-    meta_set "invalid-semver-requirement"
+    meta_set "failure" "invalid-semver-requirement"
     echo ""
     warn "Invalid semver requirement
 


### PR DESCRIPTION
I noticed while poking around that I forgot to set the `failure` key here, so this line is currently a no-op