### PR TITLE
add env var for custom binary url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## master
+- provide custom binary url for node and yarn binary downloads ([#804](https://github.com/heroku/heroku-buildpack-nodejs/pull/804))
 
 ## v173 (2020-07-16)
 - update docs URL when node modules are checked into git ([#794](https://github.com/heroku/heroku-buildpack-nodejs/pull/794))

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -39,21 +39,24 @@ install_yarn() {
   local version=${2:-1.x}
   local number url code resolve_result
 
-  echo "Resolving yarn version $version..."
-  resolve_result=$(resolve yarn "$version" || echo "failed")
-
-  if [[ "$resolve_result" == "failed" ]]; then
-    fail_bin_install yarn "$version"
-  fi
-
-  read -r number url < <(echo "$resolve_result")
-
   if [[ -n "$YARN_BINARY_URL" ]]; then
     url="$YARN_BINARY_URL"
+    echo "Downloading and installing yarn from $url"
+    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
+  else
+    echo "Resolving yarn version $version..."
+    resolve_result=$(resolve yarn "$version" || echo "failed")
+
+    if [[ "$resolve_result" == "failed" ]]; then
+      fail_bin_install yarn "$version"
+    fi
+
+    read -r number url < <(echo "$resolve_result")
+
+    echo "Downloading and installing yarn ($number)"
+    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   fi
 
-  echo "Downloading and installing yarn ($number) from $url"
-  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false
   fi
@@ -82,21 +85,24 @@ install_nodejs() {
   os=$(get_os)
   cpu=$(get_cpu)
 
-  echo "Resolving node version $version..."
-  resolve_result=$(resolve node "$version" || echo "failed")
-
-  read -r number url < <(echo "$resolve_result")
-
-  if [[ "$resolve_result" == "failed" ]]; then
-    fail_bin_install node "$version"
-  fi
-
   if [[ -n "$NODE_BINARY_URL" ]]; then
     url="$NODE_BINARY_URL"
+    echo echo "Downloading and installing node from $url"
+    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
+  else
+    echo "Resolving node version $version..."
+    resolve_result=$(resolve node "$version" || echo "failed")
+
+    read -r number url < <(echo "$resolve_result")
+
+    if [[ "$resolve_result" == "failed" ]]; then
+      fail_bin_install node "$version"
+    fi
+
+    echo "Downloading and installing node $number"
+    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
   fi
 
-  echo "Downloading and installing node $number from $url"
-  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download node: $code" && false
   fi

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -48,7 +48,11 @@ install_yarn() {
 
   read -r number url < <(echo "$resolve_result")
 
-  echo "Downloading and installing yarn ($number)..."
+  if [[ -n "$YARN_BINARY_URL" ]]; then
+    url="$YARN_BINARY_URL"
+  fi
+
+  echo "Downloading and installing yarn ($number) from $url"
   code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false
@@ -87,7 +91,11 @@ install_nodejs() {
     fail_bin_install node "$version"
   fi
 
-  echo "Downloading and installing node $number..."
+  if [[ -n "$NODE_BINARY_URL" ]]; then
+    url="$NODE_BINARY_URL"
+  fi
+
+  echo "Downloading and installing node $number from $url"
   code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download node: $code" && false

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -42,7 +42,6 @@ install_yarn() {
   if [[ -n "$YARN_BINARY_URL" ]]; then
     url="$YARN_BINARY_URL"
     echo "Downloading and installing yarn from $url"
-    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   else
     echo "Resolving yarn version $version..."
     resolve_result=$(resolve yarn "$version" || echo "failed")
@@ -54,8 +53,9 @@ install_yarn() {
     read -r number url < <(echo "$resolve_result")
 
     echo "Downloading and installing yarn ($number)"
-    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   fi
+
+  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
 
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false
@@ -87,8 +87,7 @@ install_nodejs() {
 
   if [[ -n "$NODE_BINARY_URL" ]]; then
     url="$NODE_BINARY_URL"
-    echo echo "Downloading and installing node from $url"
-    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
+    echo "Downloading and installing node from $url"
   else
     echo "Resolving node version $version..."
     resolve_result=$(resolve node "$version" || echo "failed")
@@ -100,8 +99,9 @@ install_nodejs() {
     fi
 
     echo "Downloading and installing node $number"
-    code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
   fi
+
+  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
 
   if [ "$code" != "200" ]; then
     echo "Unable to download node: $code" && false

--- a/test/run
+++ b/test/run
@@ -122,6 +122,24 @@ testNoVersion() {
   assertCapturedSuccess
 }
 
+testCustomYarnBinaryURL() {
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  echo "testurl" > $env_dir/YARN_BINARY_URL
+  compile "yarn" $cache $env_dir
+  assertCaptured "from testurl"
+}
+
+testCustomNodeBinaryURL() {
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  echo "testurl" > $env_dir/NODE_BINARY_URL
+  compile "node-10" $cache $env_dir
+  assertCaptured "from testurl"
+}
+
 testDisableCache() {
   cache=$(mktmpdir)
   env_dir=$(mktmpdir)


### PR DESCRIPTION
Create the ability to use an environment variable to direct Node binary downloads and Yarn downloads for customization.
See Issue #521 for more info.