### PR TITLE
Update Node.js inventory

### DIFF
--- a/inventory/node.toml
+++ b/inventory/node.toml
@@ -4187,6 +4187,27 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/
 etag = "4648915ed3eb1be12cf7cbe1c5b3e867-3"
 
 [[releases]]
+version = "12.22.10"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.10-linux-x64.tar.gz"
+etag = "58fe1bdc055914f433ee3f07bb380f36-3"
+
+[[releases]]
+version = "12.22.11"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.11-linux-x64.tar.gz"
+etag = "98a9f79ab4d7840b31c95968e82e9569-3"
+
+[[releases]]
+version = "12.22.12"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v12.22.12-linux-x64.tar.gz"
+etag = "84488d656cf19837e8dbc27b1a9993c9-3"
+
+[[releases]]
 version = "12.22.2"
 channel = "release"
 arch = "linux-x64"
@@ -4628,11 +4649,46 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/
 etag = "af7ed8db30228507dad9cf71afcce543-5"
 
 [[releases]]
+version = "14.19.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.0-linux-x64.tar.gz"
+etag = "06a14f4fdc59ae064ba047d4e9736fa3-5"
+
+[[releases]]
+version = "14.19.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.1-linux-x64.tar.gz"
+etag = "fcb00a3d0c4b22c1b6e157a558949657-5"
+
+[[releases]]
+version = "14.19.2"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.2-linux-x64.tar.gz"
+etag = "a6dd0bfb2f656166aeefefa37cfa8122-5"
+
+[[releases]]
+version = "14.19.3"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.19.3-linux-x64.tar.gz"
+etag = "3990a70c4d0794e8646575c76bff11a7-5"
+
+[[releases]]
 version = "14.2.0"
 channel = "release"
 arch = "linux-x64"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.2.0-linux-x64.tar.gz"
 etag = "130cb565b0fac4199fbc31df53a5f767"
+
+[[releases]]
+version = "14.20.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v14.20.0-linux-x64.tar.gz"
+etag = "f6da9962195174482d28f10830caf07d-5"
 
 [[releases]]
 version = "14.3.0"
@@ -4873,6 +4929,55 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/
 etag = "8104fa926e76b71b0c22236b24310732-4"
 
 [[releases]]
+version = "16.14.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.0-linux-x64.tar.gz"
+etag = "5bc4c0b1c1c94fad08c80561e259ee99-4"
+
+[[releases]]
+version = "16.14.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.1-linux-x64.tar.gz"
+etag = "64b4bbdf40af72cd2fe6accfc8054b16-4"
+
+[[releases]]
+version = "16.14.2"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.14.2-linux-x64.tar.gz"
+etag = "4db20ae2bbff10cf3c8aa2f7ea370fb0-4"
+
+[[releases]]
+version = "16.15.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.15.0-linux-x64.tar.gz"
+etag = "4df8f054993a43950ef0f2e42b9ff53d-4"
+
+[[releases]]
+version = "16.15.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.15.1-linux-x64.tar.gz"
+etag = "b863d244e4b1c0df901c8c8c8967dd68-4"
+
+[[releases]]
+version = "16.16.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.16.0-linux-x64.tar.gz"
+etag = "ad683ead6ffb89f81e933ab93a9c770a-4"
+
+[[releases]]
+version = "16.17.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.17.0-linux-x64.tar.gz"
+etag = "2525dc9822008f0666d3f0908c4c4c43-5"
+
+[[releases]]
 version = "16.2.0"
 channel = "release"
 arch = "linux-x64"
@@ -5011,6 +5116,132 @@ channel = "release"
 arch = "linux-x64"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.4.0-linux-x64.tar.gz"
 etag = "72cd45ee41e736a3d15ccd255bc42ea5-6"
+
+[[releases]]
+version = "17.5.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.5.0-linux-x64.tar.gz"
+etag = "85ca8cdd9038440dbad047487fe5caad-6"
+
+[[releases]]
+version = "17.6.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.6.0-linux-x64.tar.gz"
+etag = "acb898de485f6fd431c5bba29737cdd6-6"
+
+[[releases]]
+version = "17.7.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.0-linux-x64.tar.gz"
+etag = "3ae4ee1f090945e80ad2209beb2c019e-6"
+
+[[releases]]
+version = "17.7.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.1-linux-x64.tar.gz"
+etag = "45444848e3db9df8e1906f30303f0b73-6"
+
+[[releases]]
+version = "17.7.2"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.7.2-linux-x64.tar.gz"
+etag = "5bfd0dc5e7e878dd4561fd0e41035051-6"
+
+[[releases]]
+version = "17.8.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.8.0-linux-x64.tar.gz"
+etag = "062cf4cae4ec3b032c41909a49df706e-6"
+
+[[releases]]
+version = "17.9.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.9.0-linux-x64.tar.gz"
+etag = "d82856ef7d8fd6ee756e0c4054e686aa-6"
+
+[[releases]]
+version = "17.9.1"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v17.9.1-linux-x64.tar.gz"
+etag = "5abb91fe234c1cb3709811ca8c62ee88-6"
+
+[[releases]]
+version = "18.0.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.0.0-linux-x64.tar.gz"
+etag = "48ae6c63e24f5ce074e86188287198e0-6"
+
+[[releases]]
+version = "18.1.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.1.0-linux-x64.tar.gz"
+etag = "37faa7d1b87accc2b5f8c5c8af3d4a85-6"
+
+[[releases]]
+version = "18.2.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.2.0-linux-x64.tar.gz"
+etag = "3e7b3258d258a95ba0e1ad06ed7f482d-6"
+
+[[releases]]
+version = "18.3.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.3.0-linux-x64.tar.gz"
+etag = "0882fd16bcfeabd57379441604051ca4-6"
+
+[[releases]]
+version = "18.4.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.4.0-linux-x64.tar.gz"
+etag = "05ff72f9371a8705b8e5b895dfd8f6b5-6"
+
+[[releases]]
+version = "18.5.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.5.0-linux-x64.tar.gz"
+etag = "9bd9fc6a152929b992967d7efe40cfa6-6"
+
+[[releases]]
+version = "18.6.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.6.0-linux-x64.tar.gz"
+etag = "96773288cff667058e088a4fb418aca3-6"
+
+[[releases]]
+version = "18.7.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.7.0-linux-x64.tar.gz"
+etag = "a0a3893b6b148788381bbc6f7260d35e-6"
+
+[[releases]]
+version = "18.8.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.8.0-linux-x64.tar.gz"
+etag = "cc3fcca2aa2dccdc333fbc0709428463-6"
+
+[[releases]]
+version = "18.9.0"
+channel = "release"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.9.0-linux-x64.tar.gz"
+etag = "8e53d83d4455c1861a22030a78f0a076-6"
 
 [[releases]]
 version = "4.0.0"
@@ -7484,6 +7715,27 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/
 etag = "4648915ed3eb1be12cf7cbe1c5b3e867-3"
 
 [[releases]]
+version = "12.22.10"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.10-linux-x64.tar.gz"
+etag = "58fe1bdc055914f433ee3f07bb380f36-3"
+
+[[releases]]
+version = "12.22.11"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.11-linux-x64.tar.gz"
+etag = "98a9f79ab4d7840b31c95968e82e9569-3"
+
+[[releases]]
+version = "12.22.12"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v12.22.12-linux-x64.tar.gz"
+etag = "84488d656cf19837e8dbc27b1a9993c9-3"
+
+[[releases]]
 version = "12.22.2"
 channel = "staging"
 arch = "linux-x64"
@@ -7925,11 +8177,46 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/
 etag = "af7ed8db30228507dad9cf71afcce543-5"
 
 [[releases]]
+version = "14.19.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.0-linux-x64.tar.gz"
+etag = "06a14f4fdc59ae064ba047d4e9736fa3-5"
+
+[[releases]]
+version = "14.19.1"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.1-linux-x64.tar.gz"
+etag = "fcb00a3d0c4b22c1b6e157a558949657-5"
+
+[[releases]]
+version = "14.19.2"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.2-linux-x64.tar.gz"
+etag = "a6dd0bfb2f656166aeefefa37cfa8122-5"
+
+[[releases]]
+version = "14.19.3"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.19.3-linux-x64.tar.gz"
+etag = "3990a70c4d0794e8646575c76bff11a7-5"
+
+[[releases]]
 version = "14.2.0"
 channel = "staging"
 arch = "linux-x64"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.2.0-linux-x64.tar.gz"
 etag = "f41be74dd195a5714eabfeb4b3b95cc2-4"
+
+[[releases]]
+version = "14.20.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v14.20.0-linux-x64.tar.gz"
+etag = "f6da9962195174482d28f10830caf07d-5"
 
 [[releases]]
 version = "14.3.0"
@@ -8170,6 +8457,55 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/
 etag = "8104fa926e76b71b0c22236b24310732-4"
 
 [[releases]]
+version = "16.14.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.0-linux-x64.tar.gz"
+etag = "5bc4c0b1c1c94fad08c80561e259ee99-4"
+
+[[releases]]
+version = "16.14.1"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.1-linux-x64.tar.gz"
+etag = "64b4bbdf40af72cd2fe6accfc8054b16-4"
+
+[[releases]]
+version = "16.14.2"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.14.2-linux-x64.tar.gz"
+etag = "4db20ae2bbff10cf3c8aa2f7ea370fb0-4"
+
+[[releases]]
+version = "16.15.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.15.0-linux-x64.tar.gz"
+etag = "4df8f054993a43950ef0f2e42b9ff53d-4"
+
+[[releases]]
+version = "16.15.1"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.15.1-linux-x64.tar.gz"
+etag = "b863d244e4b1c0df901c8c8c8967dd68-4"
+
+[[releases]]
+version = "16.16.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.16.0-linux-x64.tar.gz"
+etag = "ad683ead6ffb89f81e933ab93a9c770a-4"
+
+[[releases]]
+version = "16.17.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v16.17.0-linux-x64.tar.gz"
+etag = "2525dc9822008f0666d3f0908c4c4c43-5"
+
+[[releases]]
 version = "16.2.0"
 channel = "staging"
 arch = "linux-x64"
@@ -8308,6 +8644,132 @@ channel = "staging"
 arch = "linux-x64"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.4.0-linux-x64.tar.gz"
 etag = "72cd45ee41e736a3d15ccd255bc42ea5-6"
+
+[[releases]]
+version = "17.5.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.5.0-linux-x64.tar.gz"
+etag = "85ca8cdd9038440dbad047487fe5caad-6"
+
+[[releases]]
+version = "17.6.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.6.0-linux-x64.tar.gz"
+etag = "acb898de485f6fd431c5bba29737cdd6-6"
+
+[[releases]]
+version = "17.7.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.0-linux-x64.tar.gz"
+etag = "3ae4ee1f090945e80ad2209beb2c019e-6"
+
+[[releases]]
+version = "17.7.1"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.1-linux-x64.tar.gz"
+etag = "45444848e3db9df8e1906f30303f0b73-6"
+
+[[releases]]
+version = "17.7.2"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.7.2-linux-x64.tar.gz"
+etag = "5bfd0dc5e7e878dd4561fd0e41035051-6"
+
+[[releases]]
+version = "17.8.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.8.0-linux-x64.tar.gz"
+etag = "062cf4cae4ec3b032c41909a49df706e-6"
+
+[[releases]]
+version = "17.9.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.9.0-linux-x64.tar.gz"
+etag = "d82856ef7d8fd6ee756e0c4054e686aa-6"
+
+[[releases]]
+version = "17.9.1"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v17.9.1-linux-x64.tar.gz"
+etag = "5abb91fe234c1cb3709811ca8c62ee88-6"
+
+[[releases]]
+version = "18.0.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.0.0-linux-x64.tar.gz"
+etag = "48ae6c63e24f5ce074e86188287198e0-6"
+
+[[releases]]
+version = "18.1.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.1.0-linux-x64.tar.gz"
+etag = "37faa7d1b87accc2b5f8c5c8af3d4a85-6"
+
+[[releases]]
+version = "18.2.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.2.0-linux-x64.tar.gz"
+etag = "3e7b3258d258a95ba0e1ad06ed7f482d-6"
+
+[[releases]]
+version = "18.3.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.3.0-linux-x64.tar.gz"
+etag = "0882fd16bcfeabd57379441604051ca4-6"
+
+[[releases]]
+version = "18.4.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.4.0-linux-x64.tar.gz"
+etag = "05ff72f9371a8705b8e5b895dfd8f6b5-6"
+
+[[releases]]
+version = "18.5.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.5.0-linux-x64.tar.gz"
+etag = "9bd9fc6a152929b992967d7efe40cfa6-6"
+
+[[releases]]
+version = "18.6.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.6.0-linux-x64.tar.gz"
+etag = "96773288cff667058e088a4fb418aca3-6"
+
+[[releases]]
+version = "18.7.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.7.0-linux-x64.tar.gz"
+etag = "a0a3893b6b148788381bbc6f7260d35e-6"
+
+[[releases]]
+version = "18.8.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.8.0-linux-x64.tar.gz"
+etag = "cc3fcca2aa2dccdc333fbc0709428463-6"
+
+[[releases]]
+version = "18.9.0"
+channel = "staging"
+arch = "linux-x64"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/staging/linux-x64/node-v18.9.0-linux-x64.tar.gz"
+etag = "8e53d83d4455c1861a22030a78f0a076-6"
 
 [[releases]]
 version = "6.14.4"

--- a/inventory/yarn.toml
+++ b/inventory/yarn.toml
@@ -535,6 +535,12 @@ url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22
 etag = "fd220e06ecd3a3cc86a38f9215efdd67"
 
 [[releases]]
+version = "1.22.19"
+channel = "release"
+url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.19.tar.gz"
+etag = "c04ea97bf9f72386c1a3da6b1c8510e3"
+
+[[releases]]
 version = "1.22.4"
 channel = "release"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v1.22.4.tar.gz"


### PR DESCRIPTION
This brings the inventory up to date with https://github.com/heroku/buildpacks-nodejs.