### PR TITLE
add warning for ng build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Warn to use build flag with ng build as build script ([#878](https://github.com/heroku/heroku-buildpack-nodejs/pull/878))
 
 ## v180 (2020-12-09)
 - add Node 15.4.0 to inventory ([#873](https://github.com/heroku/heroku-buildpack-nodejs/pull/873))

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -49,6 +49,10 @@ run_build_if_present() {
   has_script_name=$(has_script "$build_dir/package.json" "$script_name")
   script=$(read_json "$build_dir/package.json" ".scripts[\"$script_name\"]")
 
+  if [[ "$script" == "ng build" ]]; then
+    warn "\"ng build\" detected as build script. We recommend you use \`ng build --prod\` or add \`--prod\` to your build flags. See https://devcenter.heroku.com/articles/nodejs-support#build-flags"
+  fi
+
   if [[ "$has_script_name" == "true" ]]; then
     if $YARN || $YARN_2; then
       echo "Running $script_name (yarn)"

--- a/test/fixtures/ng-build-script/README.md
+++ b/test/fixtures/ng-build-script/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/ng-build-script/package.json
+++ b/test/fixtures/ng-build-script/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts" : {
+    "build" : "ng build"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -66,7 +66,6 @@ testBuildScriptBehavior() {
 testNgBuildScriptWarning() {
   compile "ng-build-script"
   assertCaptured "\"ng build\" detected as build script. We recommend you use \`ng build --prod\` or add \`--prod\` to your build flags."
-  assertCapturedSuccess
 }
 
 testBuildScriptYarn() {

--- a/test/run
+++ b/test/run
@@ -63,6 +63,12 @@ testBuildScriptBehavior() {
   assertCapturedSuccess
 }
 
+testNgBuildScriptWarning() {
+  compile "ng-build-script"
+  assertCaptured "\"ng build\" detected as build script. We recommend you use \`ng build --prod\` or add \`--prod\` to your build flags."
+  assertCapturedSuccess
+}
+
 testBuildScriptYarn() {
   compile "build-script-yarn"
   assertCaptured "Running build (yarn)"


### PR DESCRIPTION
Warn users of having `ng build` in their build script. Recommend using node build flags --prod instead.