### PR TITLE
Change the default Node.js to 18.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       matrix:
         stack_number: ["18", "20", "22"]
+    env:
+      STACK: heroku-${{ matrix.stack_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Update default node version to 16.x ([#1045](https://github.com/heroku/heroku-buildpack-nodejs/pull/1045))
+
 ## v200 (2022-10-19)
 
 - Dependency pruning support for Yarn 2 / 3 / 4 ([#1040](https://github.com/heroku/heroku-buildpack-nodejs/pull/1040))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-- Update default node version to 18.x ([#1045](https://github.com/heroku/heroku-buildpack-nodejs/pull/1045))
+- Update default node version to 18.x for heroku-20 and newer ([#1045](https://github.com/heroku/heroku-buildpack-nodejs/pull/1045))
 
 ## v200 (2022-10-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-- Update default node version to 16.x ([#1045](https://github.com/heroku/heroku-buildpack-nodejs/pull/1045))
+- Update default node version to 18.x ([#1045](https://github.com/heroku/heroku-buildpack-nodejs/pull/1045))
 
 ## v200 (2022-10-19)
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -89,9 +89,20 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version=${1:-18.x}
+  local version="${1:-}"
   local dir="${2:?}"
   local code resolve_result
+
+  if [[ -z "$version" ]]; then
+    # Node.js 18+ is incompatible with ubuntu:18 (and thus heroku-18) because of a libc mismatch:
+    # node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
+    # Fallback to a 16.x default for heroku-18 until heroku-18 or Node.js 16.x are EOL.
+    if [[ "$STACK" == "heroku-18" ]]; then
+      version="16.x"
+    else
+      version="18.x"
+    fi
+  fi
 
   if [[ -n "$NODE_BINARY_URL" ]]; then
     url="$NODE_BINARY_URL"

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -89,7 +89,7 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version=${1:-16.x}
+  local version=${1:-18.x}
   local dir="${2:?}"
   local code resolve_result
 

--- a/test/run
+++ b/test/run
@@ -179,10 +179,14 @@ testYarnRun() {
 }
 
 testNoVersion() {
+  local default_version="18"
+  if [[ $STACK == "heroku-18" ]]; then
+    default_version="16"
+  fi
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "Resolving node version 18.x"
-  assertCaptured "Downloading and installing node 18."
+  assertCaptured "Resolving node version ${default_version}.x"
+  assertCaptured "Downloading and installing node ${default_version}."
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -181,8 +181,8 @@ testYarnRun() {
 testNoVersion() {
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
-  assertCaptured "Resolving node version 16.x"
-  assertCaptured "Downloading and installing node 16."
+  assertCaptured "Resolving node version 18.x"
+  assertCaptured "Downloading and installing node 18."
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
This will change the default version of Node.js that is installed when an app does not specify a `node` version in `package.json`'s `engines`.

Node.js 16 is a "Maintenance LTS" as of 2022-10-18. Node.js 18 becomes the "Active LTS" on 2022-10-25 ([Node.js Releases](https://nodejs.dev/en/about/releases/)). As of today, there isn't an "Active LTS", so we're in a short window where there isn't an "Active LTS". But, Node.js 18 is a "Current" version, so updating the default to 18 would keep our default within our posted [version support policy](https://devcenter.heroku.com/articles/nodejs-support#supported-runtimes).

However, Node.js 18 and newer are incompatible with `ubuntu:18`/`heroku-18`, due to a `gcc` version incompatibility. Changing the default on `heroku-18` would likely cause failing builds, so we'll leave the default at `16.x` on `heroku-18`. 

[W-11932999](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE000019GHxdYAG)
