### PR TITLE
Remove bundler version and change Ruby version [changelog skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   hatchet-test:
     docker:
-      - image: circleci/ruby:2.7.2
+      - image: circleci/ruby:2.6.5
     steps:
       - checkout
       - run:

--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -3,6 +3,5 @@
 [ "$CI" != "true" ] && echo "Not running on CI!" && exit 1
 [ "$CIRCLE_PROJECT_USERNAME" != "heroku" ] && echo "Run tests manually for forked PRs." && exit 0
 
-gem install bundler:1.17.3
 bundle install
 bundle exec hatchet ci:setup


### PR DESCRIPTION
Match Ruby and bundler version to the versions of the internal sync versions.