### PR TITLE
Add Heroku-20 to the Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 env:
   - TEST=shellcheck
+  - TEST=heroku-20 STACK=heroku-20
   - TEST=heroku-18 STACK=heroku-18
   - TEST=heroku-16 STACK=heroku-16
   - TEST=cedar-14 STACK=cedar-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 - Update Travis badge to `master` and other changes in README ([#753](https://github.com/heroku/heroku-buildpack-nodejs/pull/753))
+- Add Heroku-20 to the Travis test matrix ([#763](https://github.com/heroku/heroku-buildpack-nodejs/pull/763))
 
 ## v170 (2020-03-31)
 - Bump rake from 12.3.1 to 12.3.3 ([#742](https://github.com/heroku/heroku-buildpack-nodejs/pull/742))

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ heroku buildpacks:set <your-github-url>#your-branch
 ## Tests
 
 The buildpack tests use [Docker](https://www.docker.com/) to simulate
-Heroku's Heroku-16 and Heroku-18 containers.
+Heroku's stacks.
 
 To run the test suite:
 
@@ -88,8 +88,9 @@ make test
 Or to just test a specific stack:
 
 ```
-make test-heroku-16
-make test-heroku-18
+make heroku-16
+make heroku-18
+make heroku-20
 ```
 
 The tests are run via the vendored

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-test: heroku-18 heroku-16 cedar-14
+test: heroku-20 heroku-18 heroku-16 cedar-14
 
 build:
 	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./lib/vendor/resolve-version-darwin ./cmd/resolve-version
@@ -20,6 +20,11 @@ shellcheck:
 	@shellcheck -x lib/*.sh
 	@shellcheck -x ci-profile/**
 	@shellcheck -x etc/**
+
+heroku-20:
+	@echo "Running tests in docker (heroku-20)..."
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-20" heroku/heroku:20 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
+	@echo ""
 
 heroku-18:
 	@echo "Running tests in docker (heroku-18)..."


### PR DESCRIPTION
To confirm that the buildpack works on the preview of the new stack.

The readme example commands for running the tests have also been fixed to reflect the new makefile target names from #552.

Refs [W-7479929](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007Qx93IAC/view).