### PR TITLE
assign jq to binary path

### DIFF
--- a/lib/json.sh
+++ b/lib/json.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-JQ="$BP_DIR/lib/vendor/jq-$(get_os)"
+JQ="/usr/bin/jq"
 
 read_json() {
   local file="$1"


### PR DESCRIPTION
`jq` has been aded to the build stack (https://devcenter.heroku.com/changelog-items/1878). The `$JQ` variable needs to be reassigned to the binary path in case someone have scripts that reference the env var.