### PR TITLE
add heroku cleanup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - display yarn engine log to build output when engine is provided in monorepo ([#771](https://github.com/heroku/heroku-buildpack-nodejs/pull/771))
 - move proxy issues section from readme to dev center ([#778](https://github.com/heroku/heroku-buildpack-nodejs/pull/778))
 - warn when NO_PROXY is not set to "amazonaws.com" and HTTP_PROXY or HTTPS_PROXY is set ([#782](https://github.com/heroku/heroku-buildpack-nodejs/pull/782))
+- add heroku cleanup script ([#788](https://github.com/heroku/heroku-buildpack-nodejs/pull/788))
 
 ## v171 (2020-04-27)
 - Update Travis badge to `master` and other changes in README ([#753](https://github.com/heroku/heroku-buildpack-nodejs/pull/753))

--- a/bin/compile
+++ b/bin/compile
@@ -318,6 +318,8 @@ else
   prune_devdependencies | output "$LOG_FILE"
 fi
 
+run_cleanup_script "$BUILD_DIR"
+
 summarize_build() {
   if $NODE_VERBOSE; then
     list_dependencies "$BUILD_DIR"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -73,6 +73,19 @@ run_build_script() {
   fi
 }
 
+run_cleanup_script() {
+  local build_dir=${1:-}
+  local has_heroku_cleanup_script
+
+  has_heroku_cleanup_script=$(has_script "$build_dir/package.json" "heroku-cleanup")
+
+  if [[ "$has_heroku_cleanup_script" == "true" ]]; then
+    mcount "script.heroku-cleanup"
+    header "Cleanup"
+    run_if_present "$build_dir" 'heroku-cleanup'
+  fi
+}
+
 log_build_scripts() {
   local build_dir=${1:-}
 
@@ -92,7 +105,7 @@ yarn_node_modules() {
 }
 
 yarn_prune_devdependencies() {
-  local build_dir=${1:-} 
+  local build_dir=${1:-}
 
   if [ "$NODE_ENV" == "test" ]; then
     echo "Skipping because NODE_ENV is 'test'"
@@ -106,7 +119,7 @@ yarn_prune_devdependencies() {
     echo "Skipping because YARN_PRODUCTION is '$YARN_PRODUCTION'"
     meta_set "skipped-prune" "true"
     return 0
-  else 
+  else
     cd "$build_dir" || return
     monitor "yarn-prune" yarn install --frozen-lockfile --ignore-engines --ignore-scripts --prefer-offline 2>&1
     meta_set "skipped-prune" "false"
@@ -180,7 +193,7 @@ npm_rebuild() {
 
 npm_prune_devdependencies() {
   local npm_version
-  local build_dir=${1:-} 
+  local build_dir=${1:-}
 
   npm_version=$(npm --version)
 

--- a/test/fixtures/cleanup-scripts/README.md
+++ b/test/fixtures/cleanup-scripts/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/cleanup-scripts/package.json
+++ b/test/fixtures/cleanup-scripts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts" : {
+    "heroku-cleanup" : "echo heroku-cleanup hook message"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -100,6 +100,13 @@ testPrePostBuildScripts() {
   assertCapturedSuccess
 }
 
+testCleanupScript() {
+  compile "cleanup-scripts"
+  assertCaptured "Running heroku-cleanup"
+  assertCaptured "echo heroku-cleanup hook message"
+  assertCapturedSuccess
+}
+
 testYarnRun() {
   compile "yarn-run"
   assertCaptured "Running heroku-postbuild (yarn)"


### PR DESCRIPTION
Add a "heroku-cleanup" script feature that would run at the end of the node build after writing to the cache and pruning the dependencies of devDependencies
See https://github.com/heroku/heroku-buildpack-nodejs/issues/781 for linked issue