### PR TITLE
Set WEB_CONCURRENCY_SET_BY if appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 - Refactor $WEB_CONCURRENCY logic ([#931](https://github.com/heroku/heroku-buildpack-nodejs/pull/931))
+- Export `WEB_CONCURRENCY_SET_BY=heroku/nodejs` if we've calculated and set it ([#932](https://github.com/heroku/heroku-buildpack-nodejs/pull/932))
 
 ## v185 (2021-06-03)
 - Drop Heroku-16 from CI test matrix ([#920](https://github.com/heroku/heroku-buildpack-nodejs/pull/920))

--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -64,6 +64,7 @@ appropriate for your application.
 DETECTED=$(detect_memory 512)
 export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(bound_memory $DETECTED)}
 export WEB_MEMORY=${WEB_MEMORY-512}
+OLD_WEB_CONCURRENCY="${WEB_CONCURRENCY:-}" # we need to remember whether WEB_CONCURRENCY was set already
 WEB_CONCURRENCY=${WEB_CONCURRENCY-$(calculate_concurrency "$MEMORY_AVAILABLE" "$WEB_MEMORY")}
 validated_concurrency=$(validate_concurrency "$WEB_CONCURRENCY")
 case $? in # validate_concurrency exit code indicates result
@@ -80,6 +81,7 @@ case $? in # validate_concurrency exit code indicates result
     export WEB_CONCURRENCY
     ;;
 esac
+[[ -z "${OLD_WEB_CONCURRENCY:+isset}" || "${OLD_WEB_CONCURRENCY}" != "${WEB_CONCURRENCY}" ]] && export WEB_CONCURRENCY_SET_BY="heroku/nodejs"
 
 if [[ "${LOG_CONCURRENCY+isset}" && "$LOG_CONCURRENCY" == "true" ]]; then
   log_concurrency

--- a/test/unit
+++ b/test/unit
@@ -287,6 +287,16 @@ testWebConcurrencyDoesNotOverrideManualValue() {
   source "$(pwd)"/profile/WEB_CONCURRENCY.sh
 
   assertEquals 123 "$WEB_CONCURRENCY"
+  assertNull "$WEB_CONCURRENCY_SET_BY"
+}
+
+testWebConcurrencyOverridesOutOfBounds() {
+  WEB_CONCURRENCY=400
+
+  source "$(pwd)"/profile/WEB_CONCURRENCY.sh
+
+  assertEquals 1 "$WEB_CONCURRENCY"
+  assertEquals "heroku/nodejs" "$WEB_CONCURRENCY_SET_BY"
 }
 
 testWebConcurrencySetsAValueWhenUnset() {
@@ -295,6 +305,7 @@ testWebConcurrencySetsAValueWhenUnset() {
   source "$(pwd)"/profile/WEB_CONCURRENCY.sh
 
   assertNotNull "WEB_CONCURRENCY is null" "$WEB_CONCURRENCY"
+  assertEquals "heroku/nodejs" "$WEB_CONCURRENCY_SET_BY"
 }
 
 testWebConcurrencyProfileScript() {


### PR DESCRIPTION
If WEB_CONCURRENCY is unset and we are calculating it, or if it is set to an out-of-bounds value, then we set WEB_CONCURRENCY_SET_BY=heroku/nodejs.

The purpose of this variable is to allow another buildpack running before this buildpack, but which is actually the buildpack that's launching the web process, to be able to ignore the set value, or at least warn the user about the potentially wrong value for their purpose.

Without this, it's not possible for following code (e.g. the WEB_CONCURRENCY calculation of another language if it happens at startup) to tell the whether WEB_CONCURRENCY was set by the user, or whether it was set by e.g. heroku/nodejs - the variable exists in the environment in either case.

It's not uncommon for users of other programming languages to use heroku/nodejs together with their language, and have it e.g. build assets with webpack. The correct usage order in that case of course is to have heroku/nodejs install webpack first, then have the "main" programming language buildpack run, and from in there, using whatever hooks it provides, run e.g. 'webpack' - but many users instead set their "primary" language buildpack set as the first buildpack, and heroku/nodejs second (and have that run e.g. 'webpack' for them).

With this env var set, it's also possible for a user (or support) to understand where a value for WEB_CONCURRENCY is coming from.