### PR TITLE
Log exact installed npm version

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -140,6 +140,6 @@ install_npm() {
     if ! npm install --unsafe-perm --quiet -g "npm@$version" 2>@1>/dev/null; then
       echo "Unable to install npm $version; does it exist?" && false
     fi
-    echo "npm $version installed"
+    echo "npm $(npm --version) installed"
   fi
 }


### PR DESCRIPTION
When a new version of npm is installed only the specified compatible version is logged, not the resolved/installed one. This differs from when installing Node, where both versions are logged. Logging the exact version helps in debugging and adds clarity.

Before:

```sh
Resolving node version ~16...
Downloading and installing node 16.14.2...
Bootstrapping npm ~8 (replacing 8.5.0)...
npm ~8 installed
```
After:

```sh
Resolving node version ~16...
Downloading and installing node 16.14.2...
Bootstrapping npm ~8 (replacing 8.5.0)...
npm 8.6.0 installed
```