### PR TITLE
Fix NODE_BINARY_URL extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 - Refactor $WEB_CONCURRENCY logic ([#931](https://github.com/heroku/heroku-buildpack-nodejs/pull/931))
 - Fix broken tests, update node and yarn inventory, update shunit2 ([#934](https://github.com/heroku/heroku-buildpack-nodejs/pull/934))
+- Fix NODE_BINARY_URL extraction prefix stripping logic ([#928](https://github.com/heroku/heroku-buildpack-nodejs/pull/928))
 
 ## v185 (2021-06-03)
 - Drop Heroku-16 from CI test matrix ([#920](https://github.com/heroku/heroku-buildpack-nodejs/pull/920))

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -89,10 +89,7 @@ install_yarn() {
 install_nodejs() {
   local version=${1:-14.x}
   local dir="${2:?}"
-  local code os cpu resolve_result
-
-  os=$(get_os)
-  cpu=$(get_cpu)
+  local code resolve_result
 
   if [[ -n "$NODE_BINARY_URL" ]]; then
     url="$NODE_BINARY_URL"
@@ -115,9 +112,8 @@ install_nodejs() {
   if [ "$code" != "200" ]; then
     echo "Unable to download node: $code" && false
   fi
-  tar xzf /tmp/node.tar.gz -C /tmp
   rm -rf "${dir:?}"/*
-  mv /tmp/node-v"$number"-"$os"-"$cpu"/* "$dir"
+  tar xzf /tmp/node.tar.gz --strip-components 1 -C "$dir"
   chmod +x "$dir"/bin/*
 }
 


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-buildpack-nodejs/issues/927

Maintains backward compatibility with anyone who set up a custom tarball with an embedded misnamed folder like `node-v-linux-x64` by stripping the initial path component unconditionally rather than baking in an assumption about what that path component will look like. 