### PR TITLE
move build flags into script name string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Fix syntax for passing in script flags for npm build script ([#869](https://github.com/heroku/heroku-buildpack-nodejs/pull/869))
 
 ## v178 (2020-11-17)
 - Add NODE_BUILD_FLAG env var ([#859](https://github.com/heroku/heroku-buildpack-nodejs/pull/859))

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -54,17 +54,18 @@ run_build_if_present() {
       echo "Running $script_name (yarn)"
       # yarn will throw an error if the script is an empty string, so check for this case
       if [[ -n "$script" ]]; then
-        if [[ -n $NODE_BUILD_FLAG ]]; then
-          echo "Running with $NODE_BUILD_FLAG flags"
-          monitor "${script_name}-script" yarn run "$script_name" "$NODE_BUILD_FLAG"
+        if [[ -n $NODE_BUILD_FLAGS ]]; then
+          echo "Running with $NODE_BUILD_FLAGS flags"
+          monitor "${script_name}-script" yarn run "$script_name" "$NODE_BUILD_FLAGS"
+        else
+          monitor "${script_name}-script" yarn run "$script_name"
         fi
-        monitor "${script_name}-script" yarn run "$script_name"
       fi
     else
       echo "Running $script_name"
-      if [[ -n $NODE_BUILD_FLAG ]]; then
-        echo "Running with $NODE_BUILD_FLAG flags"
-        monitor "${script_name}-script" npm run "$script_name" "$NODE_BUILD_FLAG" --if-present
+      if [[ -n $NODE_BUILD_FLAGS ]]; then
+        echo "Running with $NODE_BUILD_FLAGS flags"
+        monitor "${script_name}-script" npm run "$script_name" --if-present -- "$NODE_BUILD_FLAGS"
       else
         monitor "${script_name}-script" npm run "$script_name" --if-present
       fi

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -47,7 +47,6 @@ monitor() {
   local peak_mem_output start
   local command_name=$1
   shift
-
   local command=( "$@" )
 
   peak_mem_output=$(mktemp)

--- a/test/run
+++ b/test/run
@@ -74,10 +74,23 @@ testBuildFlags() {
   cache=$(mktmpdir)
   env_dir=$(mktmpdir)
 
-  echo "--prod --optimize" > $env_dir/NODE_BUILD_FLAG
+  echo "--prod --optimize" > $env_dir/NODE_BUILD_FLAGS
   compile "build-script" $cache $env_dir
   assertCaptured "Running build"
   assertCaptured "Running with --prod --optimize flags"
+  assertCaptured 'echo build hook message "--prod --optimize"'
+  assertCapturedSuccess
+}
+
+testBuildFlagsWithYarn() {
+  cache=$(mktmpdir)
+  env_dir=$(mktmpdir)
+
+  echo "--prod --optimize" > $env_dir/NODE_BUILD_FLAGS
+  compile "build-script-yarn" $cache $env_dir
+  assertCaptured "Running build"
+  assertCaptured "Running with --prod --optimize flags"
+  assertCaptured "$ echo build hook message '--prod --optimize'"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Fixes the previously implemented customizable build flag with the following:

- adds the `--` for adding flags to npm scripts
- adds an `else` for executing a yarn script without flags
- changes env var to `NODE_BUILD_FLAGS`