### PR TITLE
[changelog skip] Hatchet v7.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,48 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     erubis (2.7.0)
-    excon (0.71.0)
-    heroics (0.0.25)
+    excon (0.76.0)
+    heroics (0.1.1)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (4.0.13)
+    heroku_hatchet (7.0.0)
       excon (~> 0)
-      minitest-retry (~> 0.1.9)
-      platform-api (~> 2)
-      repl_runner (~> 0.0.3)
+      platform-api (~> 3)
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (1.8.2)
-      concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
-    minitest-retry (0.1.9)
-      minitest (>= 5.0)
     moneta (1.0.0)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     parallel (1.12.1)
     parallel_split_test (0.7.0)
       parallel (>= 0.5.13)
       rspec (>= 3.1.0)
     parallel_tests (2.22.0)
       parallel
-    platform-api (2.2.0)
-      heroics (~> 0.0.25)
+    platform-api (3.0.0)
+      heroics (~> 0.1.1)
       moneta (~> 1.0.0)
+      rate_throttle_client (~> 0.1.0)
     rake (12.3.3)
-    repl_runner (0.0.3)
-      activesupport
+    rate_throttle_client (0.1.2)
     rrrretry (1.0.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -61,11 +47,7 @@ GEM
     rspec-support (3.8.0)
     sem_version (2.0.1)
     thor (0.20.3)
-    thread_safe (0.3.6)
     threaded (0.0.4)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
@@ -80,4 +62,4 @@ DEPENDENCIES
   sem_version
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/etc/ci-cleanup.sh
+++ b/etc/ci-cleanup.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-if [[ -n "$HEROKU_API_KEY" ]]; then 
-  heroku keys:remove "$USER@$(hostname)"
-fi

--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -2,28 +2,5 @@
 
 [ "$CI" != "true" ] && echo "Not running on CI!" && exit 1
 
-git config --global user.email "${HEROKU_API_USER:-"buildpack@example.com"}"
-git config --global user.name 'BuildpackTester'
-
-cat <<EOF >> ~/.ssh/config
-Host heroku.com
-    StrictHostKeyChecking no
-    CheckHostIP no
-    UserKnownHostsFile=/dev/null
-Host github.com
-    StrictHostKeyChecking no
-EOF
-
-cat <<EOF >> ~/.netrc
-machine git.heroku.com
-  login ${HEROKU_API_USER:-"buildpack@example.com"}
-  password ${HEROKU_API_KEY:-"password"}
-EOF
-
-sudo apt-get -qq update
-sudo apt-get install software-properties-common -y
-curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install-ubuntu.sh | sh
-
-if [ -n "$HEROKU_API_KEY" ]; then
-  yes | heroku keys:add
-fi
+bundle install
+bundle exec hatchet ci:setup

--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -38,10 +38,8 @@ fi
 
 export HATCHET_BUILDPACK_BRANCH
 
-bundle install
-
 export HATCHET_RETRIES=3
-export HATCHET_APP_LIMIT=20
+export HATCHET_APP_LIMIT=100
 export HATCHET_DEPLOY_STRATEGY=git
 export HATCHET_BUILDPACK_BASE="https://github.com/heroku/heroku-buildpack-nodejs"
 

--- a/makefile
+++ b/makefile
@@ -45,7 +45,6 @@ hatchet:
 	@echo "Running hatchet integration tests..."
 	@bash etc/ci-setup.sh
 	@bash etc/hatchet.sh spec/ci/
-	@bash etc/ci-cleanup.sh
 	@echo ""
 
 nodebin-test:


### PR DESCRIPTION
- ActiveSupport's Object#blank? and Object#present? are no longer provided by default (https://github.com/heroku/hatchet/pull/107)
- Remove deprecated support for passing a block to `App#run` (https://github.com/heroku/hatchet/pull/105)
- Ignore  403 on app delete due to race condition (https://github.com/heroku/hatchet/pull/101)
- The hatchet.lock file can now be locked to "main" in addition to "master" (https://github.com/heroku/hatchet/pull/86)
- Allow concurrent one-off dyno runs with the `run_multi: true` flag on apps (https://github.com/heroku/hatchet/pull/94)
- Apps are now marked as being "finished" by enabling maintenance mode on them when `teardown!` is called. Finished apps can be reaped immediately (https://github.com/heroku/hatchet/pull/97)
- Applications that are not marked as "finished" will be allowed to live for a HATCHET_ALIVE_TTL_MINUTES duration before they're deleted by the reaper to protect against deleting an app mid-deploy, default is seven minutes (https://github.com/heroku/hatchet/pull/97)
- The HEROKU_APP_LIMIT env var no longer does anything, instead hatchet application reaping is manually executed if an app cannot be created (https://github.com/heroku/hatchet/pull/97)
- App#deploy without a block will no longer run `teardown!` automatically (https://github.com/heroku/hatchet/pull/97)
- Calls to `git push heroku` are now rate throttled (https://github.com/heroku/hatchet/pull/98)
- Calls to `app.run` are now rate throttled (https://github.com/heroku/hatchet/pull/99)
- Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)