### PR TITLE
lock yarn installed version at 1.22.x when not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## master
+- Install Yarn version at 1.22.x when not specified in package.json engines ([#817](https://github.com/heroku/heroku-buildpack-nodejs/pull/817))
 
 ## v174 (2020-07-23)
 - provide custom binary url for node and yarn binary downloads ([#804](https://github.com/heroku/heroku-buildpack-nodejs/pull/804))

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -36,7 +36,7 @@ resolve() {
 
 install_yarn() {
   local dir="$1"
-  local version=${2:-1.x}
+  local version=${2:-1.22.x}
   local number url code resolve_result
 
   if [[ -n "$YARN_BINARY_URL" ]]; then


### PR DESCRIPTION
Fixes: https://github.com/heroku/heroku-buildpack-nodejs/issues/512

Those that are using Yarn 1 will get 1.22.x installed when not specified in the package.json with engines. Release candidates for Yarn 1 are coming out less frequently (due to Yarn 2), so if there is a new minor version, it can be updated it accordingly.

Additionally, this will be sure to install Yarn 1.22.x for those that are using Yarn 2 (as it is needed to set the version).

If a new 1.x version comes out, then the default installed version will need to be updated.