### PR TITLE
Log error message in unknown error scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Log error details in unknown error scenarios ([#1051](https://github.com/heroku/heroku-buildpack-nodejs/pull/1051))
+
 ## v201 (2022-10-19)
 
 - Add metrics and tests for Node.js 19.x line ([#1046](https://github.com/heroku/heroku-buildpack-nodejs/pull/1046))

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -244,7 +244,7 @@ fail_bin_install() {
   elif [[ $error == "Could not parse"* ]] || [[ $error == "Could not get"* ]]; then
     echo "Error: Invalid semantic version \"$version\""
   else
-    echo "Error: Unknown error installing \"$version\" of $bin"
+    echo "Error: Unknown error installing \"$version\" of $bin: \"$error\""
   fi
 
   return 1


### PR DESCRIPTION
Errors like `Error: Unknown error installing "16.18.0" of node` aren't especially useful. This adds the actual error message to that line to hopefully help consumers and developers understand why this error occurs.

[W-12004245](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00001BRQcTYAX)