### PR TITLE
Update changelog release date for v188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-## v188 (2021-09-09)
+## v188 (2021-09-10)
 - Update Node version inventory, includes 12.22.6, 14.17.6, 16.8.0, 16.7.0 and others ([#940](https://github.com/heroku/heroku-buildpack-nodejs/pull/940))
 - Support non-zero-install support for Yarn 2 ([#888](https://github.com/heroku/heroku-buildpack-nodejs/pull/888))
 


### PR DESCRIPTION
Since it was published the day after the currently listed date:

```
$ h buildpacks:versions heroku/nodejs | head -n3
Version  Released At               Status
───────  ────────────────────────  ─────────
188      2021-09-10T17:03:08.056Z  published
```