### PR TITLE
Prefer local packages when present in cache

### DIFF
--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -137,7 +137,7 @@ yarn_node_modules() {
 
   echo "Installing node modules (yarn.lock)"
   cd "$build_dir" || return
-  monitor "yarn-install" yarn install --production="$production" --frozen-lockfile --ignore-engines 2>&1
+  monitor "yarn-install" yarn install --production="$production" --frozen-lockfile --ignore-engines --prefer-offline 2>&1
 }
 
 yarn_2_install() {


### PR DESCRIPTION
This change updates the `yarn install` step to use the
`--prefer-offline` argument. This chaneg avoids reinstalling
already-present packages when the local cache has them. Yarn's
default behavior is to attempt to install packages from the network before
falling back to the local cache, which can be unnecessarily time-consuming.
