### PR TITLE
Fix broken tests; bump shUnit2 to 2.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 - Refactor $WEB_CONCURRENCY logic ([#931](https://github.com/heroku/heroku-buildpack-nodejs/pull/931))
+- Fix broken tests, update node and yarn inventory, update shunit2 ([#934](https://github.com/heroku/heroku-buildpack-nodejs/pull/934))
 
 ## v185 (2021-06-03)
 - Drop Heroku-16 from CI test matrix ([#920](https://github.com/heroku/heroku-buildpack-nodejs/pull/920))

--- a/inventory/node.toml
+++ b/inventory/node.toml
@@ -3788,6 +3788,20 @@ url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.2
 etag = "6a05b6db3a7e812691eb2992c8287670-3"
 
 [[releases]]
+version = "10.24.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.24.0-linux-x64.tar.gz"
+etag = "b179fd013f51c02a3c77281fe744dd41-3"
+
+[[releases]]
+version = "10.24.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.24.1-linux-x64.tar.gz"
+etag = "957994ef8bf3610b7f0b67365691ebaf-3"
+
+[[releases]]
 version = "10.3.0"
 channel = "release"
 arch = "linux-x64"
@@ -4152,6 +4166,48 @@ url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.2
 etag = "d296cca07540a62c9c583ce4f23afee7-3"
 
 [[releases]]
+version = "12.21.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.21.0-linux-x64.tar.gz"
+etag = "a0fe4d871fc223d21fbac24689c598fd-3"
+
+[[releases]]
+version = "12.22.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.0-linux-x64.tar.gz"
+etag = "b0eb62d33d028e6cd3f1b7220b962a55-3"
+
+[[releases]]
+version = "12.22.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.1-linux-x64.tar.gz"
+etag = "4648915ed3eb1be12cf7cbe1c5b3e867-3"
+
+[[releases]]
+version = "12.22.2"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.2-linux-x64.tar.gz"
+etag = "a014e16e46f6c158facd9d48c6a450f7-3"
+
+[[releases]]
+version = "12.22.3"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.3-linux-x64.tar.gz"
+etag = "41956f3f2a7cbbfc012e0d52facee55d-3"
+
+[[releases]]
+version = "12.22.4"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v12.22.4-linux-x64.tar.gz"
+etag = "461546c7894049caaa06041520e4172e-3"
+
+[[releases]]
 version = "12.3.0"
 channel = "release"
 arch = "linux-x64"
@@ -4446,6 +4502,55 @@ url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.1
 etag = "78ef6759634ee37a78d17be7af46ed79-4"
 
 [[releases]]
+version = "14.16.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.16.0-linux-x64.tar.gz"
+etag = "f2cbbae39184fee9c13b611437b10921-4"
+
+[[releases]]
+version = "14.16.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.16.1-linux-x64.tar.gz"
+etag = "e03bf3ea73d969d9c08c8b7ae5493613-4"
+
+[[releases]]
+version = "14.17.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.0-linux-x64.tar.gz"
+etag = "cdc57f6a3cc4ca6f12f49dadd75a554e-5"
+
+[[releases]]
+version = "14.17.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.1-linux-x64.tar.gz"
+etag = "b41c1f2d90ecda727af59f7cc7c5dcfb-5"
+
+[[releases]]
+version = "14.17.2"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.2-linux-x64.tar.gz"
+etag = "7021d231631d65ece0f74c95bbc43eb3-5"
+
+[[releases]]
+version = "14.17.3"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.3-linux-x64.tar.gz"
+etag = "0bdbb8e1b6e813dbc040da523831c684-5"
+
+[[releases]]
+version = "14.17.4"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v14.17.4-linux-x64.tar.gz"
+etag = "81ca69987ef377abff2ecb2ae35d7ad7-5"
+
+[[releases]]
 version = "14.2.0"
 channel = "release"
 arch = "linux-x64"
@@ -4523,6 +4628,41 @@ url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.1
 etag = "e1d3af432eb7accbfc614a3cf48c7583-4"
 
 [[releases]]
+version = "15.10.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.10.0-linux-x64.tar.gz"
+etag = "485a712d740b014662a226e834bd9557-4"
+
+[[releases]]
+version = "15.11.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.11.0-linux-x64.tar.gz"
+etag = "ef6f1f9484a255594673ca7bcfbed280-4"
+
+[[releases]]
+version = "15.12.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.12.0-linux-x64.tar.gz"
+etag = "231a5764d7aafa2c8d99fcd147b0e875-4"
+
+[[releases]]
+version = "15.13.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.13.0-linux-x64.tar.gz"
+etag = "6a6b953c042ee7fca4a7e4482de60dc2-4"
+
+[[releases]]
+version = "15.14.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.14.0-linux-x64.tar.gz"
+etag = "0f2e0ef70eebc4840eab7547e59880ae-4"
+
+[[releases]]
 version = "15.2.0"
 channel = "release"
 arch = "linux-x64"
@@ -4584,6 +4724,83 @@ channel = "release"
 arch = "linux-x64"
 url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.8.0-linux-x64.tar.gz"
 etag = "e88c6266c1926b5c4348ad943e1c2ee2-4"
+
+[[releases]]
+version = "15.9.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v15.9.0-linux-x64.tar.gz"
+etag = "38308de828100c4f52adb07e8de3cc9d-4"
+
+[[releases]]
+version = "16.0.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.0.0-linux-x64.tar.gz"
+etag = "9ced677cf96c5ca3b4067f35c21311ac-4"
+
+[[releases]]
+version = "16.1.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.1.0-linux-x64.tar.gz"
+etag = "8d4e3e558429cf64b22302f210b3d7e5-4"
+
+[[releases]]
+version = "16.2.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.2.0-linux-x64.tar.gz"
+etag = "ee81bd1f587c60c54432650eba4c51bc-4"
+
+[[releases]]
+version = "16.3.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.3.0-linux-x64.tar.gz"
+etag = "b0a9cecd669951adac9e27a35102923d-4"
+
+[[releases]]
+version = "16.4.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.4.0-linux-x64.tar.gz"
+etag = "8a77e82e1ca44f4fe1922714403161e8-4"
+
+[[releases]]
+version = "16.4.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.4.1-linux-x64.tar.gz"
+etag = "558b0575a48ff39c21a1fd9402fa0b84-4"
+
+[[releases]]
+version = "16.4.2"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.4.2-linux-x64.tar.gz"
+etag = "722a9783a7201b020ad6a89b9703cc3b-4"
+
+[[releases]]
+version = "16.5.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.5.0-linux-x64.tar.gz"
+etag = "5322a660d103a2974b9e073eae890bfb-4"
+
+[[releases]]
+version = "16.6.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.6.0-linux-x64.tar.gz"
+etag = "dfbee0cdf68d776ad1e51ca482250b0a-4"
+
+[[releases]]
+version = "16.6.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v16.6.1-linux-x64.tar.gz"
+etag = "bc15b11b0fd5ff2b62c6bf83646c82df-4"
 
 [[releases]]
 version = "4.0.0"
@@ -6707,6 +6924,20 @@ url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.2
 etag = "6a05b6db3a7e812691eb2992c8287670-3"
 
 [[releases]]
+version = "10.24.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.24.0-linux-x64.tar.gz"
+etag = "b179fd013f51c02a3c77281fe744dd41-3"
+
+[[releases]]
+version = "10.24.1"
+channel = "staging"
+arch = "linux-x64"
+url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v10.24.1-linux-x64.tar.gz"
+etag = "957994ef8bf3610b7f0b67365691ebaf-3"
+
+[[releases]]
 version = "10.9.0"
 channel = "staging"
 arch = "linux-x64"
@@ -6769,429 +7000,3 @@ arch = "linux-x64"
 url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.14.0-linux-x64.tar.gz"
 etag = "d1ec8cc7a5a102c92d5486cfa9e03b00"
 
-[[releases]]
-version = "11.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.15.0-linux-x64.tar.gz"
-etag = "ab251fc5b77761064204d00be022fda3"
-
-[[releases]]
-version = "11.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.2.0-linux-x64.tar.gz"
-etag = "6f1e2002e2af3f660ec0d84dda5e8a6a"
-
-[[releases]]
-version = "11.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.3.0-linux-x64.tar.gz"
-etag = "dc1a836d178e97e06107e1673d3caf96"
-
-[[releases]]
-version = "11.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.4.0-linux-x64.tar.gz"
-etag = "2718dafe1f89dd3794a0da222ee365ae"
-
-[[releases]]
-version = "11.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.5.0-linux-x64.tar.gz"
-etag = "7a32d6b4c300f6a7b78f3a28ed4587e3"
-
-[[releases]]
-version = "11.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.6.0-linux-x64.tar.gz"
-etag = "9ab9d9540290c15caad5fdf0a32b40fa"
-
-[[releases]]
-version = "11.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.7.0-linux-x64.tar.gz"
-etag = "35c41456320eb8a712dde2aac4145166"
-
-[[releases]]
-version = "11.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.8.0-linux-x64.tar.gz"
-etag = "7a6bdb9ffd31bc5ae4c6d866b5462826"
-
-[[releases]]
-version = "11.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v11.9.0-linux-x64.tar.gz"
-etag = "8805aeb4cfb798106c6a99ed34536682"
-
-[[releases]]
-version = "12.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.0.0-linux-x64.tar.gz"
-etag = "246f00fcffbd01974f260b4383f91c58"
-
-[[releases]]
-version = "12.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.1.0-linux-x64.tar.gz"
-etag = "d4df5a60e1b73c062131985de2ada621"
-
-[[releases]]
-version = "12.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.10.0-linux-x64.tar.gz"
-etag = "74dc625cf656bd501f0cd08f28e92131"
-
-[[releases]]
-version = "12.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.11.0-linux-x64.tar.gz"
-etag = "3ad3502adff89d3a037cd910ef17f725"
-
-[[releases]]
-version = "12.11.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.11.1-linux-x64.tar.gz"
-etag = "fb56b6d4439d3ccca91a8ff419391c3e"
-
-[[releases]]
-version = "12.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.12.0-linux-x64.tar.gz"
-etag = "41e3b3ccc2e2254869234f1f4c50dffc"
-
-[[releases]]
-version = "12.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.13.0-linux-x64.tar.gz"
-etag = "5f1bc3459c59f8b80cf6ea3d38944da7"
-
-[[releases]]
-version = "12.13.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.13.1-linux-x64.tar.gz"
-etag = "169ca5c7407b7532ed947a2014a48b1e"
-
-[[releases]]
-version = "12.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.14.0-linux-x64.tar.gz"
-etag = "919f124e16acb7464459c58dd2cfd36e"
-
-[[releases]]
-version = "12.14.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.14.1-linux-x64.tar.gz"
-etag = "cf97b81a436bdd484e642660eb769e16"
-
-[[releases]]
-version = "12.15.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.15.0-linux-x64.tar.gz"
-etag = "6c5ee256556aec2f1ca11f02b58d81b4"
-
-[[releases]]
-version = "12.16.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.0-linux-x64.tar.gz"
-etag = "7f8d2520e715d7df82f368b0fab9d2b6"
-
-[[releases]]
-version = "12.16.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.1-linux-x64.tar.gz"
-etag = "656435219a1655586fe02ac5f8bfa694"
-
-[[releases]]
-version = "12.16.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.2-linux-x64.tar.gz"
-etag = "ee1bd62aa6e09c627610868e3d0117bf-3"
-
-[[releases]]
-version = "12.16.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.16.3-linux-x64.tar.gz"
-etag = "f0478be22ff8042183df5b8cf0e6a736-3"
-
-[[releases]]
-version = "12.17.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.17.0-linux-x64.tar.gz"
-etag = "4a9c63315d8b0c2e41711caf04121acd-3"
-
-[[releases]]
-version = "12.18.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.0-linux-x64.tar.gz"
-etag = "cce51b56de0a404d30864591c1b6695c-3"
-
-[[releases]]
-version = "12.18.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.1-linux-x64.tar.gz"
-etag = "8e2e94383d7e833eb42fa619c27ed4df-3"
-
-[[releases]]
-version = "12.18.2"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.2-linux-x64.tar.gz"
-etag = "655570eb6f1b10edafc64366878dd03e-3"
-
-[[releases]]
-version = "12.18.3"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.3-linux-x64.tar.gz"
-etag = "9e7444e9d66072035f73e9ac0ee51322-3"
-
-[[releases]]
-version = "12.18.4"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.18.4-linux-x64.tar.gz"
-etag = "fdecf94ced8dcdeb972e14b333c72e47-3"
-
-[[releases]]
-version = "12.19.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.19.0-linux-x64.tar.gz"
-etag = "1962f4127fb09f2942b82f48f4ae2cf8-3"
-
-[[releases]]
-version = "12.19.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.19.1-linux-x64.tar.gz"
-etag = "7851352d2c9d60d4c5779910af828755-3"
-
-[[releases]]
-version = "12.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.2.0-linux-x64.tar.gz"
-etag = "87dc21fee7f484defd9010a6c606aa92"
-
-[[releases]]
-version = "12.20.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.20.0-linux-x64.tar.gz"
-etag = "3383e1624171a83a04740f24831c5c92-3"
-
-[[releases]]
-version = "12.20.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.20.1-linux-x64.tar.gz"
-etag = "51c80c3820855d8e77f37c9a67b9d89b-3"
-
-[[releases]]
-version = "12.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.3.0-linux-x64.tar.gz"
-etag = "123a93553a06e8a7615c444c1ea42882"
-
-[[releases]]
-version = "12.3.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.3.1-linux-x64.tar.gz"
-etag = "82721dca1c9757af1e50fda8f23a0175"
-
-[[releases]]
-version = "12.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.4.0-linux-x64.tar.gz"
-etag = "75341c471626e3155079041fc8737bab"
-
-[[releases]]
-version = "12.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.5.0-linux-x64.tar.gz"
-etag = "7377ca5f3d429dba8069808c57509f24"
-
-[[releases]]
-version = "12.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.6.0-linux-x64.tar.gz"
-etag = "259326813ae277cf8a2cd764c610df8c"
-
-[[releases]]
-version = "12.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.7.0-linux-x64.tar.gz"
-etag = "b013a541a950c7ac8547622e4588542e"
-
-[[releases]]
-version = "12.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.8.0-linux-x64.tar.gz"
-etag = "2bc1f6bf496bfb6447c3fa129cf8a3d6"
-
-[[releases]]
-version = "12.8.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.8.1-linux-x64.tar.gz"
-etag = "f0ad395a6b921fa1121cd60aa3f47fef"
-
-[[releases]]
-version = "12.9.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.9.0-linux-x64.tar.gz"
-etag = "406857cde2b0012cb860653de74777ea"
-
-[[releases]]
-version = "12.9.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v12.9.1-linux-x64.tar.gz"
-etag = "74001acf6e4f1980045a985a86b198d1"
-
-[[releases]]
-version = "13.0.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.0.0-linux-x64.tar.gz"
-etag = "80ec0dee495ddf5ac1f52658fc7004d8"
-
-[[releases]]
-version = "13.0.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.0.1-linux-x64.tar.gz"
-etag = "248b1a416a4c2af6b888ce1897df12cd"
-
-[[releases]]
-version = "13.1.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.1.0-linux-x64.tar.gz"
-etag = "ef41097c9220782c8cac61161fe9eb60"
-
-[[releases]]
-version = "13.10.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.10.0-linux-x64.tar.gz"
-etag = "fc533a5c86419ad4976f7e15b5333100"
-
-[[releases]]
-version = "13.10.1"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.10.1-linux-x64.tar.gz"
-etag = "e5e28ed8047859e8be1cee3b7155df4e"
-
-[[releases]]
-version = "13.11.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.11.0-linux-x64.tar.gz"
-etag = "2af22200c0261f417cf32a3279da2621-4"
-
-[[releases]]
-version = "13.12.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.12.0-linux-x64.tar.gz"
-etag = "8d22abc5a44d5645c0a9eab6177df570-4"
-
-[[releases]]
-version = "13.13.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.13.0-linux-x64.tar.gz"
-etag = "b9a24b0caa34a7a12ebb3e31b6830769-4"
-
-[[releases]]
-version = "13.14.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.14.0-linux-x64.tar.gz"
-etag = "70ecff1b96a40b3330cc0b98ddf529b5-4"
-
-[[releases]]
-version = "13.2.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.2.0-linux-x64.tar.gz"
-etag = "021173844878f2a62d6644da631b384e"
-
-[[releases]]
-version = "13.3.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.3.0-linux-x64.tar.gz"
-etag = "0984273970fbe1b55d46a74132c79768"
-
-[[releases]]
-version = "13.4.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.4.0-linux-x64.tar.gz"
-etag = "822b0185650e14a8e614caa4db36e1b2"
-
-[[releases]]
-version = "13.5.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.5.0-linux-x64.tar.gz"
-etag = "28e68b5893a353dae4525655d3230d19"
-
-[[releases]]
-version = "13.6.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.6.0-linux-x64.tar.gz"
-etag = "5758d37594fa78cabb0b4578771a01fd"
-
-[[releases]]
-version = "13.7.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.7.0-linux-x64.tar.gz"
-etag = "66087b902dac00d18558ec6b892de497"
-
-[[releases]]
-version = "13.8.0"
-channel = "staging"
-arch = "linux-x64"
-url = "https://s3.amazonaws.com/heroku-nodebin/node/staging/linux-x64/node-v13.8.0-linux-x64.tar.gz"
-etag = "308ec153bc621d3ef32a3d9731083e44"

--- a/inventory/yarn.toml
+++ b/inventory/yarn.toml
@@ -487,6 +487,12 @@ url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.10.tar.gz
 etag = "52e8dbe9d0cb90683dd3ee2ebf2becb8"
 
 [[releases]]
+version = "1.22.11"
+channel = "release"
+url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.11.tar.gz"
+etag = "abac2ecbe725c04e91dafc56ae2163b3"
+
+[[releases]]
 version = "1.22.4"
 channel = "release"
 url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.4.tar.gz"
@@ -551,3 +557,4 @@ version = "1.9.4"
 channel = "release"
 url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.9.4.tar.gz"
 etag = "1202576a1a67d2228b44bb6f87a4eb64"
+

--- a/test/fixtures/cache-directories/bower.json
+++ b/test/fixtures/cache-directories/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "node-buildpack-test-app",
   "dependencies": {
-    "jquery": "^1.11.1"
+    "jquery": "^3.6.0"
   }
 }

--- a/test/fixtures/cache-directories/package.json
+++ b/test/fixtures/cache-directories/package.json
@@ -2,18 +2,21 @@
   "name": "node-buildpack-test-app",
   "version": "0.0.1",
   "description": "node buildpack integration test app",
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/example/example.git"
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/example/example.git"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   },
   "dependencies": {
-    "bower": "1.3.12"
+    "bower": "1.8.12"
   },
   "scripts": {
     "postinstall": "bower install --allow-root"
   },
-  "cache_directories": ["bower_components", "node_modules"]
+  "cache_directories": [
+    "bower_components",
+    "node_modules"
+  ]
 }

--- a/test/run
+++ b/test/run
@@ -1301,8 +1301,8 @@ testBuildMetaData() {
   assertFileContains "node-build-success=true" $log_file
 
   # resolve-version tests
-  assertFileContains 'resolve-v1-yarn="1.22.' $log_file
-  assertFileContains 'resolve-v2-yarn="1.22.' $log_file
+  assertFileContainsMatch 'resolve-v1-yarn="1.[[:digit:]]+.[[:digit:]]+ https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.[[:digit:]]+.[[:digit:]]+.tar.gz"' $log_file
+  assertFileContainsMatch 'resolve-v2-yarn="1.[[:digit:]]+.[[:digit:]]+ https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.[[:digit:]]+.[[:digit:]]+.tar.gz"' $log_file
   assertFileContains "resolve-is-equal-yarn=true" $log_file
 }
 

--- a/test/run
+++ b/test/run
@@ -1301,8 +1301,8 @@ testBuildMetaData() {
   assertFileContains "node-build-success=true" $log_file
 
   # resolve-version tests
-  assertFileContains 'resolve-v1-yarn="1.22.10 https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.10.tar.gz"' $log_file
-  assertFileContains 'resolve-v2-yarn="1.22.10 https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.10.tar.gz"' $log_file
+  assertFileContains 'resolve-v1-yarn="1.22.' $log_file
+  assertFileContains 'resolve-v2-yarn="1.22.' $log_file
   assertFileContains "resolve-is-equal-yarn=true" $log_file
 }
 

--- a/test/run
+++ b/test/run
@@ -1278,15 +1278,10 @@ testBuildMetaData() {
   assertFileContains "save-cache-time=" $log_file
 
   # resolve-version tests
-
-  # tests have become flaky because of releases that aren't caught on time, going to disable since
-  # we know this still works.
-
-  # TODO: replace with a better test
-
-  # assertFileContains 'resolve-v1-node="10.23.2 https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.23.2-linux-x64.tar.gz"' $log_file
-  # assertFileContains 'resolve-v2-node="10.23.2 https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.23.2-linux-x64.tar.gz"' $log_file
-  # assertFileContains "resolve-is-equal-node=true" $log_file
+  cat $log_file
+  assertFileContainsMatch 'resolve-v1-node="10.[[:digit:]]+.[[:digit:]]+ https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.[[:digit:]]+.[[:digit:]]+-linux-x64.tar.gz"' $log_file
+  assertFileContainsMatch 'resolve-v2-node="10.[[:digit:]]+.[[:digit:]]+ https://s3.amazonaws.com/heroku-nodebin/node/release/linux-x64/node-v10.[[:digit:]]+.[[:digit:]]+-linux-x64.tar.gz"' $log_file
+  assertFileContains "resolve-is-equal-node=true" $log_file
 
   # erase the log file
   echo "" > $log_file

--- a/test/shunit2
+++ b/test/shunit2
@@ -1,95 +1,154 @@
 #! /bin/sh
-# $Id: shunit2 335 2011-05-01 20:10:33Z kate.ward@forestent.com $
 # vim:et:ft=sh:sts=2:sw=2
 #
-# Copyright 2008 Kate Ward. All Rights Reserved.
-# Released under the LGPL (GNU Lesser General Public License)
+# Copyright 2008-2020 Kate Ward. All Rights Reserved.
+# Released under the Apache 2.0 license.
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # shUnit2 -- Unit testing framework for Unix shell scripts.
-# http://code.google.com/p/shunit2/
+# https://github.com/kward/shunit2
 #
 # Author: kate.ward@forestent.com (Kate Ward)
 #
 # shUnit2 is a xUnit based unit test framework for Bourne shell scripts. It is
 # based on the popular JUnit unit testing framework for Java.
+#
+# $() are not fully portable (POSIX != portable).
+#   shellcheck disable=SC2006
+# expr may be antiquated, but it is the only solution in some cases.
+#   shellcheck disable=SC2003
 
-# return if shunit already loaded
-[ -n "${SHUNIT_VERSION:-}" ] && exit 0
+# Return if shunit2 already loaded.
+command [ -n "${SHUNIT_VERSION:-}" ] && exit 0
+SHUNIT_VERSION='2.1.8'
 
-SHUNIT_VERSION='2.1.6'
-
+# Return values that scripts can use.
 SHUNIT_TRUE=0
 SHUNIT_FALSE=1
 SHUNIT_ERROR=2
 
-# enable strict mode by default
-SHUNIT_STRICT=${SHUNIT_STRICT:-${SHUNIT_TRUE}}
+# Logging functions.
+_shunit_warn() {
+  ${__SHUNIT_CMD_ECHO_ESC} \
+      "${__shunit_ansi_yellow}shunit2:WARN${__shunit_ansi_none} $*" >&2
+}
+_shunit_error() {
+  ${__SHUNIT_CMD_ECHO_ESC} \
+      "${__shunit_ansi_red}shunit2:ERROR${__shunit_ansi_none} $*" >&2
+}
+_shunit_fatal() {
+  ${__SHUNIT_CMD_ECHO_ESC} \
+      "${__shunit_ansi_red}shunit2:FATAL${__shunit_ansi_none} $*" >&2
+  exit ${SHUNIT_ERROR}
+}
 
-_shunit_warn() { echo "shunit2:WARN $@" >&2; }
-_shunit_error() { echo "shunit2:ERROR $@" >&2; }
-_shunit_fatal() { echo "shunit2:FATAL $@" >&2; exit ${SHUNIT_ERROR}; }
+# Determine some reasonable command defaults.
+__SHUNIT_CMD_ECHO_ESC='echo -e'
+# shellcheck disable=SC2039
+command [ "`echo -e test`" = '-e test' ] && __SHUNIT_CMD_ECHO_ESC='echo'
 
-# specific shell checks
-if [ -n "${ZSH_VERSION:-}" ]; then
+__SHUNIT_UNAME_S=`uname -s`
+case "${__SHUNIT_UNAME_S}" in
+  BSD) __SHUNIT_CMD_EXPR='gexpr' ;;
+  *) __SHUNIT_CMD_EXPR='expr' ;;
+esac
+__SHUNIT_CMD_TPUT='tput'
+
+# Commands a user can override if needed.
+SHUNIT_CMD_EXPR=${SHUNIT_CMD_EXPR:-${__SHUNIT_CMD_EXPR}}
+SHUNIT_CMD_TPUT=${SHUNIT_CMD_TPUT:-${__SHUNIT_CMD_TPUT}}
+
+# Enable color output. Options are 'never', 'always', or 'auto'.
+SHUNIT_COLOR=${SHUNIT_COLOR:-auto}
+
+# Specific shell checks.
+if command [ -n "${ZSH_VERSION:-}" ]; then
   setopt |grep "^shwordsplit$" >/dev/null
-  if [ $? -ne ${SHUNIT_TRUE} ]; then
+  if command [ $? -ne ${SHUNIT_TRUE} ]; then
     _shunit_fatal 'zsh shwordsplit option is required for proper operation'
   fi
-  if [ -z "${SHUNIT_PARENT:-}" ]; then
+  if command [ -z "${SHUNIT_PARENT:-}" ]; then
     _shunit_fatal "zsh does not pass \$0 through properly. please declare \
 \"SHUNIT_PARENT=\$0\" before calling shUnit2"
   fi
 fi
 
 #
-# constants
+# Constants
 #
 
-__SHUNIT_ASSERT_MSG_PREFIX='ASSERT:'
 __SHUNIT_MODE_SOURCED='sourced'
 __SHUNIT_MODE_STANDALONE='standalone'
 __SHUNIT_PARENT=${SHUNIT_PARENT:-$0}
 
-# set the constants readonly
-shunit_constants_=`set |grep '^__SHUNIT_' |cut -d= -f1`
-echo "${shunit_constants_}" |grep '^Binary file' >/dev/null && \
-    shunit_constants_=`set |grep -a '^__SHUNIT_' |cut -d= -f1`
-for shunit_constant_ in ${shunit_constants_}; do
-  shunit_ro_opts_=''
-  case ${ZSH_VERSION:-} in
-    '') ;;  # this isn't zsh
-    [123].*) ;;  # early versions (1.x, 2.x, 3.x)
-    *) shunit_ro_opts_='-g' ;;  # all later versions. declare readonly globally
-  esac
-  readonly ${shunit_ro_opts_} ${shunit_constant_}
+# User provided test prefix to display in front of the name of the test being
+# executed. Define by setting the SHUNIT_TEST_PREFIX variable.
+__SHUNIT_TEST_PREFIX=${SHUNIT_TEST_PREFIX:-}
+
+# ANSI colors.
+__SHUNIT_ANSI_NONE='\033[0m'
+__SHUNIT_ANSI_RED='\033[1;31m'
+__SHUNIT_ANSI_GREEN='\033[1;32m'
+__SHUNIT_ANSI_YELLOW='\033[1;33m'
+__SHUNIT_ANSI_CYAN='\033[1;36m'
+
+# Set the constants readonly.
+__shunit_constants=`set |grep '^__SHUNIT_' |cut -d= -f1`
+echo "${__shunit_constants}" |grep '^Binary file' >/dev/null && \
+    __shunit_constants=`set |grep -a '^__SHUNIT_' |cut -d= -f1`
+for __shunit_const in ${__shunit_constants}; do
+  if command [ -z "${ZSH_VERSION:-}" ]; then
+    readonly "${__shunit_const}"
+  else
+    case ${ZSH_VERSION} in
+      [123].*) readonly "${__shunit_const}" ;;
+      *) readonly -g "${__shunit_const}"  # Declare readonly constants globally.
+    esac
+  fi
 done
-unset shunit_constant_ shunit_constants_ shunit_ro_opts_
+unset __shunit_const __shunit_constants
 
-# variables
-__shunit_lineno=''  # line number of executed test
-__shunit_mode=${__SHUNIT_MODE_SOURCED}  # operating mode
-__shunit_reportGenerated=${SHUNIT_FALSE}  # is report generated
-__shunit_script=''  # filename of unittest script (standalone mode)
-__shunit_skip=${SHUNIT_FALSE}  # is skipping enabled
-__shunit_suite=''  # suite of tests to execute
+#
+# Internal variables.
+#
 
-# counts of tests
+# Variables.
+__shunit_lineno=''  # Line number of executed test.
+__shunit_mode=${__SHUNIT_MODE_SOURCED}  # Operating mode.
+__shunit_reportGenerated=${SHUNIT_FALSE}  # Is report generated.
+__shunit_script=''  # Filename of unittest script (standalone mode).
+__shunit_skip=${SHUNIT_FALSE}  # Is skipping enabled.
+__shunit_suite=''  # Suite of tests to execute.
+__shunit_clean=${SHUNIT_FALSE}  # _shunit_cleanup() was already called.
+
+# ANSI colors (populated by _shunit_configureColor()).
+__shunit_ansi_none=''
+__shunit_ansi_red=''
+__shunit_ansi_green=''
+__shunit_ansi_yellow=''
+__shunit_ansi_cyan=''
+
+# Counts of tests.
 __shunit_testSuccess=${SHUNIT_TRUE}
 __shunit_testsTotal=0
 __shunit_testsPassed=0
 __shunit_testsFailed=0
 
-# counts of asserts
+# Counts of asserts.
 __shunit_assertsTotal=0
 __shunit_assertsPassed=0
 __shunit_assertsFailed=0
 __shunit_assertsSkipped=0
 
-# macros
-_SHUNIT_LINENO_='eval __shunit_lineno=""; if [ "${1:-}" = "--lineno" ]; then [ -n "$2" ] && __shunit_lineno="[$2] "; shift 2; fi'
+#
+# Macros.
+#
+
+# shellcheck disable=SC2016,SC2089
+_SHUNIT_LINENO_='eval __shunit_lineno=""; if command [ "${1:-}" = "--lineno" ]; then command [ -n "$2" ] && __shunit_lineno="[$2] "; shift 2; fi'
 
 #-----------------------------------------------------------------------------
-# assert functions
+# Assertion functions.
 #
 
 # Assert that two values are equal to one another.
@@ -100,18 +159,18 @@ _SHUNIT_LINENO_='eval __shunit_lineno=""; if [ "${1:-}" = "--lineno" ]; then [ -
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertEquals()
-{
+assertEquals() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertEquals() requires two or three arguments; $# given"
-    _shunit_error "1: ${1:+$1} 2: ${2:+$2} 3: ${3:+$3}${4:+ 4: $4}"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if command [ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -119,7 +178,7 @@ assertEquals()
   shunit_actual_=$2
 
   shunit_return=${SHUNIT_TRUE}
-  if [ "${shunit_expected_}" = "${shunit_actual_}" ]; then
+  if command [ "${shunit_expected_}" = "${shunit_actual_}" ]; then
     _shunit_assertPass
   else
     failNotEquals "${shunit_message_}" "${shunit_expected_}" "${shunit_actual_}"
@@ -129,6 +188,7 @@ assertEquals()
   unset shunit_message_ shunit_expected_ shunit_actual_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_EQUALS_='eval assertEquals --lineno "${LINENO:-}"'
 
 # Assert that two values are not equal to one another.
@@ -139,17 +199,18 @@ _ASSERT_EQUALS_='eval assertEquals --lineno "${LINENO:-}"'
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertNotEquals()
-{
+assertNotEquals() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertNotEquals() requires two or three arguments; $# given"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if command [ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -157,17 +218,98 @@ assertNotEquals()
   shunit_actual_=$2
 
   shunit_return=${SHUNIT_TRUE}
-  if [ "${shunit_expected_}" != "${shunit_actual_}" ]; then
+  if command [ "${shunit_expected_}" != "${shunit_actual_}" ]; then
     _shunit_assertPass
   else
-    failSame "${shunit_message_}" "$@"
+    failSame "${shunit_message_}" "${shunit_expected_}" "${shunit_actual_}"
     shunit_return=${SHUNIT_FALSE}
   fi
 
   unset shunit_message_ shunit_expected_ shunit_actual_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_NOT_EQUALS_='eval assertNotEquals --lineno "${LINENO:-}"'
+
+# Assert that a container contains a content.
+#
+# Args:
+#   message: string: failure message [optional]
+#   container: string: container to analyze
+#   content: string: content to find
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+assertContains() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
+    _shunit_error "assertContains() requires two or three arguments; $# given"
+    _shunit_assertFail
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 3 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+  shunit_container_=$1
+  shunit_content_=$2
+
+  shunit_return=${SHUNIT_TRUE}
+  if echo "$shunit_container_" | grep -F -- "$shunit_content_" > /dev/null; then
+    _shunit_assertPass
+  else
+    failNotFound "${shunit_message_}" "${shunit_content_}"
+    shunit_return=${SHUNIT_FALSE}
+  fi
+
+  unset shunit_message_ shunit_container_ shunit_content_
+  return ${shunit_return}
+}
+# shellcheck disable=SC2016,SC2034
+_ASSERT_CONTAINS_='eval assertContains --lineno "${LINENO:-}"'
+
+# Assert that a container does not contain a content.
+#
+# Args:
+#   message: string: failure message [optional]
+#   container: string: container to analyze
+#   content: string: content to look for
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+assertNotContains() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
+    _shunit_error "assertNotContains() requires two or three arguments; $# given"
+    _shunit_assertFail
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 3 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+  shunit_container_=$1
+  shunit_content_=$2
+
+  shunit_return=${SHUNIT_TRUE}
+  if echo "$shunit_container_" | grep -F -- "$shunit_content_" > /dev/null; then
+    failFound "${shunit_message_}" "${shunit_content_}"
+    shunit_return=${SHUNIT_FALSE}
+  else
+    _shunit_assertPass
+  fi
+
+  unset shunit_message_ shunit_container_ shunit_content_
+  return ${shunit_return}
+}
+# shellcheck disable=SC2016,SC2034
+_ASSERT_NOT_CONTAINS_='eval assertNotContains --lineno "${LINENO:-}"'
 
 # Assert that a value is null (i.e. an empty string)
 #
@@ -176,17 +318,18 @@ _ASSERT_NOT_EQUALS_='eval assertNotEquals --lineno "${LINENO:-}"'
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertNull()
-{
+assertNull() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 1 -o $# -gt 2 ]; then
+  if command [ $# -lt 1 -o $# -gt 2 ]; then
     _shunit_error "assertNull() requires one or two arguments; $# given"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if command [ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -196,6 +339,7 @@ assertNull()
   unset shunit_message_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_NULL_='eval assertNull --lineno "${LINENO:-}"'
 
 # Assert that a value is not null (i.e. a non-empty string)
@@ -205,17 +349,18 @@ _ASSERT_NULL_='eval assertNull --lineno "${LINENO:-}"'
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertNotNull()
-{
+assertNotNull() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -gt 2 ]; then  # allowing 0 arguments as $1 might actually be null
+  if command [ $# -gt 2 ]; then  # allowing 0 arguments as $1 might actually be null
     _shunit_error "assertNotNull() requires one or two arguments; $# given"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if command [ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -227,6 +372,7 @@ assertNotNull()
   unset shunit_actual_ shunit_message_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_NOT_NULL_='eval assertNotNull --lineno "${LINENO:-}"'
 
 # Assert that two values are the same (i.e. equal to one another).
@@ -237,17 +383,18 @@ _ASSERT_NOT_NULL_='eval assertNotNull --lineno "${LINENO:-}"'
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertSame()
-{
+assertSame() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertSame() requires two or three arguments; $# given"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if command [ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -257,6 +404,7 @@ assertSame()
   unset shunit_message_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_SAME_='eval assertSame --lineno "${LINENO:-}"'
 
 # Assert that two values are not the same (i.e. not equal to one another).
@@ -267,17 +415,18 @@ _ASSERT_SAME_='eval assertSame --lineno "${LINENO:-}"'
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertNotSame()
-{
+assertNotSame() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "assertNotSame() requires two or three arguments; $# given"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if command [ $# -eq 3 ]; then
     shunit_message_="${shunit_message_:-}$1"
     shift
   fi
@@ -287,6 +436,7 @@ assertNotSame()
   unset shunit_message_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_NOT_SAME_='eval assertNotSame --lineno "${LINENO:-}"'
 
 # Assert that a value or shell test condition is true.
@@ -301,49 +451,50 @@ _ASSERT_NOT_SAME_='eval assertNotSame --lineno "${LINENO:-}"'
 # The following test will succeed:
 #   assertTrue 0
 #   assertTrue "[ 34 -gt 23 ]"
-# The folloing test will fail with a message:
+# The following test will fail with a message:
 #   assertTrue 123
-#   assertTrue "test failed" "[ -r '/non/existant/file' ]"
+#   assertTrue "test failed" "[ -r '/non/existent/file' ]"
 #
 # Args:
 #   message: string: failure message [optional]
 #   condition: string: integer value or shell conditional statement
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertTrue()
-{
+assertTrue() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -gt 2 ]; then
-    _shunit_error "assertTrue() takes one two arguments; $# given"
+  if command [ $# -lt 1 -o $# -gt 2 ]; then
+    _shunit_error "assertTrue() takes one or two arguments; $# given"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if command [ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
   shunit_condition_=$1
 
-  # see if condition is an integer, i.e. a return value
+  # See if condition is an integer, i.e. a return value.
   shunit_match_=`expr "${shunit_condition_}" : '\([0-9]*\)'`
   shunit_return=${SHUNIT_TRUE}
-  if [ -z "${shunit_condition_}" ]; then
-    # null condition
+  if command [ -z "${shunit_condition_}" ]; then
+    # Null condition.
     shunit_return=${SHUNIT_FALSE}
-  elif [ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
+  elif command [ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
   then
-    # possible return value. treating 0 as true, and non-zero as false.
-    [ ${shunit_condition_} -ne 0 ] && shunit_return=${SHUNIT_FALSE}
+    # Possible return value. Treating 0 as true, and non-zero as false.
+    command [ "${shunit_condition_}" -ne 0 ] && shunit_return=${SHUNIT_FALSE}
   else
-    # (hopefully) a condition
-    ( eval ${shunit_condition_} ) >/dev/null 2>&1
-    [ $? -ne 0 ] && shunit_return=${SHUNIT_FALSE}
+    # Hopefully... a condition.
+    ( eval "${shunit_condition_}" ) >/dev/null 2>&1
+    command [ $? -ne 0 ] && shunit_return=${SHUNIT_FALSE}
   fi
 
-  # record the test
-  if [ ${shunit_return} -eq ${SHUNIT_TRUE} ]; then
+  # Record the test.
+  if command [ ${shunit_return} -eq ${SHUNIT_TRUE} ]; then
     _shunit_assertPass
   else
     _shunit_assertFail "${shunit_message_}"
@@ -352,6 +503,7 @@ assertTrue()
   unset shunit_message_ shunit_condition_ shunit_match_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_TRUE_='eval assertTrue --lineno "${LINENO:-}"'
 
 # Assert that a value or shell test condition is false.
@@ -366,7 +518,7 @@ _ASSERT_TRUE_='eval assertTrue --lineno "${LINENO:-}"'
 # The following test will succeed:
 #   assertFalse 1
 #   assertFalse "[ 'apples' = 'oranges' ]"
-# The folloing test will fail with a message:
+# The following test will fail with a message:
 #   assertFalse 0
 #   assertFalse "test failed" "[ 1 -eq 1 -a 2 -eq 2 ]"
 #
@@ -375,52 +527,54 @@ _ASSERT_TRUE_='eval assertTrue --lineno "${LINENO:-}"'
 #   condition: string: integer value or shell conditional statement
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-assertFalse()
-{
+assertFalse() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 1 -o $# -gt 2 ]; then
-    _shunit_error "assertFalse() quires one or two arguments; $# given"
+  if command [ $# -lt 1 -o $# -gt 2 ]; then
+    _shunit_error "assertFalse() requires one or two arguments; $# given"
+    _shunit_assertFail
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 2 ]; then
+  if command [ $# -eq 2 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
   shunit_condition_=$1
 
-  # see if condition is an integer, i.e. a return value
+  # See if condition is an integer, i.e. a return value.
   shunit_match_=`expr "${shunit_condition_}" : '\([0-9]*\)'`
   shunit_return=${SHUNIT_TRUE}
-  if [ -z "${shunit_condition_}" ]; then
-    # null condition
+  if command [ -z "${shunit_condition_}" ]; then
+    # Null condition.
     shunit_return=${SHUNIT_FALSE}
-  elif [ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
+  elif command [ -n "${shunit_match_}" -a "${shunit_condition_}" = "${shunit_match_}" ]
   then
-    # possible return value. treating 0 as true, and non-zero as false.
-    [ ${shunit_condition_} -eq 0 ] && shunit_return=${SHUNIT_FALSE}
+    # Possible return value. Treating 0 as true, and non-zero as false.
+    command [ "${shunit_condition_}" -eq 0 ] && shunit_return=${SHUNIT_FALSE}
   else
-    # (hopefully) a condition
-    ( eval ${shunit_condition_} ) >/dev/null 2>&1
-    [ $? -eq 0 ] && shunit_return=${SHUNIT_FALSE}
+    # Hopefully... a condition.
+    ( eval "${shunit_condition_}" ) >/dev/null 2>&1
+    command [ $? -eq 0 ] && shunit_return=${SHUNIT_FALSE}
   fi
 
-  # record the test
-  if [ ${shunit_return} -eq ${SHUNIT_TRUE} ]; then
+  # Record the test.
+  if command [ "${shunit_return}" -eq "${SHUNIT_TRUE}" ]; then
     _shunit_assertPass
   else
     _shunit_assertFail "${shunit_message_}"
   fi
 
   unset shunit_message_ shunit_condition_ shunit_match_
-  return ${shunit_return}
+  return "${shunit_return}"
 }
+# shellcheck disable=SC2016,SC2034
 _ASSERT_FALSE_='eval assertFalse --lineno "${LINENO:-}"'
 
 #-----------------------------------------------------------------------------
-# failure functions
+# Failure functions.
 #
 
 # Records a test failure.
@@ -429,17 +583,17 @@ _ASSERT_FALSE_='eval assertFalse --lineno "${LINENO:-}"'
 #   message: string: failure message [optional]
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-fail()
-{
+fail() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -gt 1 ]; then
+  if command [ $# -gt 1 ]; then
     _shunit_error "fail() requires zero or one arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 1 ]; then
+  if command [ $# -eq 1 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -449,6 +603,7 @@ fail()
   unset shunit_message_
   return ${SHUNIT_FALSE}
 }
+# shellcheck disable=SC2016,SC2034
 _FAIL_='eval fail --lineno "${LINENO:-}"'
 
 # Records a test failure, stating two values were not equal.
@@ -459,29 +614,94 @@ _FAIL_='eval fail --lineno "${LINENO:-}"'
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-failNotEquals()
-{
+failNotEquals() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "failNotEquals() requires one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if command [ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
   shunit_expected_=$1
   shunit_actual_=$2
 
+  shunit_message_=${shunit_message_%% }
   _shunit_assertFail "${shunit_message_:+${shunit_message_} }expected:<${shunit_expected_}> but was:<${shunit_actual_}>"
 
   unset shunit_message_ shunit_expected_ shunit_actual_
   return ${SHUNIT_FALSE}
 }
+# shellcheck disable=SC2016,SC2034
 _FAIL_NOT_EQUALS_='eval failNotEquals --lineno "${LINENO:-}"'
+
+# Records a test failure, stating a value was found.
+#
+# Args:
+#   message: string: failure message [optional]
+#   content: string: found value
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+failFound() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 1 -o $# -gt 2 ]; then
+    _shunit_error "failFound() requires one or two arguments; $# given"
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 2 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+
+  shunit_message_=${shunit_message_%% }
+  _shunit_assertFail "${shunit_message_:+${shunit_message_} }Found"
+
+  unset shunit_message_
+  return ${SHUNIT_FALSE}
+}
+# shellcheck disable=SC2016,SC2034
+_FAIL_FOUND_='eval failFound --lineno "${LINENO:-}"'
+
+# Records a test failure, stating a content was not found.
+#
+# Args:
+#   message: string: failure message [optional]
+#   content: string: content not found
+# Returns:
+#   integer: success (TRUE/FALSE/ERROR constant)
+failNotFound() {
+  # shellcheck disable=SC2090
+  ${_SHUNIT_LINENO_}
+  if command [ $# -lt 1 -o $# -gt 2 ]; then
+    _shunit_error "failNotFound() requires one or two arguments; $# given"
+    return ${SHUNIT_ERROR}
+  fi
+  _shunit_shouldSkip && return ${SHUNIT_TRUE}
+
+  shunit_message_=${__shunit_lineno}
+  if command [ $# -eq 2 ]; then
+    shunit_message_="${shunit_message_}$1"
+    shift
+  fi
+  shunit_content_=$1
+
+  shunit_message_=${shunit_message_%% }
+  _shunit_assertFail "${shunit_message_:+${shunit_message_} }Not found:<${shunit_content_}>"
+
+  unset shunit_message_ shunit_content_
+  return ${SHUNIT_FALSE}
+}
+# shellcheck disable=SC2016,SC2034
+_FAIL_NOT_FOUND_='eval failNotFound --lineno "${LINENO:-}"'
 
 # Records a test failure, stating two values should have been the same.
 #
@@ -493,24 +713,27 @@ _FAIL_NOT_EQUALS_='eval failNotEquals --lineno "${LINENO:-}"'
 #   integer: success (TRUE/FALSE/ERROR constant)
 failSame()
 {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
     _shunit_error "failSame() requires two or three arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if command [ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
 
+  shunit_message_=${shunit_message_%% }
   _shunit_assertFail "${shunit_message_:+${shunit_message_} }expected not same"
 
   unset shunit_message_
   return ${SHUNIT_FALSE}
 }
+# shellcheck disable=SC2016,SC2034
 _FAIL_SAME_='eval failSame --lineno "${LINENO:-}"'
 
 # Records a test failure, stating two values were not equal.
@@ -523,17 +746,17 @@ _FAIL_SAME_='eval failSame --lineno "${LINENO:-}"'
 #   actual: string: actual value
 # Returns:
 #   integer: success (TRUE/FALSE/ERROR constant)
-failNotSame()
-{
+failNotSame() {
+  # shellcheck disable=SC2090
   ${_SHUNIT_LINENO_}
-  if [ $# -lt 2 -o $# -gt 3 ]; then
-    _shunit_error "failNotEquals() requires one or two arguments; $# given"
+  if command [ $# -lt 2 -o $# -gt 3 ]; then
+    _shunit_error "failNotSame() requires one or two arguments; $# given"
     return ${SHUNIT_ERROR}
   fi
   _shunit_shouldSkip && return ${SHUNIT_TRUE}
 
   shunit_message_=${__shunit_lineno}
-  if [ $# -eq 3 ]; then
+  if command [ $# -eq 3 ]; then
     shunit_message_="${shunit_message_}$1"
     shift
   fi
@@ -543,10 +766,11 @@ failNotSame()
   unset shunit_message_
   return ${shunit_return}
 }
+# shellcheck disable=SC2016,SC2034
 _FAIL_NOT_SAME_='eval failNotSame --lineno "${LINENO:-}"'
 
 #-----------------------------------------------------------------------------
-# skipping functions
+# Skipping functions.
 #
 
 # Force remaining assert and fail functions to be "skipped".
@@ -557,19 +781,13 @@ _FAIL_NOT_SAME_='eval failNotSame --lineno "${LINENO:-}"'
 #
 # Args:
 #   None
-startSkipping()
-{
-  __shunit_skip=${SHUNIT_TRUE}
-}
+startSkipping() { __shunit_skip=${SHUNIT_TRUE}; }
 
 # Resume the normal recording behavior of assert and fail calls.
 #
 # Args:
 #   None
-endSkipping()
-{
-  __shunit_skip=${SHUNIT_FALSE}
-}
+endSkipping() { __shunit_skip=${SHUNIT_FALSE}; }
 
 # Returns the state of assert and fail call skipping.
 #
@@ -577,13 +795,10 @@ endSkipping()
 #   None
 # Returns:
 #   boolean: (TRUE/FALSE constant)
-isSkipping()
-{
-  return ${__shunit_skip}
-}
+isSkipping() { return ${__shunit_skip}; }
 
 #-----------------------------------------------------------------------------
-# suite functions
+# Suite functions.
 #
 
 # Stub. This function should contains all unit test calls to be made.
@@ -610,8 +825,7 @@ isSkipping()
 #
 # Args:
 #   function: string: name of a function to add to current unit test suite
-suite_addTest()
-{
+suite_addTest() {
   shunit_func_=${1:-}
 
   __shunit_suite="${__shunit_suite:+${__shunit_suite} }${shunit_func_}"
@@ -653,7 +867,7 @@ suite_addTest()
 #
 # Args:
 #   None
-#setUp() { :; }
+#setUp() { :; }  # DO NOT UNCOMMENT THIS FUNCTION
 
 # Note: see _shunit_mktempFunc() for actual implementation
 # Stub. This function will be called after each test is run.
@@ -668,41 +882,41 @@ suite_addTest()
 #tearDown() { :; }  # DO NOT UNCOMMENT THIS FUNCTION
 
 #------------------------------------------------------------------------------
-# internal shUnit2 functions
+# Internal shUnit2 functions.
 #
 
 # Create a temporary directory to store various run-time files in.
 #
 # This function is a cross-platform temporary directory creation tool. Not all
-# OSes have the mktemp function, so one is included here.
+# OSes have the `mktemp` function, so one is included here.
 #
 # Args:
 #   None
 # Outputs:
 #   string: the temporary directory that was created
-_shunit_mktempDir()
-{
-  # try the standard mktemp function
+_shunit_mktempDir() {
+  # Try the standard `mktemp` function.
   ( exec mktemp -dqt shunit.XXXXXX 2>/dev/null ) && return
 
-  # the standard mktemp didn't work.  doing our own.
-  if [ -r '/dev/urandom' -a -x '/usr/bin/od' ]; then
+  # The standard `mktemp` didn't work. Use our own.
+  # shellcheck disable=SC2039
+  if command [ -r '/dev/urandom' -a -x '/usr/bin/od' ]; then
     _shunit_random_=`/usr/bin/od -vAn -N4 -tx4 </dev/urandom \
-        |sed 's/^[^0-9a-f]*//'`
-  elif [ -n "${RANDOM:-}" ]; then
+        |command sed 's/^[^0-9a-f]*//'`
+  elif command [ -n "${RANDOM:-}" ]; then
     # $RANDOM works
     _shunit_random_=${RANDOM}${RANDOM}${RANDOM}$$
   else
-    # $RANDOM doesn't work
+    # `$RANDOM` doesn't work.
     _shunit_date_=`date '+%Y%m%d%H%M%S'`
-    _shunit_random_=`expr ${_shunit_date_} / $$`
+    _shunit_random_=`expr "${_shunit_date_}" / $$`
   fi
 
   _shunit_tmpDir_="${TMPDIR:-/tmp}/shunit.${_shunit_random_}"
-  ( umask 077 && mkdir "${_shunit_tmpDir_}" ) || \
+  ( umask 077 && command mkdir "${_shunit_tmpDir_}" ) || \
       _shunit_fatal 'could not create temporary directory! exiting'
 
-  echo ${_shunit_tmpDir_}
+  echo "${_shunit_tmpDir_}"
   unset _shunit_date_ _shunit_random_ _shunit_tmpDir_
 }
 
@@ -710,16 +924,15 @@ _shunit_mktempDir()
 #
 # Args:
 #   None
-_shunit_mktempFunc()
-{
+_shunit_mktempFunc() {
   for _shunit_func_ in oneTimeSetUp oneTimeTearDown setUp tearDown suite noexec
   do
     _shunit_file_="${__shunit_tmpDir}/${_shunit_func_}"
-    cat <<EOF >"${_shunit_file_}"
+    command cat <<EOF >"${_shunit_file_}"
 #! /bin/sh
 exit ${SHUNIT_TRUE}
 EOF
-    chmod +x "${_shunit_file_}"
+    command chmod +x "${_shunit_file_}"
   done
 
   unset _shunit_file_
@@ -733,32 +946,43 @@ EOF
 #
 # Args:
 #   name: string: name of the trap called (specified when trap defined)
-_shunit_cleanup()
-{
+_shunit_cleanup() {
   _shunit_name_=$1
 
-  case ${_shunit_name_} in
-    EXIT) _shunit_signal_=0 ;;
-    INT) _shunit_signal_=2 ;;
-    TERM) _shunit_signal_=15 ;;
+  case "${_shunit_name_}" in
+    EXIT) ;;
+    INT) _shunit_signal_=130 ;;  # 2+128
+    TERM) _shunit_signal_=143 ;;  # 15+128
     *)
-      _shunit_warn "unrecognized trap value (${_shunit_name_})"
+      _shunit_error "unrecognized trap value (${_shunit_name_})"
       _shunit_signal_=0
       ;;
   esac
-
-  # do our work
-  rm -fr "${__shunit_tmpDir}"
-
-  # exit for all non-EXIT signals
-  if [ ${_shunit_name_} != 'EXIT' ]; then
+  if command [ "${_shunit_name_}" != 'EXIT' ]; then
     _shunit_warn "trapped and now handling the (${_shunit_name_}) signal"
-    # disable EXIT trap
-    trap 0
-    # add 128 to signal and exit
-    exit `expr ${_shunit_signal_} + 128`
-  elif [ ${__shunit_reportGenerated} -eq ${SHUNIT_FALSE} ] ; then
-    _shunit_assertFail 'Unknown failure encountered running a test'
+  fi
+
+  # Do our work.
+  if command [ ${__shunit_clean} -eq ${SHUNIT_FALSE} ]; then
+    # Ensure tear downs are only called once.
+    __shunit_clean=${SHUNIT_TRUE}
+
+    tearDown
+    command [ $? -eq ${SHUNIT_TRUE} ] \
+        || _shunit_warn "tearDown() returned non-zero return code."
+    oneTimeTearDown
+    command [ $? -eq ${SHUNIT_TRUE} ] \
+        || _shunit_warn "oneTimeTearDown() returned non-zero return code."
+
+    command rm -fr "${__shunit_tmpDir}"
+  fi
+
+  if command [ "${_shunit_name_}" != 'EXIT' ]; then
+    # Handle all non-EXIT signals.
+    trap - 0  # Disable EXIT trap.
+    exit ${_shunit_signal_}
+  elif command [ ${__shunit_reportGenerated} -eq ${SHUNIT_FALSE} ]; then
+    _shunit_assertFail 'unknown failure encountered running a test'
     _shunit_generateReport
     exit ${SHUNIT_ERROR}
   fi
@@ -766,30 +990,84 @@ _shunit_cleanup()
   unset _shunit_name_ _shunit_signal_
 }
 
+# configureColor based on user color preference.
+#
+# Args:
+#   color: string: color mode (one of `always`, `auto`, or `none`).
+_shunit_configureColor() {
+  _shunit_color_=${SHUNIT_FALSE}  # By default, no color.
+  case $1 in
+    'always') _shunit_color_=${SHUNIT_TRUE} ;;
+    'auto')
+      command [ "`_shunit_colors`" -ge 8 ] && _shunit_color_=${SHUNIT_TRUE}
+      ;;
+    'none') ;;
+    *) _shunit_fatal "unrecognized color option '$1'" ;;
+  esac
+
+  case ${_shunit_color_} in
+    ${SHUNIT_TRUE})
+      __shunit_ansi_none=${__SHUNIT_ANSI_NONE}
+      __shunit_ansi_red=${__SHUNIT_ANSI_RED}
+      __shunit_ansi_green=${__SHUNIT_ANSI_GREEN}
+      __shunit_ansi_yellow=${__SHUNIT_ANSI_YELLOW}
+      __shunit_ansi_cyan=${__SHUNIT_ANSI_CYAN}
+      ;;
+    ${SHUNIT_FALSE})
+      __shunit_ansi_none=''
+      __shunit_ansi_red=''
+      __shunit_ansi_green=''
+      __shunit_ansi_yellow=''
+      __shunit_ansi_cyan=''
+      ;;
+  esac
+
+  unset _shunit_color_ _shunit_tput_
+}
+
+# colors returns the number of supported colors for the TERM.
+_shunit_colors() {
+  _shunit_tput_=`${SHUNIT_CMD_TPUT} colors 2>/dev/null`
+  if command [ $? -eq 0 ]; then
+    echo "${_shunit_tput_}"
+  else
+    echo 16
+  fi
+  unset _shunit_tput_
+}
+
 # The actual running of the tests happens here.
 #
 # Args:
 #   None
-_shunit_execSuite()
-{
+_shunit_execSuite() {
   for _shunit_test_ in ${__shunit_suite}; do
     __shunit_testSuccess=${SHUNIT_TRUE}
 
-    # disable skipping
+    # Disable skipping.
     endSkipping
 
-    # execute the per-test setup function
+    # Execute the per-test setup function.
     setUp
+    command [ $? -eq ${SHUNIT_TRUE} ] \
+        || _shunit_fatal "setup() returned non-zero return code."
 
-    # execute the test
-    echo "${_shunit_test_}"
-    eval ${_shunit_test_}
+    # Execute the test.
+    echo "${__SHUNIT_TEST_PREFIX}${_shunit_test_}"
+    eval "${_shunit_test_}"
+    if command [ $? -ne ${SHUNIT_TRUE} ]; then
+      _shunit_error "${_shunit_test_}() returned non-zero return code."
+      __shunit_testSuccess=${SHUNIT_ERROR}
+      _shunit_incFailedCount
+    fi
 
-    # execute the per-test tear-down function
+    # Execute the per-test tear-down function.
     tearDown
+    command [ $? -eq ${SHUNIT_TRUE} ] \
+        || _shunit_fatal "tearDown() returned non-zero return code."
 
-    # update stats
-    if [ ${__shunit_testSuccess} -eq ${SHUNIT_TRUE} ]; then
+    # Update stats.
+    if command [ ${__shunit_testSuccess} -eq ${SHUNIT_TRUE} ]; then
       __shunit_testsPassed=`expr ${__shunit_testsPassed} + 1`
     else
       __shunit_testsFailed=`expr ${__shunit_testsFailed} + 1`
@@ -805,45 +1083,41 @@ _shunit_execSuite()
 #   None
 # Output:
 #   string: the report of successful and failed tests, as well as totals.
-_shunit_generateReport()
-{
+_shunit_generateReport() {
+  command [ "${__shunit_reportGenerated}" -eq ${SHUNIT_TRUE} ] && return
+
   _shunit_ok_=${SHUNIT_TRUE}
 
-  # if no exit code was provided one, determine an appropriate one
-  [ ${__shunit_testsFailed} -gt 0 \
+  # If no exit code was provided, determine an appropriate one.
+  command [ "${__shunit_testsFailed}" -gt 0 \
       -o ${__shunit_testSuccess} -eq ${SHUNIT_FALSE} ] \
           && _shunit_ok_=${SHUNIT_FALSE}
 
   echo
-  if [ ${__shunit_testsTotal} -eq 1 ]; then
-    echo "Ran ${__shunit_testsTotal} test."
+  _shunit_msg_="Ran ${__shunit_ansi_cyan}${__shunit_testsTotal}${__shunit_ansi_none}"
+  if command [ "${__shunit_testsTotal}" -eq 1 ]; then
+    ${__SHUNIT_CMD_ECHO_ESC} "${_shunit_msg_} test."
   else
-    echo "Ran ${__shunit_testsTotal} tests."
+    ${__SHUNIT_CMD_ECHO_ESC} "${_shunit_msg_} tests."
   fi
 
-  _shunit_failures_=''
-  _shunit_skipped_=''
-  [ ${__shunit_assertsFailed} -gt 0 ] \
-      && _shunit_failures_="failures=${__shunit_assertsFailed}"
-  [ ${__shunit_assertsSkipped} -gt 0 ] \
-      && _shunit_skipped_="skipped=${__shunit_assertsSkipped}"
-
-  if [ ${_shunit_ok_} -eq ${SHUNIT_TRUE} ]; then
-    _shunit_msg_='OK'
-    [ -n "${_shunit_skipped_}" ] \
-        && _shunit_msg_="${_shunit_msg_} (${_shunit_skipped_})"
+  if command [ ${_shunit_ok_} -eq ${SHUNIT_TRUE} ]; then
+    _shunit_msg_="${__shunit_ansi_green}OK${__shunit_ansi_none}"
+    command [ "${__shunit_assertsSkipped}" -gt 0 ] \
+        && _shunit_msg_="${_shunit_msg_} (${__shunit_ansi_yellow}skipped=${__shunit_assertsSkipped}${__shunit_ansi_none})"
   else
-    _shunit_msg_="FAILED (${_shunit_failures_}"
-    [ -n "${_shunit_skipped_}" ] \
-        && _shunit_msg_="${_shunit_msg_},${_shunit_skipped_}"
+    _shunit_msg_="${__shunit_ansi_red}FAILED${__shunit_ansi_none}"
+    _shunit_msg_="${_shunit_msg_} (${__shunit_ansi_red}failures=${__shunit_assertsFailed}${__shunit_ansi_none}"
+    command [ "${__shunit_assertsSkipped}" -gt 0 ] \
+        && _shunit_msg_="${_shunit_msg_},${__shunit_ansi_yellow}skipped=${__shunit_assertsSkipped}${__shunit_ansi_none}"
     _shunit_msg_="${_shunit_msg_})"
   fi
 
   echo
-  echo ${_shunit_msg_}
+  ${__SHUNIT_CMD_ECHO_ESC} "${_shunit_msg_}"
   __shunit_reportGenerated=${SHUNIT_TRUE}
 
-  unset _shunit_failures_ _shunit_msg_ _shunit_ok_ _shunit_skipped_
+  unset _shunit_msg_ _shunit_ok_
 }
 
 # Test for whether a function should be skipped.
@@ -852,9 +1126,8 @@ _shunit_generateReport()
 #   None
 # Returns:
 #   boolean: whether the test should be skipped (TRUE/FALSE constant)
-_shunit_shouldSkip()
-{
-  [ ${__shunit_skip} -eq ${SHUNIT_FALSE} ] && return ${SHUNIT_FALSE}
+_shunit_shouldSkip() {
+  command [ ${__shunit_skip} -eq ${SHUNIT_FALSE} ] && return ${SHUNIT_FALSE}
   _shunit_assertSkip
 }
 
@@ -862,8 +1135,7 @@ _shunit_shouldSkip()
 #
 # Args:
 #   None
-_shunit_assertPass()
-{
+_shunit_assertPass() {
   __shunit_assertsPassed=`expr ${__shunit_assertsPassed} + 1`
   __shunit_assertsTotal=`expr ${__shunit_assertsTotal} + 1`
 }
@@ -872,26 +1144,31 @@ _shunit_assertPass()
 #
 # Args:
 #   message: string: failure message to provide user
-_shunit_assertFail()
-{
-  _shunit_msg_=$1
-
+_shunit_assertFail() {
   __shunit_testSuccess=${SHUNIT_FALSE}
-  __shunit_assertsFailed=`expr ${__shunit_assertsFailed} + 1`
-  __shunit_assertsTotal=`expr ${__shunit_assertsTotal} + 1`
-  echo "${__SHUNIT_ASSERT_MSG_PREFIX}${_shunit_msg_}"
+  _shunit_incFailedCount
 
-  unset _shunit_msg_
+  \[ $# -gt 0 ] && ${__SHUNIT_CMD_ECHO_ESC} \
+      "${__shunit_ansi_red}ASSERT:${__shunit_ansi_none}$*"
 }
+
+# Increment the count of failed asserts.
+#
+# Args:
+#   none
+_shunit_incFailedCount() {
+  __shunit_assertsFailed=`expr "${__shunit_assertsFailed}" + 1`
+  __shunit_assertsTotal=`expr "${__shunit_assertsTotal}" + 1`
+}
+
 
 # Records a skipped test.
 #
 # Args:
 #   None
-_shunit_assertSkip()
-{
-  __shunit_assertsSkipped=`expr ${__shunit_assertsSkipped} + 1`
-  __shunit_assertsTotal=`expr ${__shunit_assertsTotal} + 1`
+_shunit_assertSkip() {
+  __shunit_assertsSkipped=`expr "${__shunit_assertsSkipped}" + 1`
+  __shunit_assertsTotal=`expr "${__shunit_assertsTotal}" + 1`
 }
 
 # Prepare a script filename for sourcing.
@@ -900,8 +1177,7 @@ _shunit_assertSkip()
 #   script: string: path to a script to source
 # Returns:
 #   string: filename prefixed with ./ (if necessary)
-_shunit_prepForSourcing()
-{
+_shunit_prepForSourcing() {
   _shunit_script_=$1
   case "${_shunit_script_}" in
     /*|./*) echo "${_shunit_script_}" ;;
@@ -917,18 +1193,17 @@ _shunit_prepForSourcing()
 #   s: string: to escape character in
 # Returns:
 #   string: with escaped character(s)
-_shunit_escapeCharInStr()
-{
-  [ -n "$2" ] || return  # no point in doing work on an empty string
+_shunit_escapeCharInStr() {
+  command [ -n "$2" ] || return  # No point in doing work on an empty string.
 
   # Note: using shorter variable names to prevent conflicts with
   # _shunit_escapeCharactersInString().
   _shunit_c_=$1
   _shunit_s_=$2
 
-
-  # escape the character
-  echo ''${_shunit_s_}'' |sed 's/\'${_shunit_c_}'/\\\'${_shunit_c_}'/g'
+  # Escape the character.
+  # shellcheck disable=SC1003,SC2086
+  echo ''${_shunit_s_}'' |command sed 's/\'${_shunit_c_}'/\\\'${_shunit_c_}'/g'
 
   unset _shunit_c_ _shunit_s_
 }
@@ -939,9 +1214,8 @@ _shunit_escapeCharInStr()
 #   str: string: to escape characters in
 # Returns:
 #   string: with escaped character(s)
-_shunit_escapeCharactersInString()
-{
-  [ -n "$1" ] || return  # no point in doing work on an empty string
+_shunit_escapeCharactersInString() {
+  command [ -n "$1" ] || return  # No point in doing work on an empty string.
 
   _shunit_str_=$1
 
@@ -961,88 +1235,109 @@ _shunit_escapeCharactersInString()
 #   script: string: name of script to extract functions from
 # Returns:
 #   string: of function names
-_shunit_extractTestFunctions()
-{
+_shunit_extractTestFunctions() {
   _shunit_script_=$1
 
-  # extract the lines with test function names, strip of anything besides the
+  # Extract the lines with test function names, strip of anything besides the
   # function name, and output everything on a single line.
-  _shunit_regex_='^[ 	]*(function )*test[A-Za-z0-9_]* *\(\)'
+  _shunit_regex_='^\s*((function test[A-Za-z0-9_-]*)|(test[A-Za-z0-9_-]* *\(\)))'
+  # shellcheck disable=SC2196
   egrep "${_shunit_regex_}" "${_shunit_script_}" \
-  |sed 's/^[^A-Za-z0-9_]*//;s/^function //;s/\([A-Za-z0-9_]*\).*/\1/g' \
+  |command sed 's/^[^A-Za-z0-9_-]*//;s/^function //;s/\([A-Za-z0-9_-]*\).*/\1/g' \
   |xargs
 
   unset _shunit_regex_ _shunit_script_
 }
 
 #------------------------------------------------------------------------------
-# main
+# Main.
 #
 
-# determine the operating mode
-if [ $# -eq 0 ]; then
+# Determine the operating mode.
+if command [ $# -eq 0 -o "${1:-}" = '--' ]; then
   __shunit_script=${__SHUNIT_PARENT}
   __shunit_mode=${__SHUNIT_MODE_SOURCED}
 else
   __shunit_script=$1
-  [ -r "${__shunit_script}" ] || \
+  command [ -r "${__shunit_script}" ] || \
       _shunit_fatal "unable to read from ${__shunit_script}"
   __shunit_mode=${__SHUNIT_MODE_STANDALONE}
 fi
 
-# create a temporary storage location
+# Create a temporary storage location.
 __shunit_tmpDir=`_shunit_mktempDir`
 
-# provide a public temporary directory for unit test scripts
-# TODO(kward): document this
+# Provide a public temporary directory for unit test scripts.
+# TODO(kward): document this.
 SHUNIT_TMPDIR="${__shunit_tmpDir}/tmp"
-mkdir "${SHUNIT_TMPDIR}"
+command mkdir "${SHUNIT_TMPDIR}"
 
-# setup traps to clean up after ourselves
+# Setup traps to clean up after ourselves.
 trap '_shunit_cleanup EXIT' 0
 trap '_shunit_cleanup INT' 2
 trap '_shunit_cleanup TERM' 15
 
-# create phantom functions to work around issues with Cygwin
+# Create phantom functions to work around issues with Cygwin.
 _shunit_mktempFunc
 PATH="${__shunit_tmpDir}:${PATH}"
 
-# make sure phantom functions are executable. this will bite if /tmp (or the
-# current $TMPDIR) points to a path on a partition that was mounted with the
-# 'noexec' option. the noexec command was created with _shunit_mktempFunc().
+# Make sure phantom functions are executable. This will bite if `/tmp` (or the
+# current `$TMPDIR`) points to a path on a partition that was mounted with the
+# 'noexec' option. The noexec command was created with `_shunit_mktempFunc()`.
 noexec 2>/dev/null || _shunit_fatal \
-    'please declare TMPDIR with path on partition with exec permission'
+    'Please declare TMPDIR with path on partition with exec permission.'
 
-# we must manually source the tests in standalone mode
-if [ "${__shunit_mode}" = "${__SHUNIT_MODE_STANDALONE}" ]; then
-  . "`_shunit_prepForSourcing \"${__shunit_script}\"`"
+# We must manually source the tests in standalone mode.
+if command [ "${__shunit_mode}" = "${__SHUNIT_MODE_STANDALONE}" ]; then
+  # shellcheck disable=SC1090
+  command . "`_shunit_prepForSourcing \"${__shunit_script}\"`"
 fi
 
-# execute the oneTimeSetUp function (if it exists)
+# Configure default output coloring behavior.
+_shunit_configureColor "${SHUNIT_COLOR}"
+
+# Execute the oneTimeSetUp function (if it exists).
 oneTimeSetUp
+command [ $? -eq ${SHUNIT_TRUE} ] \
+    || _shunit_fatal "oneTimeSetUp() returned non-zero return code."
 
-# execute the suite function defined in the parent test script
-# deprecated as of 2.1.0
-suite
+# Command line selected tests or suite selected tests
+if command [ "$#" -ge 2 ]; then
+  # Argument $1 is either the filename of tests or '--'; either way, skip it.
+  shift
+  # Remaining arguments ($2 .. $#) are assumed to be test function names.
+  # Interate through all remaining args in "$@" in a POSIX (likely portable) way.
+  # Helpful tip: https://unix.stackexchange.com/questions/314032/how-to-use-arguments-like-1-2-in-a-for-loop
+  for _shunit_arg_ do
+    suite_addTest "${_shunit_arg_}"
+  done
+  unset _shunit_arg_
+else
+  # Execute the suite function defined in the parent test script.
+  # DEPRECATED as of 2.1.0.
+  suite
+fi
 
-# if no suite function was defined, dynamically build a list of functions
-if [ -z "${__shunit_suite}" ]; then
+# If no tests or suite specified, dynamically build a list of functions.
+if command [ -z "${__shunit_suite}" ]; then
   shunit_funcs_=`_shunit_extractTestFunctions "${__shunit_script}"`
   for shunit_func_ in ${shunit_funcs_}; do
-    suite_addTest ${shunit_func_}
+    suite_addTest "${shunit_func_}"
   done
 fi
 unset shunit_func_ shunit_funcs_
 
-# execute the tests
+# Execute the suite of unit tests.
 _shunit_execSuite
 
-# execute the oneTimeTearDown function (if it exists)
+# Execute the oneTimeTearDown function (if it exists).
 oneTimeTearDown
+command [ $? -eq ${SHUNIT_TRUE} ] \
+    || _shunit_fatal "oneTimeTearDown() returned non-zero return code."
 
-# generate the report
+# Generate a report summary.
 _shunit_generateReport
 
-# that's it folks
-[ ${__shunit_testsFailed} -eq 0 ]
+# That's it folks.
+command [ "${__shunit_testsFailed}" -eq 0 ]
 exit $?

--- a/test/unit
+++ b/test/unit
@@ -246,8 +246,8 @@ testBuildDataPreviousBuild() {
   # the first time, there will be no previous build file
   meta_init "$cache_dir"
   meta_setup
-  assertContains "nodejs" "$BUILD_DATA_FILE"
-  assertContains "nodejs-prev" "$PREVIOUS_BUILD_DATA_FILE"
+  assertContains "$BUILD_DATA_FILE" "nodejs"
+  assertContains "$PREVIOUS_BUILD_DATA_FILE" "nodejs-prev"
   assertFileExists "$BUILD_DATA_FILE"
 
   # set a value in the build data file

--- a/test/utils
+++ b/test/utils
@@ -147,16 +147,6 @@ _assertContains()
   fi
 }
 
-assertContains()
-{
-  _assertContains "$@" 0 "text"
-}
-
-assertNotContains()
-{
-  _assertContains "$@" 1 "text"
-}
-
 assertFileContains()
 {
   _assertContains "$@" 0 "file"

--- a/test/utils
+++ b/test/utils
@@ -157,6 +157,17 @@ assertFileNotContains()
   _assertContains "$@" 1 "file"
 }
 
+assertFileContainsMatch()
+{
+  local needle=$1
+  local haystack=$2
+
+  grep -q -E -e "${needle}" ${haystack}
+  if [ "$?" != 0 ]; then
+    fail "Expected <${haystack}> to contain <${needle}>"
+  fi
+}
+
 command_exists () {
     type "$1" > /dev/null 2>&1 ;
 }


### PR DESCRIPTION
There have been some recent failures in CI. This PR fixes the following issues:

1)
```
testBuildWithUserCacheDirectories
ASSERT:expected:<1> but was:<0>
```

This appears to be due to using an ancient and vulnerable version of jQuery in the `cache-directories` fixture. I've updated the `node`, `bower`, and `jQuery` versions for this fixture.

2)
```
ASSERT:Expected </tmp/tmp.zHnCba0e4H> to contain <resolve-v1-yarn="1.22.10 https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.10.tar.gz">
ASSERT:Expected </tmp/tmp.zHnCba0e4H> to contain <resolve-is-equal-yarn=true>
```

This was due to a newer release of yarn becoming available, 1.22.11. The problem here is twofold. 1) inventory/yarn.toml needs the new entry 2) these tests were not tolerant to version changes.

3)
Additionally, this PR bumps `shunit` to 2.1.8. The previous version, 2.1.6 is over 10 years old. By bumping the version, we can now run single tests with a command like `test/run -- testBuildWithUserCacheDirectories`.  The new `shunit2` comes with a new `assertContains()` function which conflicted with our own method of the same name. 