### PR TITLE
use meta_get to get package manager name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 - update docs URL when node modules are checked into git ([#794](https://github.com/heroku/heroku-buildpack-nodejs/pull/794))
 - move disabling yarn caching YARN_CACHE env var ([#796](https://github.com/heroku/heroku-buildpack-nodejs/pull/796))
+- use meta_get "node-package-manager" for reporting ([#802](https://github.com/heroku/heroku-buildpack-nodejs/pull/802))
 
 ## v172 (2020-05-28)
 - display yarn engine log to build output when engine is provided in monorepo ([#771](https://github.com/heroku/heroku-buildpack-nodejs/pull/771))

--- a/bin/report
+++ b/bin/report
@@ -68,7 +68,7 @@ kv_pair_string() {
   value="$2"
   if [[ -n "$value" ]]; then
     value=$(echo $value | sed 's/"/\\"/g')
-    echo "$1: \"$value\"" >> $output
+    echo "$key: \"$value\"" >> $output
   fi
 }
 
@@ -104,11 +104,7 @@ kv_pair "heroku_postbuild_script_time" "$(meta_get "heroku-postbuild-script-time
 kv_pair "heroku_postbuild_script_memory" "$(meta_get "heroku-postbuild-script-memory")"
 
 # which package manager was used
-if [[ "$YARN" == "true" ]]; then
-  kv_pair_string "package_manager" "yarn"
-else
-  kv_pair_string "package_manager" "npm"
-fi
+kv_pair "package_manager" "$(meta_get "node-package-manager")"
 
 # We have to get this info from bin/compile since a lockfile will be generated if there wasn't one
 kv_pair "lock_file" "$(meta_get "has-node-lock-file")"

--- a/bin/report
+++ b/bin/report
@@ -104,7 +104,7 @@ kv_pair "heroku_postbuild_script_time" "$(meta_get "heroku-postbuild-script-time
 kv_pair "heroku_postbuild_script_memory" "$(meta_get "heroku-postbuild-script-memory")"
 
 # which package manager was used
-kv_pair "package_manager" "$(meta_get "node-package-manager")"
+kv_pair_string "package_manager" "$(meta_get "node-package-manager")"
 
 # We have to get this info from bin/compile since a lockfile will be generated if there wasn't one
 kv_pair "lock_file" "$(meta_get "has-node-lock-file")"

--- a/test/run
+++ b/test/run
@@ -1325,6 +1325,11 @@ testBinReportScriptsWithQuotes() {
   assertCaptured "postinstall_script: \"if [ \\\"\${NODE_ENV}\\\" = \\\"staging\\\" ]; then env ASSETS_ENV=production gulp assets:build; else echo \\\"Skipped heroku-postbuild\\\"; fi\""
 }
 
+testBinReportYarn() {
+  compile_and_report "yarn"
+  assertCaptured "package_manager: \"yarn\""
+}
+
 # Utils
 
 pushd "$(dirname 0)" >/dev/null


### PR DESCRIPTION
It seems that the all package managers are being reported as `npm`, so the `if` statement here is not `true`: https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/report#L107, and the reporting is wrong.

This pull request creates a method in `lib/dependencies.sh` to use in both `bin/compile` and `bin/report` to detect for a `yarn.lock` file (and subsequently use Yarn logic).