### PR TITLE
Added inventory entry for yarn 1.22.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## main
 
+## v194 (2022-03-28)
+- Added Yarn 1.22.18 to `inventory/yarn.toml` ([#992](https://github.com/heroku/heroku-buildpack-nodejs/pull/992))
+
 ## v193 (2022-03-15)
-- Fix issue with pruning yarn 2 cache when using the workspaces plugin ([#918](https://github.com/heroku/heroku-buildpack-nodejs/issues/918))
+- Fix issue with pruning yarn 2 cache when using the workspaces plugin ([#990](https://github.com/heroku/heroku-buildpack-nodejs/pull/990))
 
 ## v192 (2022-02-16)
-- Fix issue with nested yarn cache during cache restoration ([987](https://github.com/heroku/heroku-buildpack-nodejs/pull/987))
+- Fix issue with nested yarn cache during cache restoration ([#987](https://github.com/heroku/heroku-buildpack-nodejs/pull/987))
 - Fix issue with nested yarn caches and cache growth ([#985](https://github.com/heroku/heroku-buildpack-nodejs/pull/985))
 
 ## v191 (2022-02-14)

--- a/inventory/yarn.toml
+++ b/inventory/yarn.toml
@@ -529,6 +529,12 @@ url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.17.tar.gz
 etag = "291fea6d3b993c201b946ab566de816c"
 
 [[releases]]
+version = "1.22.18"
+channel = "release"
+url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.18.tar.gz"
+etag = "fd220e06ecd3a3cc86a38f9215efdd67"
+
+[[releases]]
 version = "1.22.4"
 channel = "release"
 url = "https://s3.amazonaws.com/heroku-nodebin/yarn/release/yarn-v1.22.4.tar.gz"


### PR DESCRIPTION
Noticed this was causing CI failures after merging #990.  This should get the failing tests sorted.