### PR TITLE
Add Yarn 1.22.1{2,3,4,5} to inventory/yarn.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Add Yarn 1.22.1{2,3,4,5} to inventory/yarn.yml ([#947](https://github.com/heroku/heroku-buildpack-nodejs/pull/947))
 
 ## v189 (2021-09-14)
 - Revert non-zero-install support from #888 ([#944](https://github.com/heroku/heroku-buildpack-nodejs/pull/944))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
-- Add Yarn 1.22.1{2,3,4,5} to inventory/yarn.yml ([#947](https://github.com/heroku/heroku-buildpack-nodejs/pull/947))
+- Add Yarn 1.22.1{2,3,4,5} to `inventory/yarn.toml` ([#947](https://github.com/heroku/heroku-buildpack-nodejs/pull/947))
 
 ## v189 (2021-09-14)
 - Revert non-zero-install support from #888 ([#944](https://github.com/heroku/heroku-buildpack-nodejs/pull/944))

--- a/inventory/yarn.toml
+++ b/inventory/yarn.toml
@@ -493,6 +493,30 @@ url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.11.tar.gz
 etag = "abac2ecbe725c04e91dafc56ae2163b3"
 
 [[releases]]
+version = "1.22.12"
+channel = "release"
+url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.12.tar.gz"
+etag = "1ff62ef8049c14c3e5f2fa3bf594132a"
+
+[[releases]]
+version = "1.22.13"
+channel = "release"
+url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.13.tar.gz"
+etag = "5083b9c6ac6ed6fb4f8c666c41c1cab1"
+
+[[releases]]
+version = "1.22.14"
+channel = "release"
+url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.14.tar.gz"
+etag = "8e166ebb48570c137bf801e38dcf4c5c"
+
+[[releases]]
+version = "1.22.15"
+channel = "release"
+url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.15.tar.gz"
+etag = "4113da7ab81a77fb30f74737a459a225"
+
+[[releases]]
 version = "1.22.4"
 channel = "release"
 url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.4.tar.gz"


### PR DESCRIPTION
To fix CI on `main`, now that there are newer Yarn versions, which cause `testBuildMetaData` to fail, the same as it did in #934.

Example failure:
https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-nodejs/341/workflows/ec520072-c915-4dba-8fe3-ffe1f2197e8f/jobs/2277

GUS-W-9981764.