### PR TITLE
change node version to 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Update node version to 14 ([#885](https://github.com/heroku/heroku-buildpack-nodejs/pull/885))
 
 # v182 (2020-01-05)
 - add Node 14.15.3 and 15.5.0 to inventory ([#881](https://github.com/heroku/heroku-buildpack-nodejs/pull/881))

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -87,7 +87,7 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version=${1:-12.x}
+  local version=${1:-14.x}
   local dir="${2:?}"
   local code os cpu resolve_result
 

--- a/test/run
+++ b/test/run
@@ -157,8 +157,8 @@ testYarnRun() {
 testNoVersion() {
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "Resolving node version 12.x"
-  assertCaptured "Downloading and installing node 12."
+  assertCaptured "Resolving node version 14.x"
+  assertCaptured "Downloading and installing node 14."
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
With Node 14 as the current active version, we will install the latest version of Node 14 as default.