### PR TITLE
Set up hatchet script for Circle CI [CHANGELOG SKIP]

### DIFF
--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -25,7 +25,9 @@ if [ -z "$HEROKU_API_KEY" ]; then
   exit 1
 fi
 
-if [ -n "$CIRCLE_BRANCH" ]; then
+if [[ "$CIRCLE_PROJECT_REPONAME" == "nodebin" ]]; then
+  HATCHET_BUILDPACK_BRANCH="master"
+elif [ -n "$CIRCLE_BRANCH" ]; then
   HATCHET_BUILDPACK_BRANCH="$CIRCLE_BRANCH"
 elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
   export IS_RUNNING_ON_TRAVIS=true
@@ -36,7 +38,6 @@ fi
 
 export HATCHET_BUILDPACK_BRANCH
 
-gem install bundler
 bundle install
 
 export HATCHET_RETRIES=3

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -98,7 +98,7 @@ install_nodejs() {
       fail_bin_install node "$version"
     fi
 
-    echo "Downloading and installing node $number"
+    echo "Downloading and installing node $number..."
   fi
 
   code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")


### PR DESCRIPTION
Lets the hatchet script know to use the base branch when running tests against the buildpack. Also, fixes a typo that made it through tests that are making the hatchet tests for binaries break.