### PR TITLE
Don't override WEB_CONCURRENCY if set

### DIFF
--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -58,7 +58,7 @@ appropriate for your application."
 DETECTED=$(detect_memory 512)
 export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(bound_memory $DETECTED)}
 export WEB_MEMORY=${WEB_MEMORY-512}
-export WEB_CONCURRENCY=$(calculate_concurrency $MEMORY_AVAILABLE $WEB_MEMORY)
+export WEB_CONCURRENCY=${WEB_CONCURRENCY:-$(calculate_concurrency $MEMORY_AVAILABLE $WEB_MEMORY)}
 
 warn_bad_web_concurrency
 


### PR DESCRIPTION
We would like to take advantage of the [Puma Memory Reduction](https://medium.com/@CGA1123/reducing-rails-memory-usage-by-15-56090b6294bd) available through single mode.

However the Heroku/NodeJS buildpack currently overrides `WEB_CONCURRENCY` when determining the best configuration based on system memorry.

This pull request updates the script to keep the existing default if it is set, I'm not certain this is the best approach but thought this is a good way to start the conversation.