### PR TITLE
Add unit tests around WEB_CONCURRENCY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 - Update node version to 14 ([#885](https://github.com/heroku/heroku-buildpack-nodejs/pull/885))
+- Add unit tests around the behavior of `WEB_CONCURRENCY` ([#876](https://github.com/heroku/heroku-buildpack-nodejs/pull/876))
 
 # v182 (2020-01-05)
 - add Node 14.15.3 and 15.5.0 to inventory ([#881](https://github.com/heroku/heroku-buildpack-nodejs/pull/881))

--- a/test/unit
+++ b/test/unit
@@ -281,6 +281,22 @@ testBuildDataPreviousBuild() {
   assertEquals "$(meta_get test)" ""
 }
 
+testWebConcurrencyDoesNotOverrideManualValue() {
+  WEB_CONCURRENCY=123
+
+  source "$(pwd)"/profile/WEB_CONCURRENCY.sh
+
+  assertEquals 123 "$WEB_CONCURRENCY"
+}
+
+testWebConcurrencySetsAValueWhenUnset() {
+  unset WEB_CONCURRENCY
+
+  source "$(pwd)"/profile/WEB_CONCURRENCY.sh
+
+  assertNotNull "WEB_CONCURRENCY is null" "$WEB_CONCURRENCY"
+}
+
 testWebConcurrencyProfileScript() {
   # this was set when we sourced the WEB_CONCURRENCY.sh file
   unset WEB_MEMORY


### PR DESCRIPTION
This buildpack is inconsistent with [the heroku/ruby buildpack's setting
of WEB_CONCURRENCY][1]. It tries to guess a reasonable value for
WEB_CONCURRENCY, even if one is set manually in the application's
configuration.

Since this value is used, by default, [by the Puma web server][2], this
behavior is undesirable. Newer Rails applications use both the
heroku/nodejs buildpack and the heroku/ruby buildpack because Rails
manages assets through Webpack.

This change respects any value that the customer sets for
WEB_CONCURRENCY via `heroku config:set` instead of blindly overwriting
the value. With this behavior, the customer can better control the
process-level concurrency for their applications.

I verified that this behavior does, indeed, occur by doing the
following:

1. `heroku config:set WEB_CONCURRENCY=2 -a <myapp>`
2. `heroku run -a <myapp> bash`
3. `echo $WEB_CONCURRENCY`

For step (3), the value was set to `WEB_CONCURRENCY=1` instead of the
expected `WEB_CONCURRENCY=2`. I do not believe the buildpacks have an
order-dependence since the Ruby one does not override a set value.

[1]: https://github.com/heroku/heroku-buildpack-ruby/blob/ff7927dc5f93d89a45683895ac157d739bfbb2f1/lib/language_pack/ruby.rb#L321-L344
[2]: https://github.com/puma/puma/blob/c13829c258034dbe6511c5e60604b7546e125d19/lib/puma/configuration.rb#L195