### PR TITLE
Embedded Node Application

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,10 +17,11 @@ BPLOG_PREFIX="buildpack.nodejs"
 
 ### Configure directories
 
-BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
+PACKAGE_JSON_PATH=$(find $BUILD_DIR -iname package.json -not -path "*node_modules/*")
+BUILD_DIR="$(dirname $PACKAGE_JSON_PATH)"
 
 ### Load dependencies
 

--- a/bin/detect
+++ b/bin/detect
@@ -19,7 +19,9 @@ error() {
 	exit 1
 }
 
-if [ -f "$1/package.json" ]; then
+
+PACKAGE_JSON_PATH=$(find $1 -maxdepth 5 -iname package.json -not -path "*node_modules/*")
+if [ -n "$PACKAGE_JSON_PATH" ]; then
   echo 'Node.js'
   exit 0
 fi


### PR DESCRIPTION
Sometimes the node app isn't at the base directory. In the case of a .NET app there can be a react/nodejs application that lives inside of the project. The buildpack should be smart enough to figure this out.

This change simply looks for a `package.json` file within 5 layers of the build directory. If present, `bin/detect` passes and the `BUILD_DIR` is set to that where the `package.json` is located.