### PR TITLE
feat: set xtrace if $BUILDPACK_XTRACE set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ## v190 (2022-01-31)
 - Update default node version to 16.x ([#973](https://github.com/heroku/heroku-buildpack-nodejs/pull/973))
 - Add Yarn 1.22.1{2,3,4,5} to `inventory/yarn.toml` ([#947](https://github.com/heroku/heroku-buildpack-nodejs/pull/947))
+- Set xtrace mode in buildpack when BUILDPACK_XTRACE environment variable is set ([#925](https://github.com/heroku/heroku-buildpack-nodejs/pull/925))
 
 ## v189 (2021-09-14)
 - Revert non-zero-install support from #888 ([#944](https://github.com/heroku/heroku-buildpack-nodejs/pull/944))

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,8 @@ set -o errexit    # always exit on error
 set -o pipefail   # don't ignore exit codes when piping output
 unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 
+[ "$BUILDPACK_XTRACE" ] && set -o xtrace
+
 ### Constants
 
 # This is used by the buildpack stdlib for metrics

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
+[ "$BUILDPACK_XTRACE" ] && set -o xtrace
+
 error() {
   local c="2,999 s/^/ !     /"
 	# send all of our output to stderr


### PR DESCRIPTION
For debugging or for folks who are curious about how the buildpack works.

Similar implementation here: heroku/heroku-buildpack-python#226