### PR TITLE
Fix CI runs [changelog skip]

### DIFF
--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -2,29 +2,6 @@
 
 set -e
 
-if [ "$CIRCLECI" == "true" ] && [ -n "$CI_PULL_REQUEST" ]; then
-  if [ "$CIRCLE_PR_USERNAME" != "heroku" ]; then
-    echo "Skipping integration tests on forked PR."
-    exit 0
-  fi
-fi
-
-if [ "$TRAVIS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  if [ "$TRAVIS_PULL_REQUEST_SLUG" != "heroku/heroku-buildpack-nodejs" ]; then
-    echo "Skipping integration tests on forked PR."
-    exit 0
-  fi
-fi
-
-if [ -z "$HEROKU_API_KEY" ]; then
-  echo ""
-  echo "ERROR: Missing \$HEROKU_API_KEY."
-  echo ""
-  echo "NOTE: You can create token this by running: heroku authorizations:create --description \"For Travis\""
-  echo ""
-  exit 1
-fi
-
 if [[ "$CIRCLE_PROJECT_REPONAME" == "nodebin" ]]; then
   HATCHET_BUILDPACK_BRANCH="main"
 elif [ -n "$CIRCLE_BRANCH" ]; then

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -1,5 +1,5 @@
 ---
 - - "./repos/heroku/node-js-getting-started"
-  - master
+  - main
 - - "./repos/nodejs/default-node"
   - master


### PR DESCRIPTION
Since `master` had been deleted on the `node-js-getting-started` repo, the tests broke. This PR changes the branch name from `master` to `main` for hatchet tests. (It also removes skipping of hatchet tests on forks as this process will be added as a manual step... docs to come).