### PR TITLE
Replace yarn cache rather than nest it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Fix issue with nested yarn caches and cache growth ([#985](https://github.com/heroku/heroku-buildpack-nodejs/pull/985))
+
 ## v191 (2022-02-14)
 - Improve support for yarn 2+ installs ([#978](https://github.com/heroku/heroku-buildpack-nodejs/pull/978)
 

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -116,7 +116,7 @@ save_default_cache_directories() {
   if [[ $(features_get "cache-native-yarn-cache") == "true" ]] && [[ "$YARN" == "true" ]]; then
     if [[ -d "$yarn_cache_dir" ]]; then
       if [[ "$YARN_2" == "true" ]] && ! node_modules_enabled "$BUILD_DIR"; then
-        cp -R "$yarn_cache_dir" "$cache_dir/node/cache/yarn"
+        cp -RTf "$yarn_cache_dir" "$cache_dir/node/cache/yarn"
       else
         mv "$yarn_cache_dir" "$cache_dir/node/cache/yarn"
       fi


### PR DESCRIPTION
It looks like the current yarn cache save logic (introduced in #978) creates nested caches like this:

```
- node
  - cache
    - yarn
      - yarn
        - yarn
          - yarn
```

This PR changes the cache save logic to replace the existing yarn folder in the cache, rather than creating a directory inside.

GUS-W-10519616