### PR TITLE
Upgrade to latest heroku_hatchet (7.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Upgrade heroku_hatchet to 7.3.4 to get CI green again ([#936](https://github.com/heroku/heroku-buildpack-nodejs/pull/936))
 
 ## v186 (2021-08-11)
 - Refactor $WEB_CONCURRENCY logic ([#931](https://github.com/heroku/heroku-buildpack-nodejs/pull/931))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,17 +3,18 @@ GEM
   specs:
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.76.0)
-    heroics (0.1.1)
+    excon (0.85.0)
+    heroics (0.1.2)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (7.1.3)
+      webrick
+    heroku_hatchet (7.3.4)
       excon (~> 0)
       platform-api (~> 3)
       rrrretry (~> 1)
-      thor (~> 0)
+      thor (~> 1)
       threaded (~> 0)
     moneta (1.0.0)
     multi_json (1.15.0)
@@ -23,7 +24,7 @@ GEM
       rspec (>= 3.1.0)
     parallel_tests (3.2.0)
       parallel
-    platform-api (3.0.0)
+    platform-api (3.3.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
@@ -46,8 +47,9 @@ GEM
       rspec-core (> 3.3)
     rspec-support (3.9.3)
     sem_version (2.0.1)
-    thor (0.20.3)
+    thor (1.1.0)
     threaded (0.0.4)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -62,4 +64,4 @@ DEPENDENCIES
   sem_version
 
 BUNDLED WITH
-   2.2.1
+   2.2.22

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,15 @@ end
 def successful_body(app, options = {})
   retry_limit = options[:retry_limit] || 100
   path = options[:path] ? "/#{options[:path]}" : ''
-  Excon.get("http://#{app.name}.herokuapp.com#{path}", :idempotent => true, :expects => 200, :retry_limit => retry_limit).body
+  Excon.get("http://#{app.name}.herokuapp.com#{path}",
+              idempotent:     true,
+              expects:        200,
+              retry_interval: 0.5,
+              retry_limit:    retry_limit
+           ).body
+rescue Excon::HTTPStatus => e
+  puts e.response.body
+  raise e
 end
 
 def successful_json_body(app, options = {})


### PR DESCRIPTION
Recent pull requests are failing in CI, due to hatchet installation failures. I'm upgrading hatchet here to get CI green again.

Example failures:
- https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-nodejs/294/workflows/c3e91594-980a-4c15-b331-c81eb8d0a063/jobs/2016
- https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-nodejs/292/workflows/8516bef5-4011-41d0-980a-a3bcb5547308/jobs/2009