### PR TITLE
Fix for skipping pruning with Yarn 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 - Drop the `yarn-native-cache` feature flag ([#1004](https://github.com/heroku/heroku-buildpack-nodejs/pull/1004))
+- Fix skip pruning behavior with Yarn 2 ([#1008](https://github.com/heroku/heroku-buildpack-nodejs/pull/1008))
 
 ## v196 (2022-05-31)
 - Add metrics plugin for Node 17 and 18 ([#1002](https://github.com/heroku/heroku-buildpack-nodejs/pull/1002))

--- a/bin/compile
+++ b/bin/compile
@@ -69,6 +69,7 @@ build_start_time=$(nowms)
 handle_failure() {
   meta_set "node-build-success" "false"
   header "Build failed"
+  fail_using_yarn2_with_yarn_production_environment_variable_set "$LOG_FILE"
   fail_yarn_outdated "$LOG_FILE"
   fail_yarn_lockfile_outdated "$LOG_FILE"
   fail_node_install "$LOG_FILE" "$BUILD_DIR"
@@ -150,11 +151,6 @@ if [[ "$YARN_2" == "true" ]]; then
   if [[ -f "$BUILD_DIR/.yarnrc" ]]; then
     warn "There is an existing .yarnrc file that will not be used. All configurations are read from the .yarnrc.yml file." "https://devcenter.heroku.com/articles/migrating-to-yarn-2"
   fi
-
-  # YARN 2/3 does not like the YARN_PRODUCTION environment variable and will fail if it is set so
-  # we need to change the YARN_PRODUCTION environment variable to YARN_2_PRODUCTION
-  YARN_2_PRODUCTION=$YARN_PRODUCTION
-  unset YARN_PRODUCTION
 
   # When in Plug'n'Play mode the yarn cache will include dependencies needed at
   # runtime; the cache must live in /app (not /tmp) so that dependencies are

--- a/bin/compile
+++ b/bin/compile
@@ -151,6 +151,11 @@ if [[ "$YARN_2" == "true" ]]; then
     warn "There is an existing .yarnrc file that will not be used. All configurations are read from the .yarnrc.yml file." "https://devcenter.heroku.com/articles/migrating-to-yarn-2"
   fi
 
+  # YARN 2/3 does not like the YARN_PRODUCTION environment variable and will fail if it is set so
+  # we need to change the YARN_PRODUCTION environment variable to YARN_2_PRODUCTION
+  YARN_2_PRODUCTION=$YARN_PRODUCTION
+  unset YARN_PRODUCTION
+
   # When in Plug'n'Play mode the yarn cache will include dependencies needed at
   # runtime; the cache must live in /app (not /tmp) so that dependencies are
   # persisted. When using zero-install, /app/.yarn/cache will include all

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -166,12 +166,12 @@ yarn_prune_devdependencies() {
     echo "Skipping because YARN_PRODUCTION is '$YARN_PRODUCTION'"
     meta_set "skipped-prune" "true"
     return 0
-  elif [ "$YARN_2_PRODUCTION" == "false" ]; then
-    # keeping the messaging the same even though we replaced out YARN_PRODUCTION with YARN_2_PRODUCTION
-    echo "Skipping because YARN_PRODUCTION is '$YARN_2_PRODUCTION'"
-    meta_set "skipped-prune" "true"
-    return 0
   elif $YARN_2; then
+    if [ "$YARN2_SKIP_PRUNING" == "true" ]; then
+      echo "Skipping because YARN2_SKIP_PRUNING is '$YARN2_SKIP_PRUNING'"
+      meta_set "skipped-prune" "true"
+      return 0
+    fi
     cd "$build_dir" || return
     echo "Running 'yarn heroku prune'"
     export YARN_PLUGINS="${buildpack_dir}/yarn2-plugins/prune-dev-dependencies/bundles/@yarnpkg/plugin-prune-dev-dependencies.js"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -166,6 +166,11 @@ yarn_prune_devdependencies() {
     echo "Skipping because YARN_PRODUCTION is '$YARN_PRODUCTION'"
     meta_set "skipped-prune" "true"
     return 0
+  elif [ "$YARN_2_PRODUCTION" == "false" ]; then
+    # keeping the messaging the same even though we replaced out YARN_PRODUCTION with YARN_2_PRODUCTION
+    echo "Skipping because YARN_PRODUCTION is '$YARN_2_PRODUCTION'"
+    meta_set "skipped-prune" "true"
+    return 0
   elif $YARN_2; then
     cd "$build_dir" || return
     echo "Running 'yarn heroku prune'"

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -342,6 +342,33 @@ fail_invalid_semver() {
 
 # Yarn 2 failures
 
+fail_using_yarn2_with_yarn_production_environment_variable_set() {
+  local yarn_engine
+  local skip_pruning
+  local log_file="$1"
+
+  if grep -qi 'Unrecognized or legacy configuration settings found: production' "$log_file"; then
+    yarn_engine=$(yarn --version)
+    if [[ "$YARN_PRODUCTION" == "true" ]]; then
+      skip_pruning=false
+    else
+      skip_pruning=true
+    fi
+
+    mcount "failures.yarn2-with-yarn-production-env-set"
+    meta_set "failure" "yarn2-with-yarn-production-env-set"
+    echo ""
+    warn "Legacy Yarn 1.x configuration present:
+
+       Your application uses Yarn v$yarn_engine which does not support the YARN_PRODUCTION environment variable. Please
+       update your heroku config vars to remove YARN_PRODUCTION and set YARN2_SKIP_PRUNING instead.
+
+         $ heroku config:unset YARN_PRODUCTION && heroku config:set YARN2_SKIP_PRUNING=$skip_pruning
+    " https://devcenter.heroku.com/articles/nodejs-support#skip-pruning
+    fail
+  fi
+}
+
 fail_missing_yarnrc_yml() {
   local build_dir="$1"
 

--- a/test/run
+++ b/test/run
@@ -684,6 +684,29 @@ testYarn2() {
   assertCapturedSuccess
 }
 
+testYarn2WithYarnProductionTrue() {
+  env_dir=$(mktmpdir)
+  echo "true" > $env_dir/YARN_PRODUCTION
+  compile "yarn-2" "$(mktmpdir)" $env_dir
+  assertCaptured "Running 'yarn install' with yarn.lock"
+  assertCaptured "Version 3.9.7" # tsc output
+  assertCaptured "Running 'yarn heroku prune'"
+  assertCaptured "debug-npm-4.3.2-f0148b6afe-5543570879.zip appears to be unused - removing"
+  assertCaptured "ms-npm-2.1.2-ec0c1512ff-9b65fb709b.zip appears to be unused - removing"
+  assertCapturedSuccess
+}
+
+testYarn2WithYarnProductionFalseToSkipPruning() {
+  env_dir=$(mktmpdir)
+  echo "false" > $env_dir/YARN_PRODUCTION
+  compile "yarn-2" "$(mktmpdir)" $env_dir
+  assertCaptured "Running 'yarn install' with yarn.lock"
+  assertCaptured "Version 3.9.7" # tsc output
+  assertCaptured "Skipping because YARN_PRODUCTION is 'false'"
+  assertNotCaptured "Running 'yarn heroku prune'"
+  assertCapturedSuccess
+}
+
 testYarn2WithNodeModules() {
   compile "yarn-2-with-node-modules"
   assertCaptured "Running 'yarn install' with yarn.lock"

--- a/test/run
+++ b/test/run
@@ -684,9 +684,9 @@ testYarn2() {
   assertCapturedSuccess
 }
 
-testYarn2WithYarnProductionTrue() {
+testYarn2WithYarn2SkipPruningFalse() {
   env_dir=$(mktmpdir)
-  echo "true" > $env_dir/YARN_PRODUCTION
+  echo "false" > $env_dir/YARN2_SKIP_PRUNING
   compile "yarn-2" "$(mktmpdir)" $env_dir
   assertCaptured "Running 'yarn install' with yarn.lock"
   assertCaptured "Version 3.9.7" # tsc output
@@ -696,16 +696,24 @@ testYarn2WithYarnProductionTrue() {
   assertCapturedSuccess
 }
 
-testYarn2WithYarnProductionFalseToSkipPruning() {
+testYarn2WithYarn2SkipPruningTrue() {
   env_dir=$(mktmpdir)
-  echo "false" > $env_dir/YARN_PRODUCTION
+  echo "true" > $env_dir/YARN2_SKIP_PRUNING
   compile "yarn-2" "$(mktmpdir)" $env_dir
   assertCaptured "Running 'yarn install' with yarn.lock"
   assertCaptured "Version 3.9.7" # tsc output
-  assertCaptured "Skipping because YARN_PRODUCTION is 'false'"
+  assertCaptured "Skipping because YARN2_SKIP_PRUNING is 'true'"
   assertNotCaptured "Running 'yarn heroku prune'"
   assertCapturedSuccess
 }
+
+testYarn2WithYarnProductionSetCapturesAndReportsError() {
+   env_dir=$(mktmpdir)
+   echo "false" > $env_dir/YARN_PRODUCTION
+   compile "yarn-2" "$(mktmpdir)" $env_dir
+   assertCaptured "Legacy Yarn 1.x configuration present"
+   assertCapturedError
+ }
 
 testYarn2WithNodeModules() {
   compile "yarn-2-with-node-modules"


### PR DESCRIPTION
The [Node support docs](https://devcenter.heroku.com/articles/nodejs-support#skip-pruning) state that Yarn dependency pruning can be skipped by setting `YARN_PRODUCTION=false` but this only works with Yarn v1 since using the `YARN_PRODUCTION` environment variable with Yarn v2+ will cause `yarn` commands to fail.
 
This PR will:
 * detect when Yarn v2+ is used in the build and raise an actionable error if `YARN_PRODUCTION` is set
 * checks for the presence of a `YARN2_SKIP_PRUNING` environment variable to determine if we should skip pruning or not

Fixes #1007 