### PR TITLE
Warn yarn2 with cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Node.js Buildpack Changelog
 
 ## feature: Yarn 2 support
-
-##2020-04-08
 - Add warning for detection of Yarn 2 usage with caching ([#755](https://github.com/heroku/heroku-buildpack-nodejs/pull/755))
 
 ## master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## feature: Yarn 2 support
 
+##2020-04-08
+- Add warning for detection of Yarn 2 usage with caching ([#755](https://github.com/heroku/heroku-buildpack-nodejs/pull/755))
+
 ## master
 - Update Travis badge to `master` and other changes in README ([#753](https://github.com/heroku/heroku-buildpack-nodejs/pull/753))
 

--- a/bin/compile
+++ b/bin/compile
@@ -96,6 +96,7 @@ meta_set "build-step" "init"
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
+YARN2=$(detect_yarn2 "$YARN" "$BUILD_DIR")
 
 ### Save build info
 features_init "nodejs" "$BUILD_DIR" "$CACHE_DIR" "$BP_DIR/features"
@@ -138,6 +139,12 @@ create_build_env
 [ ! "$YARN_CACHE_FOLDER" ] && YARN_CACHE_FOLDER=$(mktemp -d -t yarncache.XXXXX)
 [ ! "$NPM_CONFIG_CACHE" ] && NPM_CONFIG_CACHE=$(mktemp -d -t npmcache.XXXXX)
 export YARN_CACHE_FOLDER NPM_CONFIG_CACHE
+
+if [[ "$YARN2" == "true" && "$NODE_MODULES_CACHE" == "true" ]]; then
+  warn "
+    WARNING- You are using Yarn2. The buildpack won't cache, because yarn2 does not provide node modules.
+    "
+fi
 
 install_bins() {
   local node_engine npm_engine yarn_engine npm_version node_version

--- a/bin/compile
+++ b/bin/compile
@@ -142,7 +142,7 @@ export YARN_CACHE_FOLDER NPM_CONFIG_CACHE
 
 if [[ "$YARN2" == "true" && "$NODE_MODULES_CACHE" == "true" ]]; then
   warn "
-    WARNING- You are using Yarn2. The buildpack won't cache, because yarn2 does not provide node modules.
+    WARNING- You are using Yarn2. The buildpack won't cache, because Yarn 2 does not provide node modules.
     "
 fi
 

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -114,11 +114,7 @@ fail_iojs_unsupported() {
 }
 
 fail_yarn2_unsupported() {
-  local uses_yarn="$1"
-  local build_dir="$2"
-  local uses_yarn2
-
-  uses_yarn2=$(detect_yarn2 "$uses_yarn" "$build_dir")
+  local uses_yarn2="$1"
 
   if [[ "$uses_yarn2" == "true" ]]; then
     mcount "failures.yarn2-unsupported"

--- a/test/run
+++ b/test/run
@@ -590,6 +590,13 @@ testIoJs() {
   assertCapturedError
 }
 
+testYarn2WithCache() {
+  compile "yarn-2"
+  assertCaptured "The buildpack won't cache, because Yarn 2 does not provide node modules."
+  #expected failure with yarn incompatibility
+  assertCapturedError
+}
+
 testSpecificVersion() {
   compile "specific-version"
   assertCaptured "Resolving node version"


### PR DESCRIPTION
Warn user when Yarn 2 and NODE_MODULES_CACHE is used. 

This checks for when the user is using Yarn 2 and NODE_MODULES_CACHE and generates a warning that the buildpack won't cache. This PR also removes the use of a fail_yarn2_unsupported method since a failure should not occur if users are using Yarn 2. 