### PR TITLE
Adjust curl retry and connection timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+- Adjust curl retry and connection timeout handling ([#1017](https://github.com/heroku/heroku-buildpack-nodejs/pull/1017))
 - `jq` is no longer installed by the buildpack([#1016](https://github.com/heroku/heroku-buildpack-nodejs/pull/1016))
 - Switch away from deprecated path-based S3 URLs ([#1013](https://github.com/heroku/heroku-buildpack-nodejs/pull/1013))
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -64,7 +64,7 @@ install_yarn() {
     echo "Downloading and installing yarn ($number)"
   fi
 
-  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
+  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
 
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false
@@ -109,7 +109,7 @@ install_nodejs() {
     echo "Downloading and installing node $number..."
   fi
 
-  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/node.tar.gz --write-out "%{http_code}")
+  code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 -o /tmp/node.tar.gz --write-out "%{http_code}")
 
   if [ "$code" != "200" ]; then
     echo "Unable to download node: $code" && false

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -746,7 +746,7 @@ warn_old_npm() {
   npm_version="$(npm --version)"
 
   if [ "${npm_version:0:1}" -lt "2" ]; then
-    latest_npm="$(curl --silent --get --retry 5 --retry-max-time 15 https://semver.herokuapp.com/npm/stable)"
+    latest_npm="$(curl --silent --get --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 https://semver.herokuapp.com/npm/stable)"
     warning "This version of npm ($npm_version) has several known issues - consider upgrading to the latest release ($latest_npm)" "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
     mcount 'warnings.npm.old'
   fi


### PR DESCRIPTION
In the shimmed CNBs used in `heroku/builder` we have been seeing quite a few transient errors related to buildpacks downloading from S3.

Adding appropriate retries and connection timeouts to all of our buildpack's curl usages should help with these, as well as make builds more reliable in general for users on Heroku, plus also anyone using a shimmed CNB locally with Pack CLI (where the network connection may be even less reliable).

The `--retry-connrefused` option has been used since otherwise curl doesn't retry cases where the connection was refused. Ideally we would use `--retry-all-errors` which takes that one step further, however that option was only added in curl 7.71, so is only supported by Heroku-22+.

For more on curl options, see:
https://curl.se/docs/manpage.html

GUS-W-11283397.