### PR TITLE
Add Heroku-22 to the CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
     parameters:
       stack-number:
         type: "string"
-        default: "20"
     docker:
       - image: heroku/heroku:<< parameters.stack-number >>-build
     steps:
@@ -28,7 +27,6 @@ jobs:
     parameters:
       stack-number:
         type: "string"
-        default: "20"
     docker:
       - image: heroku/heroku:<< parameters.stack-number >>-build
     steps:
@@ -53,9 +51,17 @@ workflows:
   buildpack-tests:
     jobs:
       - unit-test:
+          name: heroku-22 unit tests
+          stack-number: "22"
+      - unit-test-heroku-build:
+          name: heroku-22 build tests
+          stack-number: "22"
+      - unit-test:
           name: heroku-20 unit tests
+          stack-number: "20"
       - unit-test-heroku-build:
           name: heroku-20 build tests
+          stack-number: "20"
       - unit-test:
           name: heroku-18 unit tests
           stack-number: "18"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 - Enable Yarn 2 `devDependency` pruning using a custom plugin for all customers ([#1001](https://github.com/heroku/heroku-buildpack-nodejs/pull/1001))
+- Test against Heroku-22 ([#1003](https://github.com/heroku/heroku-buildpack-nodejs/pull/1003))
 
 ## v195 (2022-04-13)
 - Enable Yarn 2 `devDependency` pruning using a custom plugin for 20% of customers ([#999](https://github.com/heroku/heroku-buildpack-nodejs/pull/999))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ There are unit tests that are run with `shunit`. For any change you make, write 
 
 ### Running Tests
 
-To run the tests, run `make test`. You will need Docker installed. This will start a test run of all 3 Heroku stack images that will run serially. If you want to test one stack image (which is usually adequate), run `make heroku-20` (or whatever stack image you'd like to test).
+To run the tests, run `make test`. You will need Docker installed. This will start a test run of all 3 Heroku stack images that will run serially. If you want to test one stack image (which is usually adequate), run `make heroku-22` (or whatever stack image you'd like to test).
 
 ## Opening a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Or to just test a specific stack:
 ```
 make heroku-18-build
 make heroku-20-build
+make heroku-22-build
 ```
 
 The tests are run via the vendored

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-test: heroku-20-build heroku-18-build
+test: heroku-22-build heroku-20-build heroku-18-build
 
 build:
 	@GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -v -o ./lib/vendor/resolve-version-darwin ./cmd/resolve-version
@@ -20,6 +20,11 @@ shellcheck:
 	@shellcheck -x lib/*.sh
 	@shellcheck -x ci-profile/**
 	@shellcheck -x etc/**
+
+heroku-22-build:
+	@echo "Running tests in docker (heroku-22-build)..."
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-22" heroku/heroku:22-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
+	@echo ""
 
 heroku-20-build:
 	@echo "Running tests in docker (heroku-20-build)..."
@@ -44,11 +49,11 @@ nodebin-test:
 	@echo ""
 
 unit:
-	@echo "Running unit tests in docker (heroku-20)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-20" heroku/heroku:20 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/unit;'
+	@echo "Running unit tests in docker (heroku-22)..."
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-22" heroku/heroku:22 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/unit;'
 	@echo ""
 
 shell:
-	@echo "Opening heroku-20 shell..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it heroku/heroku:20 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; bash'
+	@echo "Opening heroku-22 shell..."
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it heroku/heroku:22 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; bash'
 	@echo ""

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -4,8 +4,8 @@ describe "Stack Changes" do
   #Test upgrading stack invalidates the cache
   it "should not restore cached directories" do
     Hatchet::Runner.new("default-node", stack: "heroku-20").deploy do |app, heroku|
-      app.update_stack("heroku-18")
-      run!('git commit --allow-empty -m "heroku-18 migrate"')
+      app.update_stack("heroku-22")
+      app.commit!
       app.push!
       expect(app.output).to include("Cached directories were not restored due to a change in version of node, npm, yarn or stack")
     end
@@ -15,7 +15,7 @@ describe "Stack Changes" do
   it "should not restore cache if the stack did not change" do
     Hatchet::Runner.new('default-node', stack: "heroku-20").deploy do |app, heroku|
       app.update_stack("heroku-20")
-      run!('git commit --allow-empty -m "cedar migrate"')
+      app.commit!
       app.push!
       expect(app.output).to_not include("Cached directories were not restored due to a change in version of node, npm, yarn or stack")
       expect(app.output).to include("not cached - skipping")


### PR DESCRIPTION
The Node.js binaries are not stack-specific, so no buildpack/binary changes are needed for Heroku-22 - only testing it in CI.

GUS-W-10343867.