### PR TITLE
Remove unused parallel_tests gem & refresh Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ gem 'heroku_hatchet'
 gem 'rspec-retry'
 gem 'rspec-expectations'
 gem 'sem_version'
-gem "parallel_tests"
 gem "parallel_split_test"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.85.0)
+    excon (0.86.0)
     heroics (0.1.2)
       erubis (~> 2.0)
       excon
@@ -18,34 +18,25 @@ GEM
       threaded (~> 0)
     moneta (1.0.0)
     multi_json (1.15.0)
-    parallel (1.19.2)
-    parallel_split_test (0.8.0)
+    parallel (1.21.0)
+    parallel_split_test (0.10.0)
       parallel (>= 0.5.13)
-      rspec (>= 3.1.0)
-    parallel_tests (3.2.0)
-      parallel
+      rspec-core (>= 3.9.0)
     platform-api (3.3.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
-    rake (13.0.1)
+    rake (13.0.6)
     rate_throttle_client (0.1.2)
     rrrretry (1.0.0)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
+      rspec-support (~> 3.10.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.9.3)
+    rspec-support (3.10.2)
     sem_version (2.0.1)
     thor (1.1.0)
     threaded (0.0.4)
@@ -57,11 +48,10 @@ PLATFORMS
 DEPENDENCIES
   heroku_hatchet
   parallel_split_test
-  parallel_tests
   rake
   rspec-expectations
   rspec-retry
   sem_version
 
 BUNDLED WITH
-   2.2.22
+   2.2.28


### PR DESCRIPTION
- Removed unused `parallel_tests` dependency (this repository is using `parallel_split_tests` instead).
- Refreshes `Gemfile.lock` to pick up new dependencies. Moving forwards Dependabot will take care of this, but doing so in one go reduces the PR churn to get the repo up to date. Mass-updating is safe since the Ruby deps are only used in CI.

GUS-W-9981100.