### PR TITLE
Add a latest tag to buildpack releases [changelog skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,33 @@ For more general information about buildpacks on Heroku:
 - [Buildpacks](https://devcenter.heroku.com/articles/buildpacks)
 - [Buildpack API](https://devcenter.heroku.com/articles/buildpack-api)
 
+## Using the Heroku Node.js buildpack
+
+It's suggested that you use the latest version of the release buildpack. You can set it using the `heroku-cli`.
+
+```sh
+heroku buildpacks:set heroku/nodejs
+```
+
+Your builds will always used the latest published release of the buildpack.
+
+If you need to use the git url, you can use the `latest` tag to make sure you always have the latest release. **`master` will always have the latest branch updates, but does not correspond with a numbered release.**
+
+```sh
+heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#latest -a my-app
+```
+
 ## Locking to a buildpack version
 
-In production, you may want to lock dependencies - including
-buildpacks - to a specific version.
+Even though it's suggested to use the latest release, you may want to lock dependencies - including buildpacks - to a specific version.
 
 First, find the version you want from
 [the list of buildpack versions](https://github.com/heroku/heroku-buildpack-nodejs/releases).
 Then, specify that version with `buildpacks:set`:
 
 ```
-heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#v170 -a my-app
+heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#v176 -a my-app
 ```
-
-If you have trouble upgrading to the latest version of the buildpack, please
-open a support ticket at [help.heroku.com](https://help.heroku.com/) so we can assist.
 
 ### Chain Node with multiple buildpacks
 

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -26,10 +26,14 @@ case "$choice" in
   * ) exit 1;;
 esac
 
-originMaster=$(git rev-parse origin/main)
-echo "Tagging commit $originMaster with $newVersion... "
-git tag "$newVersion" "${originMaster:?}"
+originMain=$(git rev-parse origin/main)
+echo "Tagging commit $originMain with $newVersion... "
+git tag "$newVersion" "${originMain:?}"
 git push origin refs/tags/$newVersion
+
+echo "Tagging commit $originMain with latest... "
+git tag -f latest "${originMain:?}"
+git push -f origin refs/tags/latest
 
 heroku buildpacks:publish "$BP_NAME" "$newVersion"
 


### PR DESCRIPTION
It's not clear from docs that `main` does not correspond with the latest release version, so if someone wants the latest release and use the git url, we should have a "latest" tag that is the most up-to-date release.

Per https://github.com/heroku/heroku-buildpack-nodejs/issues/856

## Includes
- add to README about using the buildpack registry version of the buildpack and pinning to latest
- update publish command to tag and push a latest release