### PR TITLE
warn if http_proxy/https_proxy set and no_proxy is not aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 - display yarn engine log to build output when engine is provided in monorepo ([#771](https://github.com/heroku/heroku-buildpack-nodejs/pull/771))
 - move proxy issues section from readme to dev center ([#778](https://github.com/heroku/heroku-buildpack-nodejs/pull/778))
+- warn when NO_PROXY is not set to "amazonaws.com" and HTTP_PROXY or HTTPS_PROXY is set ([#782](https://github.com/heroku/heroku-buildpack-nodejs/pull/782))
 
 ## v171 (2020-04-27)
 - Update Travis badge to `master` and other changes in README ([#753](https://github.com/heroku/heroku-buildpack-nodejs/pull/753))

--- a/bin/compile
+++ b/bin/compile
@@ -73,6 +73,7 @@ handle_failure() {
   fail_yarn_install "$LOG_FILE" "$BUILD_DIR"
   fail_invalid_semver "$LOG_FILE"
   log_other_failures "$LOG_FILE"
+  warn_aws_proxy "$BUILD_DIR"
   warn_untracked_dependencies "$LOG_FILE"
   warn_angular_resolution "$LOG_FILE"
   warn_missing_devdeps "$LOG_FILE" "$BUILD_DIR"

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -609,7 +609,11 @@ warn() {
 
 warn_aws_proxy() {
   local build_dir=${1:-}
-  if ([[ ! -z "$build_dir/HTTP_PROXY" ]] || [[ ! -z "$build_dir/HTTPS_PROXY" ]]) && [[ "$build_dir/NO_PROXY" != "amazonaws.com" ]]; then
+  local HTTP_PROXY HTTPS_PROXY NO_PROXY
+  HTTP_PROXY="$build_dir/HTTP_PROXY"
+  HTTPS_PROXY="$build_dir/HTTPS_PROXY"
+  NO_PROXY="$build_dir/NO_PROXY"
+  if { [[ -n "$HTTP_PROXY" ]] || [[ -n "$HTTPS_PROXY" ]]; } && [[ "$NO_PROXY" != "amazonaws.com" ]]; then
     warn "Your build may fail if NO_PROXY is not set to amazonaws.com" "https://devcenter.heroku.com/articles/troubleshooting-node-deploys#aws-proxy-error"
   fi
 }

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -608,11 +608,6 @@ warn() {
 }
 
 warn_aws_proxy() {
-  local build_dir=${1:-}
-  local HTTP_PROXY HTTPS_PROXY NO_PROXY
-  HTTP_PROXY="$build_dir/HTTP_PROXY"
-  HTTPS_PROXY="$build_dir/HTTPS_PROXY"
-  NO_PROXY="$build_dir/NO_PROXY"
   if { [[ -n "$HTTP_PROXY" ]] || [[ -n "$HTTPS_PROXY" ]]; } && [[ "$NO_PROXY" != "amazonaws.com" ]]; then
     warn "Your build may fail if NO_PROXY is not set to amazonaws.com" "https://devcenter.heroku.com/articles/troubleshooting-node-deploys#aws-proxy-error"
   fi

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -607,6 +607,13 @@ warn() {
   echo ""
 }
 
+warn_aws_proxy() {
+  local build_dir=${1:-}
+  if ([[ ! -z "$build_dir/HTTP_PROXY" ]] || [[ ! -z "$build_dir/HTTPS_PROXY" ]]) && [[ "$build_dir/NO_PROXY" != "amazonaws.com" ]]; then
+    warn "Your build may fail if NO_PROXY is not set to amazonaws.com" "https://devcenter.heroku.com/articles/troubleshooting-node-deploys#aws-proxy-error"
+  fi
+}
+
 warn_node_engine() {
   local node_engine=${1:-}
   if [ "$node_engine" == "" ]; then

--- a/test/run
+++ b/test/run
@@ -358,6 +358,15 @@ testOldNpmWithLockfile() {
   assertCapturedSuccess
 }
 
+testWarnAwsProxy() {
+  env_dir=$(mktmpdir)
+  echo "http://localhost:5001" > $env_dir/HTTP_PROXY
+  echo "http://localhost:5001" > $env_dir/HTTPS_PROXY
+  compile "node-10" "$(mktmpdir)" $env_dir
+  assertCaptured "Your build may fail if NO_PROXY is not set to amazonaws.com"
+  assertCapturedError
+}
+
 testWarnUnmetDepNpm() {
   compile "unmet-dep"
   assertCaptured "fail npm install"

--- a/test/run
+++ b/test/run
@@ -358,9 +358,16 @@ testOldNpmWithLockfile() {
   assertCapturedSuccess
 }
 
-testWarnAwsProxy() {
+testWarnAwsProxyHttp() {
   env_dir=$(mktmpdir)
   echo "http://localhost:5001" > $env_dir/HTTP_PROXY
+  compile "node-10" "$(mktmpdir)" $env_dir
+  assertCaptured "Your build may fail if NO_PROXY is not set to amazonaws.com"
+  assertCapturedError
+}
+
+testWarnAwsProxyHttps() {
+  env_dir=$(mktmpdir)
   echo "http://localhost:5001" > $env_dir/HTTPS_PROXY
   compile "node-10" "$(mktmpdir)" $env_dir
   assertCaptured "Your build may fail if NO_PROXY is not set to amazonaws.com"


### PR DESCRIPTION
User should be warned of build failure if `NO_PROXY` is not set to "amazonaws.com" when `HTTP_PROXY` or `HTTPS_PROXY` is set. See [AWS proxy error](https://devcenter.heroku.com/articles/troubleshooting-node-deploys#aws-proxy-error) section.