### PR TITLE
add a cleanup script build step and output to log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - move proxy issues section from readme to dev center ([#778](https://github.com/heroku/heroku-buildpack-nodejs/pull/778))
 - warn when NO_PROXY is not set to "amazonaws.com" and HTTP_PROXY or HTTPS_PROXY is set ([#782](https://github.com/heroku/heroku-buildpack-nodejs/pull/782))
 - add heroku cleanup script ([#788](https://github.com/heroku/heroku-buildpack-nodejs/pull/788))
+- add a build step for cleanup script and output to log file ([#790](https://github.com/heroku/heroku-buildpack-nodejs/pull/790))
 
 ## v171 (2020-04-27)
 - Update Travis badge to `master` and other changes in README ([#753](https://github.com/heroku/heroku-buildpack-nodejs/pull/753))

--- a/bin/compile
+++ b/bin/compile
@@ -318,7 +318,8 @@ else
   prune_devdependencies | output "$LOG_FILE"
 fi
 
-run_cleanup_script "$BUILD_DIR"
+meta_set "build-step" "cleanup-script"
+run_cleanup_script "$BUILD_DIR" | output "$LOG_FILE"
 
 summarize_build() {
   if $NODE_VERBOSE; then


### PR DESCRIPTION
Makes a feel fixes to the `heroku-cleanup` script that has just been added.

### Includes:
- adding a `cleanup-script` step for bin/report
- outputting the content of the script to $LOG_FILE