### PR TITLE
Add support for running "npm ci" when "npm-shrinkwrap.json" is found on the project directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 - Upgrade heroku_hatchet to 7.3.4 to get CI green again ([#936](https://github.com/heroku/heroku-buildpack-nodejs/pull/936))
 - Fix typo in conflicting lockfile failure message ([#901](https://github.com/heroku/heroku-buildpack-nodejs/pull/901))
+- Add support for running "npm ci" when "npm-shrinkwrap.json" is found on the project directory ([#899](https://github.com/heroku/heroku-buildpack-nodejs/pull/899))
 
 ## v186 (2021-08-11)
 - Refactor $WEB_CONCURRENCY logic ([#931](https://github.com/heroku/heroku-buildpack-nodejs/pull/931))

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -194,6 +194,16 @@ yarn_prune_devdependencies() {
   fi
 }
 
+has_npm_lock() {
+  local build_dir=${1:-}
+
+  if [[ -f "$build_dir/package-lock.json" ]] || [[ -f "$build_dir/npm-shrinkwrap.json" ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 should_use_npm_ci() {
   local build_dir=${1:-}
   local npm_version
@@ -206,7 +216,7 @@ should_use_npm_ci() {
 
   # We should only run `npm ci` if all of the manifest files are there, and we are running at least npm 6.x
   # `npm ci` was introduced in the 5.x line in 5.7.0, but this sees very little usage, < 5% of builds
-  if [[ -f "$build_dir/package.json" ]] && [[ -f "$build_dir/package-lock.json" ]] && (( major >= 6 )); then
+  if [[ -f "$build_dir/package.json" ]] && [[ "$(has_npm_lock "$build_dir")" == "true" ]] && (( major >= 6 )); then
     echo "true"
   else
     echo "false"

--- a/test/fixtures/node-10-npm-ci-shrinkwrap/npm-shrinkwrap.json
+++ b/test/fixtures/node-10-npm-ci-shrinkwrap/npm-shrinkwrap.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "hashish": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
+      "integrity": "sha1-bWC8b/r3Ebav1g5CbQd5iAFOZVQ=",
+      "requires": {
+        "traverse": ">=0.2.4"
+      }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    }
+  }
+}

--- a/test/fixtures/node-10-npm-ci-shrinkwrap/package.json
+++ b/test/fixtures/node-10-npm-ci-shrinkwrap/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/example/example.git"
+  },
+  "dependencies": {
+    "hashish": "*"
+  },
+  "engines": {
+    "node": "10.x"
+  },
+  "scripts": {
+    "heroku-prebuild": "echo heroku-prebuild script",
+    "build": "echo build script",
+    "postinstall": "echo postinstall script",
+    "start": "node foo.js"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -25,6 +25,30 @@ testNpmCi() {
   assertCapturedSuccess
 }
 
+testNpmCiShrinkwrap() {
+  local log_file cache
+  log_file=$(mktemp)
+  cache=$(mktmpdir)
+
+  BUILDPACK_LOG_FILE="$log_file" compile "node-10-npm-ci-shrinkwrap" "$cache"
+
+   # make sure that build scripts are being called
+  assertCaptured "heroku-prebuild script"
+  assertCaptured "build script"
+  assertCaptured "postinstall script"
+  assertCapturedSuccess
+
+   # test logging
+  assertFileContains "use-npm-ci=true" "$log_file"
+  assertFileContains "npm-install-time=" "$log_file"
+  assertFileContains "npm-install-memory=" "$log_file"
+
+   # test re-using the cache
+  echo "" > "$log_file"
+  BUILDPACK_LOG_FILE="$log_file" compile "node-10-npm-ci-shrinkwrap" "$cache"
+  assertCapturedSuccess
+}
+
 testNpmCiFallback() {
   local log_file cache
   log_file=$(mktemp)


### PR DESCRIPTION
Original reasoning, discussion and so on is on the PR #899.

I'm just opening this new PR because for some reason Github didn't recognize the new commit on the fork.