### PR TITLE
Update default node version to 16.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Buildpack Changelog
 
 ## main
+- Update default node version to 16.x ([#973](https://github.com/heroku/heroku-buildpack-nodejs/pull/973)
 - Add Yarn 1.22.1{2,3,4,5} to `inventory/yarn.toml` ([#947](https://github.com/heroku/heroku-buildpack-nodejs/pull/947))
 
 ## v189 (2021-09-14)

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -87,7 +87,7 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version=${1:-14.x}
+  local version=${1:-16.x}
   local dir="${2:?}"
   local code resolve_result
 

--- a/test/run
+++ b/test/run
@@ -181,8 +181,8 @@ testYarnRun() {
 testNoVersion() {
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "Resolving node version 14.x"
-  assertCaptured "Downloading and installing node 14."
+  assertCaptured "Resolving node version 16.x"
+  assertCaptured "Downloading and installing node 16."
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
This will change the default version of Node.js that is installed when an app does not specify a `node` version in `package.json`'s `engines`.

Node.js 16 is the current Active LTS, so this would bring us up to date with our posted [support policy](https://devcenter.heroku.com/articles/nodejs-support#supported-runtimes).

Resolves #972 .

GUS-W-10500401

