### PR TITLE
update npm ci usage to be 75% of new builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 - provide custom binary url for node and yarn binary downloads ([#804](https://github.com/heroku/heroku-buildpack-nodejs/pull/804))
 - allow skipping node_modules removal with SKIP_NODE_MODULES_CHECK ([#798](https://github.com/heroku/heroku-buildpack-nodejs/pull/798))
+- expand npm ci usage to 75% of builds ([#812](https://github.com/heroku/heroku-buildpack-nodejs/pull/812))
 
 ## v173 (2020-07-16)
 - update docs URL when node modules are checked into git ([#794](https://github.com/heroku/heroku-buildpack-nodejs/pull/794))

--- a/features
+++ b/features
@@ -1,2 +1,2 @@
-use-npm-ci=50
+use-npm-ci=75
 cache-native-yarn-cache=100


### PR DESCRIPTION
Makes 75% of builds to use npm ci (instead of npm install).