### PR TITLE
log the build time before the build fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add Node v15.6.0 to inventory ([#892](https://github.com/heroku/heroku-buildpack-nodejs/pull/892))
 - add Node 10.23.2 and 15.7.0 to inventory ([#894](https://github.com/heroku/heroku-buildpack-nodejs/pull/894))
 - Update Node.js plugin for Node 15; Add tests for Node 15 ([#895](https://github.com/heroku/heroku-buildpack-nodejs/pull/895))
+- Log the build time in a failed build ([#896](https://github.com/heroku/heroku-buildpack-nodejs/pull/896))
 
 ## v182 (2020-01-05)
 - add Node 14.15.3 and 15.5.0 to inventory ([#881](https://github.com/heroku/heroku-buildpack-nodejs/pull/881))

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -10,6 +10,7 @@ detect_package_manager() {
 }
 
 fail() {
+  meta_time "build-time" "$build_start_time"
   log_meta_data >> "$BUILDPACK_LOG_FILE"
   exit 1
 }


### PR DESCRIPTION
This adds a build-time ended k/v pair to the build reporting right before the build fails.