### PR TITLE
change env variable from YARN_CACHE to USE_YARN_CACHE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - update docs URL when node modules are checked into git ([#794](https://github.com/heroku/heroku-buildpack-nodejs/pull/794))
 - move disabling yarn caching YARN_CACHE env var ([#796](https://github.com/heroku/heroku-buildpack-nodejs/pull/796))
 - use meta_get "node-package-manager" for reporting ([#802](https://github.com/heroku/heroku-buildpack-nodejs/pull/802))
+- change YARN_CACHE to USE_YARN_CACHE env var ([#803](https://github.com/heroku/heroku-buildpack-nodejs/pull/803))
 
 ## v172 (2020-05-28)
 - display yarn engine log to build output when engine is provided in monorepo ([#771](https://github.com/heroku/heroku-buildpack-nodejs/pull/771))

--- a/bin/compile
+++ b/bin/compile
@@ -142,8 +142,8 @@ create_build_env
 export YARN_CACHE_FOLDER NPM_CONFIG_CACHE
 
 if [[ $(features_get "cache-native-yarn-cache") == "false" ]]; then
-  warn "You're currently using the heroku-buildpack-features file to configure. Use 'heroku config:set YARN_CACHE=false' to set the variable. Using Yarn Cache has moved behind an environment variable."
-  YARN_CACHE=false
+  warn "You're currently using the heroku-buildpack-features file to configure. Using Yarn Cache has moved behind an environment variable. Use 'heroku config:set USE_YARN_CACHE=false' to set the variable."
+  USE_YARN_CACHE=false
 fi
 
 install_bins() {
@@ -309,7 +309,7 @@ prune_devdependencies() {
 #   and in the new feature
 #   and we're using the default cache directories
 # then save off the cache after we prune out devDepenencies
-if [[ "$YARN" == "true" ]] && [[ "$YARN_CACHE" == "true" ]] && [[ "$(get_cache_directories "$BUILD_DIR")" == "" ]]; then
+if [[ "$YARN" == "true" ]] && [[ "$USE_YARN_CACHE" == "true" ]] && [[ "$(get_cache_directories "$BUILD_DIR")" == "" ]]; then
   meta_set "build-step" "prune-dependencies"
   header "Pruning devDependencies" | output "$LOG_FILE"
   prune_devdependencies | output "$LOG_FILE"

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -27,7 +27,7 @@ create_default_env() {
   export NODE_VERBOSE=${NODE_VERBOSE:-false}
 
   if $YARN; then
-    export YARN_CACHE=${YARN_CACHE:-true}
+    export USE_YARN_CACHE=${USE_YARN_CACHE:-true}
   fi
 }
 
@@ -43,6 +43,7 @@ list_node_config() {
   echo ""
   printenv | grep ^NPM_CONFIG_ || true
   printenv | grep ^YARN_ || true
+  printenv | grep ^USE_YARN_ || true
   printenv | grep ^NODE_ || true
 
   if [ "$NPM_CONFIG_PRODUCTION" = "true" ] && [ "$NODE_ENV" != "production" ]; then


### PR DESCRIPTION
This was causing a bug with Yarn 2 when `YARN_CACHE` was set, which is a reserved env var value. This will also output `USE_YARN_CACHE` at the beginning of the build with the other user-configured build settings.

Blocks https://github.com/heroku/heroku-buildpack-nodejs/pull/795

**Error from Yarn 2 logs**
```
-----> Creating runtime environment

       NPM_CONFIG_LOGLEVEL=error
       YARN_CACHE=true
       NODE_VERBOSE=false
       NODE_ENV=production
       NODE_MODULES_CACHE=true

-----> Installing binaries
       engines.node (package.json):  unspecified
       engines.npm (package.json):   unspecified (use default)
       engines.yarn (package.json):  unspecified (use default)

       Resolving node version 12.x...
       Downloading and installing node 12.18.2...
       Using default npm version: 6.14.5
       Resolving yarn version 1.x...
       Downloading and installing yarn (1.22.4)...
       Using yarn 2.0.0-rc.33

-----> Installing dependencies
       Using Yarn 2, skipping installations.

-----> Build
       Running build (yarn)
       Usage Error: Unrecognized or legacy configuration settings found: cache - run "yarn config -v" to see the list of settings supported in Yarn (in <environment>)

       $ yarn run [--inspect] [--inspect-brk] <scriptName> ...
```