### PR TITLE
add build flag option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Add NODE_BUILD_FLAG env var ([#859](https://github.com/heroku/heroku-buildpack-nodejs/pull/859))
 
 ## v177 (2020-11-12)
 - add Node 15.2.0 to inventory ([#861](https://github.com/heroku/heroku-buildpack-nodejs/pull/861))
 - Use jq from the stack image ([#854](https://github.com/heroku/heroku-buildpack-nodejs/pull/854))
 - Start testing new `resolve` binaries with inventory lists for Node and Yarn ([#855](https://github.com/heroku/heroku-buildpack-nodejs/pull/855))
 - Follow up to [#855](https://github.com/heroku/heroku-buildpack-nodejs/pull/855) to send captured data with bin/report ([#858](https://github.com/heroku/heroku-buildpack-nodejs/pull/858))
-- Add NODE_BUILD_FLAG env var ([#859](https://github.com/heroku/heroku-buildpack-nodejs/pull/859))
 
 ## v176 (2020-09-10)
 - Only run immutable cache in yarn 2 if caching enabled ([#832](https://github.com/heroku/heroku-buildpack-nodejs/pull/832))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use jq from the stack image ([#854](https://github.com/heroku/heroku-buildpack-nodejs/pull/854))
 - Start testing new `resolve` binaries with inventory lists for Node and Yarn ([#855](https://github.com/heroku/heroku-buildpack-nodejs/pull/855))
 - Follow up to [#855](https://github.com/heroku/heroku-buildpack-nodejs/pull/855) to send captured data with bin/report ([#858](https://github.com/heroku/heroku-buildpack-nodejs/pull/858))
+- Add NODE_BUILD_FLAG env var ([#859](https://github.com/heroku/heroku-buildpack-nodejs/pull/859))
 
 ## v176 (2020-09-10)
 - Only run immutable cache in yarn 2 if caching enabled ([#832](https://github.com/heroku/heroku-buildpack-nodejs/pull/832))

--- a/test/run
+++ b/test/run
@@ -70,6 +70,17 @@ testBuildScriptYarn() {
   assertCapturedSuccess
 }
 
+testBuildFlags() {
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  echo "--prod --optimize" > $env_dir/NODE_BUILD_FLAG
+  compile "build-script" $cache $env_dir
+  assertCaptured "Running build"
+  assertCaptured "Running with --prod --optimize flags"
+  assertCapturedSuccess
+}
+
 testPreferEmptyHerokuPostbuildOverBuild() {
   compile "empty-heroku-postbuild"
   assertCaptured "Detected both \"build\" and \"heroku-postbuild\" scripts"


### PR DESCRIPTION
Add a NODE_BUILD_FLAG environment variable that can be used by the user to set build flags for the build script.