### PR TITLE
Using the export defaults with the multiple buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,7 @@ ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
 # Load the previuosly environment
+# shellcheck source=export
 [ -e "${BUILD_DIR}/export" ] && source "${BUILD_DIR}/export"
 
 ### Load dependencies

--- a/bin/compile
+++ b/bin/compile
@@ -20,6 +20,9 @@ CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
+# Load the previuosly environment
+[ -e "${BUILD_DIR}/export" ] && source "${BUILD_DIR}/export"
+
 ### Load dependencies
 
 # shellcheck source=lib/vendor/stdlib_v7.sh

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -99,7 +99,7 @@ write_export() {
   # this may occur in situations outside of Heroku, such as running the
   # buildpacks locally.
   if [ -w "$bp_dir" ]; then
-    echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > "$bp_dir/export"
+    echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" >> "$bp_dir/export"
     echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> "$bp_dir/export"
   fi
 }


### PR DESCRIPTION
I don't know if I understand right about the "export" file from previously buildpacks, but I cannot make it works with the nodejs official heroku buildpack when I'm using another buildpack at top layer, so, I created this PR.

I read this link: https://devcenter.heroku.com/articles/buildpack-api#composing-multiple-buildpacks

I don't know if this is right, please, let me know if I'm wrong about that.