### PR TITLE
upgrade to use Ruby 2.7.x and Bundler 2 [changelog skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   hatchet-test:
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7.2
     steps:
       - checkout
       - run:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,4 +62,4 @@ DEPENDENCIES
   sem_version
 
 BUNDLED WITH
-   1.17.3
+   2.2.1


### PR DESCRIPTION
Upgrades Ruby and Bundler for use on CI for hatchet tests.