### PR TITLE
Revert "Always use local yarn cache with yarn 2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Revert non-zero-install support from #888 ([#944](https://github.com/heroku/heroku-buildpack-nodejs/pull/944))
 
 ## v188 (2021-09-10)
 - Update Node version inventory, includes 12.22.6, 14.17.6, 16.8.0, 16.7.0 and others ([#940](https://github.com/heroku/heroku-buildpack-nodejs/pull/940))

--- a/bin/compile
+++ b/bin/compile
@@ -158,7 +158,9 @@ if [[ "$YARN_2" == "true" ]]; then
     warn "There is an existing .yarnrc file that will not be used. All configurations are read from the .yarnrc.yml file." "https://devcenter.heroku.com/articles/migrating-to-yarn-2"
   fi
 
-  YARN_CACHE_FOLDER="$BUILD_DIR/.yarn/cache"
+  if has_yarn_cache "$BUILD_DIR"; then
+    YARN_CACHE_FOLDER="$BUILD_DIR/.yarn/cache"
+  fi
 
   ### Configure Yarn 2
   # fail for no yarnrc.yml


### PR DESCRIPTION
Reverts heroku/heroku-buildpack-nodejs#888

There have been more than a few reports of trouble building with Yarn after this change. It doesn't seem to be working as expected. For example:

- https://github.com/heroku/heroku-buildpack-nodejs/issues/943
- https://github.com/heroku/heroku-buildpack-nodejs/issues/884#issuecomment-915783387
- https://heroku.support/1027280