### PR TITLE
Remove optional `jq` install step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-- `jq` is no longer installed if it doesn't already exist on the stack ([#1016](https://github.com/heroku/heroku-buildpack-nodejs/pull/1016))
+- `jq` is no longer installed by the buildpack([#1016](https://github.com/heroku/heroku-buildpack-nodejs/pull/1016))
 - Switch away from deprecated path-based S3 URLs ([#1013](https://github.com/heroku/heroku-buildpack-nodejs/pull/1013))
 
 ## v197 (2022-06-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+- `jq` is no longer installed if it doesn't already exist on the stack ([#1016](https://github.com/heroku/heroku-buildpack-nodejs/pull/1016))
 - Switch away from deprecated path-based S3 URLs ([#1013](https://github.com/heroku/heroku-buildpack-nodejs/pull/1013))
 
 ## v197 (2022-06-07)

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-JQ="/usr/bin/jq"
-if ! test -f "$JQ"; then
-  curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > "/usr/bin/jq" \
-      && chmod +x "/usr/bin/jq"
-fi
-
 read_json() {
   local file="$1"
   local key="$2"
@@ -16,7 +10,7 @@ read_json() {
     # --raw-output = if the filter’s result is a string then it will be written directly
     #                to stdout rather than being formatted as a JSON string with quotes
     # shellcheck disable=SC2002
-    cat "$file" | $JQ -c -M --raw-output "$key // \"\"" || return 1
+    cat "$file" | jq -c -M --raw-output "$key // \"\"" || return 1
   else
     echo ""
   fi
@@ -28,7 +22,7 @@ json_has_key() {
 
   if test -f "$file"; then
     # shellcheck disable=SC2002
-    cat "$file" | $JQ ". | has(\"$key\")"
+    cat "$file" | jq ". | has(\"$key\")"
   else
     echo "false"
   fi
@@ -40,7 +34,7 @@ has_script() {
 
   if test -f "$file"; then
     # shellcheck disable=SC2002
-    cat "$file" | $JQ ".[\"scripts\"] | has(\"$key\")"
+    cat "$file" | jq ".[\"scripts\"] | has(\"$key\")"
   else
     echo "false"
   fi
@@ -49,7 +43,7 @@ has_script() {
 is_invalid_json_file() {
   local file="$1"
   # shellcheck disable=SC2002
-  if ! cat "$file" | $JQ "." 1>/dev/null; then
+  if ! cat "$file" | jq "." 1>/dev/null; then
     echo "true"
   else
     echo "false"


### PR DESCRIPTION
Since `jq` now exists on all stacks:
https://devcenter.heroku.com/articles/stack-packages

Removing since this means one fewer `curl` call to which retries etc have to be added shortly.