### PR TITLE
delete proxy issues section from readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 - display yarn engine log to build output when engine is provided in monorepo ([#771](https://github.com/heroku/heroku-buildpack-nodejs/pull/771))
+- move proxy issues section from readme to dev center ([#778](https://github.com/heroku/heroku-buildpack-nodejs/pull/778))
 
 ## v171 (2020-04-27)
 - Update Travis badge to `master` and other changes in README ([#753](https://github.com/heroku/heroku-buildpack-nodejs/pull/753))

--- a/README.md
+++ b/README.md
@@ -106,34 +106,3 @@ make heroku-20
 The tests are run via the vendored
 [shunit2](https://github.com/kward/shunit2)
 test framework.
-
-## Common Issues
-
-### Proxy Issues
-
-If your builds are not completing and have errors you may need to examine your build environment for `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. A few examples of build output that may indicate issues with these values are below.
-
-```
-// ...
------> Installing binaries
-       engines.node (package.json):  10
-       engines.npm (package.json):   unspecified (use default)
-
-       Resolving node version 10...
-       Error: Unknown error installing "10" of node
-
------> Build failed
-// ...
-```
-
-```
-// ...
------> Node.js app detected
-curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to lang-common.s3.amazonaws.com:443
-// ...
-```
-
-If the environment where you are running the buildpack does not require a proxy to be used for HTTP connections you should try setting
-the `NO_PROXY` environment variable to `amazonaws.com`, i.e. running the command `export NO_PROXY=amazonaws.com` immediatly before executing
-the buildpack or by setting that environment value inside the buildpack. If you find `HTTP_PROXY` and `HTTPS_PROXY` environment variables and do not need a proxy in your build environment then the environment
-variables should be removed.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For more information about using this Node.js buildpack on Heroku, see these Dev
 
 - [Heroku Node.js Support](https://devcenter.heroku.com/articles/nodejs-support)
 - [Getting Started with Node.js on Heroku](https://devcenter.heroku.com/articles/nodejs)
+- [Troubleshooting Node.js Deploys](https://devcenter.heroku.com/articles/troubleshooting-node-deploys)
 
 For more general information about buildpacks on Heroku:
 


### PR DESCRIPTION
Delete proxy issues section from readme to be included in [Dev Center](https://devcenter.heroku.com/articles/nodejs-support)