### PR TITLE
Support GitHub Actions in etc scripts

### DIFF
--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 [ "$CI" != "true" ] && echo "Not running on CI!" && exit 1
-[ "$CIRCLE_PROJECT_USERNAME" != "heroku" ] && echo "Run tests manually for forked PRs." && exit 0
+ci_repo_owner=${CIRCLE_PROJECT_USERNAME:-${GITHUB_REPOSITORY_OWNER}}
+[ "$ci_repo_owner" != "heroku" ] && echo "Run tests manually for forked PRs." && exit 0
 
 bundle install
 bundle exec hatchet ci:setup

--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -16,7 +16,6 @@ else
   HATCHET_BUILDPACK_BRANCH=$(git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#\1#' | sed 's#tags\/##')
 fi
 
-echo $HATCHET_BUILDPACK_BRANCH
 export HATCHET_BUILDPACK_BRANCH
 
 export HATCHET_RETRIES=3

--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -2,19 +2,21 @@
 
 set -e
 
-[ "$CIRCLE_PROJECT_USERNAME" != "heroku" ] && echo "Run tests manually for forked PRs." && exit 0
+ci_repo_owner=${CIRCLE_PROJECT_USERNAME:-${GITHUB_REPOSITORY_OWNER}}
+ci_repo_name=${CIRCLE_PROJECT_REPONAME:-${GITHUB_REPOSITORY}}
+ci_branch=${CIRCLE_BRANCH:-${GITHUB_REF_NAME}}
 
-if [[ "$CIRCLE_PROJECT_REPONAME" == "nodebin" ]]; then
+[ "$ci_repo_owner" != "heroku" ] && echo "Run tests manually for forked PRs." && exit 0
+
+if [[ "$ci_repo_name" == *nodebin ]]; then
   HATCHET_BUILDPACK_BRANCH="main"
-elif [ -n "$CIRCLE_BRANCH" ]; then
-  HATCHET_BUILDPACK_BRANCH="$CIRCLE_BRANCH"
-elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
-  export IS_RUNNING_ON_TRAVIS=true
-  HATCHET_BUILDPACK_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+elif [ -n "$ci_branch" ]; then
+  HATCHET_BUILDPACK_BRANCH="$ci_branch"
 else
   HATCHET_BUILDPACK_BRANCH=$(git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#\1#' | sed 's#tags\/##')
 fi
 
+echo $HATCHET_BUILDPACK_BRANCH
 export HATCHET_BUILDPACK_BRANCH
 
 export HATCHET_RETRIES=3


### PR DESCRIPTION
Part of the workflow for mirroring node.js asset releases includes running the hatchet tests defined here. Over in https://github.com/heroku/nodebin/pull/183, I'm converting that mirroring process to GitHub Actions. The `etc/hatchet.sh` and `etc/ci-setup.sh` scripts are setup for use in CircleCI environments, but not in GitHub Actions environments. This PR adjusts the scripts to work in both CircleCI and GitHub Actions, and drops support for Travis, which we haven't used for some time now.