### PR TITLE
Report resolve parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 - add Node 14.15.3 and 15.5.0 to inventory ([#881](https://github.com/heroku/heroku-buildpack-nodejs/pull/881))
+- Report on parsing errors for `resolve-version.rs` ([#883](https://github.com/heroku/heroku-buildpack-nodejs/pull/883))
 
 ## v181 (2020-12-16)
 - Warn to use build flag with ng build as build script ([#878](https://github.com/heroku/heroku-buildpack-nodejs/pull/878))

--- a/bin/report
+++ b/bin/report
@@ -152,6 +152,7 @@ kv_pair "resolve_v2_node" "$(meta_get "resolve-v2-node")"
 kv_pair "resolve_v2_yarn" "$(meta_get "resolve-v2-yarn")"
 kv_pair "resolve_is_equal_node" "$(meta_get "resolve-is-equal-node")"
 kv_pair "resolve_is_equal_yarn" "$(meta_get "resolve-is-equal-yarn")"
+kv_pair_string "resolve_v2_error" "$(meta_get "resolve-v2-error")"
 
 # save which features were turned on or off
 features_list | tr ' ' '\n' | while read -r key; do

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -24,6 +24,7 @@ resolve() {
       meta_set "resolve-v1-$binary" "$output"
       meta_set "resolve-v2-$binary" "$v2_output"
       meta_set "resolve-is-equal-$binary" "$resolve_is_equal"
+      meta_set "resolve-v2-error" "$STD_ERR"
 
       echo "$output"
       return 0


### PR DESCRIPTION
Right now, the `resolve` binary prints to `$STD_ERR` instead of `$STD_OUT`. This change will write the parsing errors the reporting file and send them to internal reporting.