### PR TITLE
Drop Heroku-16 from CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,6 @@ workflows:
       - unit-test-heroku-build:
           name: heroku-18 build tests
           stack-number: "18"
-      - unit-test:
-          name: heroku-16 unit tests
-          stack-number: "16"
-      - unit-test-heroku-build:
-          name: heroku-16 build tests
-          stack-number: "16"
       - hatchet-test:
           name: Hatchet tests
       - unit-test-binary:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Drop Heroku-16 from CI test matrix ([#920](https://github.com/heroku/heroku-buildpack-nodejs/pull/920))
 
 ## v184 (2021-05-20)
 - Prune devDependencies with Yarn 2 ([#891](https://github.com/heroku/heroku-buildpack-nodejs/pull/891))

--- a/README.md
+++ b/README.md
@@ -111,9 +111,8 @@ make test
 Or to just test a specific stack:
 
 ```
-make heroku-16
-make heroku-18
-make heroku-20
+make heroku-18-build
+make heroku-20-build
 ```
 
 The tests are run via the vendored

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-test: heroku-20-build heroku-18-build heroku-16-build
+test: heroku-20-build heroku-18-build
 
 build:
 	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./lib/vendor/resolve-version-darwin ./cmd/resolve-version
@@ -31,11 +31,6 @@ heroku-18-build:
 	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-18-build" heroku/heroku:18-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
 	@echo ""
 
-heroku-16-build:
-	@echo "Running tests in docker (heroku-16-build)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-16-build" heroku/heroku:16-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
-	@echo ""
-
 hatchet:
 	@echo "Running hatchet integration tests..."
 	@bash etc/ci-setup.sh
@@ -49,11 +44,11 @@ nodebin-test:
 	@echo ""
 
 unit:
-	@echo "Running unit tests in docker (heroku-18)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-18" heroku/heroku:18 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/unit;'
+	@echo "Running unit tests in docker (heroku-20)..."
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-20" heroku/heroku:20 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/unit;'
 	@echo ""
 
 shell:
-	@echo "Opening heroku-16 shell..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it heroku/heroku:16 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; bash'
+	@echo "Opening heroku-20 shell..."
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it heroku/heroku:20 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; bash'
 	@echo ""


### PR DESCRIPTION
The Heroku-16 stack reached end-of-life on May 1st, 2021, and from June 1st, 2021, builds will be disabled.

This removes support for testing against Heroku-16 in CI.

This change is non-breaking as it only affects development (hence why it's landing a few days early), however a changelog entry has been added regardless, for improved visibility into the support status of the stack.

Closes GUS-W-9329672.