### PR TITLE
Remove dependency on semver.herokuapp.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Remove dependency on semver.herokuapp.com ([#1037](https://github.com/heroku/heroku-buildpack-nodejs/pull/1037))
+
 ## v198 (2022-06-15)
 
 - Adjust curl retry and connection timeout handling ([#1017](https://github.com/heroku/heroku-buildpack-nodejs/pull/1017))

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -746,8 +746,7 @@ warn_old_npm() {
   npm_version="$(npm --version)"
 
   if [ "${npm_version:0:1}" -lt "2" ]; then
-    latest_npm="$(curl --silent --get --retry 5 --retry-max-time 15 --retry-connrefused --connect-timeout 5 https://semver.herokuapp.com/npm/stable)"
-    warning "This version of npm ($npm_version) has several known issues - consider upgrading to the latest release ($latest_npm)" "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+    warning "This version of npm ($npm_version) has several known issues. Please update your npm version in package.json." "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
     mcount 'warnings.npm.old'
   fi
 }

--- a/test/run
+++ b/test/run
@@ -795,7 +795,7 @@ testUnstableVersion() {
 
 testOldNpm() {
   compile "old-npm"
-  assertCaptured "This version of npm (1.2.8000) has several known issues - consider upgrading to the latest release"
+  assertCaptured "This version of npm (1.2.8000) has several known issues. Please update your npm version in package.json."
   assertNotCaptured "integer expression expected"
   assertCapturedError
 }


### PR DESCRIPTION
Since:
- The app is deprecated and due to be switched off shortly.
- The buildpack should have as few dependencies on external resources as possible (particularly those not productionised or behind CDN).
- We especially should not have dependencies on `herokuapp.com` domains, given the reduced flexibility and risk of subdomain takeover.

Fixes #1015.
GUS-W-11843580.