### PR TITLE
Fix additional occurrence of yarn cache nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+- Fix issue with nested yarn cache during cache restoration ([987](https://github.com/heroku/heroku-buildpack-nodejs/pull/987)
 - Fix issue with nested yarn caches and cache growth ([#985](https://github.com/heroku/heroku-buildpack-nodejs/pull/985))
 
 ## v191 (2022-02-14)

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -53,6 +53,7 @@ restore_default_cache_directories() {
     if has_yarn_cache "$build_dir"; then
       echo "- yarn cache is checked into source control and cannot be cached"
     elif [[ -e "$cache_dir/node/cache/yarn" ]]; then
+      rm -rf "$yarn_cache_dir"
       mv "$cache_dir/node/cache/yarn" "$yarn_cache_dir"
       echo "- yarn cache"
     else

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -57,7 +57,7 @@ restore_default_cache_directories() {
       mv "$cache_dir/node/cache/yarn" "$yarn_cache_dir"
       if [[ -d "$yarn_cache_dir/yarn" ]]; then
         # Older versions of the buildpack may have created nested yarn caches.
-        # This will remove the nested cache. This correction may be removed into
+        # This will remove the nested cache. This correction may be removed in
         # the near future.
         meta_set "yarn_nested_cache" "true"
         rm -rf "$yarn_cache_dir/yarn"

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -55,6 +55,13 @@ restore_default_cache_directories() {
     elif [[ -e "$cache_dir/node/cache/yarn" ]]; then
       rm -rf "$yarn_cache_dir"
       mv "$cache_dir/node/cache/yarn" "$yarn_cache_dir"
+      if [[ -d "$yarn_cache_dir/yarn" ]]; then
+        # Older versions of the buildpack may have created nested yarn caches.
+        # This will remove the nested cache. This correction may be removed into
+        # the near future.
+        meta_set "yarn_nested_cache" "true"
+        rm -rf "$yarn_cache_dir/yarn"
+      fi
       echo "- yarn cache"
     else
       echo "- yarn cache (not cached - skipping)"


### PR DESCRIPTION
The current yarn cache restore logic (introduced in #978) can create nested caches like below, iff the `.yarn/cache` folder is committed in the repo, but empty.

```
- node
  - cache
    - yarn
      - yarn
        - yarn
          - yarn
```

This PR changes the cache restore logic to remove the empty folder before moving the cache, so we essentially replace the folder, rather than nesting folders.

This also adds some temporary logic to delete any nested caches we created in #978.

GUS-W-10519616