### PR TITLE
Rename yarn2 to yarn 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 - Install Yarn version at 1.22.x when not specified in package.json engines ([#817](https://github.com/heroku/heroku-buildpack-nodejs/pull/817))
 - Run `yarn install` for all Yarn 2 builds ([#819](https://github.com/heroku/heroku-buildpack-nodejs/pull/819))
+- Change all references from Yarn2 to Yarn 2 ([#824](https://github.com/heroku/heroku-buildpack-nodejs/pull/824))
 
 ## v174 (2020-07-23)
 - provide custom binary url for node and yarn binary downloads ([#804](https://github.com/heroku/heroku-buildpack-nodejs/pull/804))

--- a/bin/compile
+++ b/bin/compile
@@ -142,7 +142,7 @@ create_build_env
 export YARN_CACHE_FOLDER NPM_CONFIG_CACHE
 
 ### Configure vendored package manager
-export YARN_2_PATH
+export VENDOR_PATH
 
 if [[ "$YARN_2" == "true" ]]; then
   if [[ "$NODE_MODULES_CACHE" == "true" ]]; then
@@ -169,13 +169,13 @@ if [[ "$YARN_2" == "true" ]]; then
   fail_missing_yarnrc_yml "$BUILD_DIR"
 
   # get yarn_path
-  YARN_2_PATH=$(get_yarn_path "$BUILD_DIR")
+  VENDOR_PATH=$(get_yarn_path "$BUILD_DIR")
 
   # fail for no yarnPath in rc
-  fail_missing_yarn_path "$BUILD_DIR" "$YARN_2_PATH"
+  fail_missing_yarn_path "$BUILD_DIR" "$VENDOR_PATH"
 
   # fail for missing yarn in .yarn/releases
-  fail_missing_yarn_vendor "$BUILD_DIR" "$YARN_2_PATH"
+  fail_missing_yarn_vendor "$BUILD_DIR" "$VENDOR_PATH"
 fi
 
 if [[ $(features_get "cache-native-yarn-cache") == "false" ]]; then
@@ -302,7 +302,7 @@ build_dependencies() {
   cache_status="$(get_cache_status "$CACHE_DIR")"
   start=$(nowms)
   if [[ "$YARN_2" == "true" ]]; then
-    yarn_2_node_modules "$BUILD_DIR"
+    yarn_2_install "$BUILD_DIR"
   elif $YARN; then
     yarn_node_modules "$BUILD_DIR"
   elif $PREBUILD; then

--- a/bin/compile
+++ b/bin/compile
@@ -97,7 +97,7 @@ meta_set "build-step" "init"
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
-YARN2=$(detect_yarn_2 "$YARN" "$BUILD_DIR")
+YARN_2=$(detect_yarn_2 "$YARN" "$BUILD_DIR")
 
 ### Save build info
 features_init "nodejs" "$BUILD_DIR" "$CACHE_DIR" "$BP_DIR/features"
@@ -142,9 +142,9 @@ create_build_env
 export YARN_CACHE_FOLDER NPM_CONFIG_CACHE
 
 ### Configure vendored package manager
-export YARN2_PATH
+export YARN_2_PATH
 
-if [[ "$YARN2" == "true" ]]; then
+if [[ "$YARN_2" == "true" ]]; then
   if [[ "$NODE_MODULES_CACHE" == "true" ]]; then
     warn "
       WARNING- You are using Yarn 2. The buildpack won't cache because Heroku is expecting dependencies from the .yarn directory for each build. To unset NODE_MODULES_CACHE and other similar environment variables, read here: https://devcenter.heroku.com/articles/migrating-to-yarn-2#change-environment-variables
@@ -169,13 +169,13 @@ if [[ "$YARN2" == "true" ]]; then
   fail_missing_yarnrc_yml "$BUILD_DIR"
 
   # get yarn_path
-  YARN2_PATH=$(get_yarn_path "$BUILD_DIR")
+  YARN_2_PATH=$(get_yarn_path "$BUILD_DIR")
 
   # fail for no yarnPath in rc
-  fail_missing_yarn_path "$BUILD_DIR" "$YARN2_PATH"
+  fail_missing_yarn_path "$BUILD_DIR" "$YARN_2_PATH"
 
   # fail for missing yarn in .yarn/releases
-  fail_missing_yarn_vendor "$BUILD_DIR" "$YARN2_PATH"
+  fail_missing_yarn_vendor "$BUILD_DIR" "$YARN_2_PATH"
 fi
 
 if [[ $(features_get "cache-native-yarn-cache") == "false" ]]; then
@@ -190,7 +190,7 @@ install_bins() {
   npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
   yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
 
-  if [[ "$YARN2" == "true" && -n "$yarn_engine" ]]; then
+  if [[ "$YARN_2" == "true" && -n "$yarn_engine" ]]; then
     warn "You don't need to specify Yarn engine. Heroku will install the latest Yarn 1.x, so that per project version can be used. More information here: https://yarnpkg.com/getting-started/install#global-install"
     unset yarn_engine
   fi
@@ -236,7 +236,7 @@ install_bins() {
 
   warn_old_npm
 
-  if [[ $YARN2 == true ]]; then
+  if [[ $YARN_2 == true ]]; then
     YARN=false
   fi
 }
@@ -301,7 +301,7 @@ build_dependencies() {
 
   cache_status="$(get_cache_status "$CACHE_DIR")"
   start=$(nowms)
-  if [[ "$YARN2" == "true" ]]; then
+  if [[ "$YARN_2" == "true" ]]; then
     yarn_2_node_modules "$BUILD_DIR"
   elif $YARN; then
     yarn_node_modules "$BUILD_DIR"
@@ -358,7 +358,7 @@ prune_devdependencies() {
 #   and in the new feature
 #   and we're using the default cache directories
 # then save off the cache after we prune out devDepenencies
-if [[ "$YARN2" == "true" ]]; then
+if [[ "$YARN_2" == "true" ]]; then
   echo "Using Yarn 2, writing to the cache and pruning of dependencies will be skipped." | output "$LOG_FILE"
   meta_set "build-step" "prune-dependencies"
   meta_set "build-step" "save-cache"

--- a/bin/compile
+++ b/bin/compile
@@ -52,8 +52,8 @@ source "$BP_DIR/lib/metadata.sh"
 source "$BP_DIR/lib/features.sh"
 # shellcheck source=lib/builddata.sh
 source "$BP_DIR/lib/builddata.sh"
-# shellcheck source=lib/yarn2.sh
-source "$BP_DIR/lib/yarn2.sh"
+# shellcheck source=lib/yarn-2.sh
+source "$BP_DIR/lib/yarn-2.sh"
 
 export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 
@@ -97,7 +97,7 @@ meta_set "build-step" "init"
 [ -e "$BUILD_DIR/node_modules" ] && PREBUILD=true || PREBUILD=false
 [ -f "$BUILD_DIR/yarn.lock" ] && YARN=true || YARN=false
 [ -f "$BUILD_DIR/package-lock.json" ] && NPM_LOCK=true || NPM_LOCK=false
-YARN2=$(detect_yarn2 "$YARN" "$BUILD_DIR")
+YARN2=$(detect_yarn_2 "$YARN" "$BUILD_DIR")
 
 ### Save build info
 features_init "nodejs" "$BUILD_DIR" "$CACHE_DIR" "$BP_DIR/features"
@@ -302,7 +302,7 @@ build_dependencies() {
   cache_status="$(get_cache_status "$CACHE_DIR")"
   start=$(nowms)
   if [[ "$YARN2" == "true" ]]; then
-    yarn2_node_modules "$BUILD_DIR"
+    yarn_2_node_modules "$BUILD_DIR"
   elif $YARN; then
     yarn_node_modules "$BUILD_DIR"
   elif $PREBUILD; then

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -70,7 +70,7 @@ install_yarn() {
   fi
   chmod +x "$dir"/bin/*
 
-  if $YARN2; then
+  if $YARN_2; then
     echo "Using yarn $(yarn --version)"
   else
     echo "Installed yarn $(yarn --version)"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -104,12 +104,12 @@ yarn_node_modules() {
   monitor "yarn-install" yarn install --production="$production" --frozen-lockfile --ignore-engines 2>&1
 }
 
-yarn2_node_modules() {
+yarn_2_node_modules() {
   local build_dir=${1:-}
 
   echo "Running 'yarn install' with yarn.lock"
   cd "$build_dir" || return
-  monitor "yarn2-install" yarn install --immutable --immutable-cache 2>&1
+  monitor "yarn-2-install" yarn install --immutable --immutable-cache 2>&1
 }
 
 yarn_prune_devdependencies() {

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -104,7 +104,7 @@ yarn_node_modules() {
   monitor "yarn-install" yarn install --production="$production" --frozen-lockfile --ignore-engines 2>&1
 }
 
-yarn_2_node_modules() {
+yarn_2_install() {
   local build_dir=${1:-}
 
   echo "Running 'yarn install' with yarn.lock"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -27,7 +27,7 @@ run_if_present() {
   script=$(read_json "$build_dir/package.json" ".scripts[\"$script_name\"]")
 
   if [[ "$has_script_name" == "true" ]]; then
-    if $YARN || $YARN2; then
+    if $YARN || $YARN_2; then
       echo "Running $script_name (yarn)"
       # yarn will throw an error if the script is an empty string, so check for this case
       if [[ -n "$script" ]]; then

--- a/lib/yarn-2.sh
+++ b/lib/yarn-2.sh
@@ -2,7 +2,7 @@
 
 YQ="$BP_DIR/lib/vendor/yq-$(get_os)"
 
-detect_yarn2() {
+detect_yarn_2() {
   local uses_yarn="$1"
   local build_dir="$2"
   local yml_metadata


### PR DESCRIPTION
We had some different naming of Yarn 2 references, so this consolidates all of the places where Yarn2 (no space) was used and makes it 2 words.