### PR TITLE
Allow yarn version selection for yarn berry projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Allow yarn version selection for yarn berry projects ([#1060](https://github.com/heroku/heroku-buildpack-nodejs/pull/1060))
+
 ## v202 (2022-11-03)
 
 - Update go to 1.19 and recompile resolve-version ([#1050](https://github.com/heroku/heroku-buildpack-nodejs/pull/1050))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+## v203 (2023-02-10)
+
 - Allow yarn version selection for yarn berry projects ([#1060](https://github.com/heroku/heroku-buildpack-nodejs/pull/1060))
 
 ## v202 (2022-11-03)

--- a/bin/compile
+++ b/bin/compile
@@ -200,11 +200,6 @@ install_bins() {
   npm_engine=$(read_json "$BUILD_DIR/package.json" ".engines.npm")
   yarn_engine=$(read_json "$BUILD_DIR/package.json" ".engines.yarn")
 
-  if [[ "$YARN_2" == "true" && -n "$yarn_engine" ]]; then
-    warn "You don't need to specify Yarn engine. Heroku will install the latest Yarn 1.x, so that per project version can be used. More information here: https://yarnpkg.com/getting-started/install#global-install"
-    unset yarn_engine
-  fi
-
   meta_set "node-version-request" "$node_engine"
   meta_set "npm-version-request" "$npm_engine"
   meta_set "yarn-version-request" "$yarn_engine"

--- a/test/fixtures/yarn-2-with-engine/package.json
+++ b/test/fixtures/yarn-2-with-engine/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "yarn": "1.x"
+    "yarn": "2.x"
   },
   "dependencies": {
     "lodash": "^4.16.4"

--- a/test/fixtures/yarn-2-with-engine/package.json
+++ b/test/fixtures/yarn-2-with-engine/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "yarn": "2.x"
+    "yarn": "1.x"
   },
   "dependencies": {
     "lodash": "^4.16.4"

--- a/test/run
+++ b/test/run
@@ -734,7 +734,6 @@ testYarn2WithoutWorkspaceModule() {
 # Yarn 2 warnings
 testYarn2WithEngine() {
   compile "yarn-2-with-engine"
-  assertCaptured "You don't need to specify Yarn engine. Heroku will install the latest Yarn 1.x"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
Yarn berry (yarn 2.x and greater) releases are being made available in Heroku's yarn mirror. This should allow yarn berry projects to install a yarn berry CLI, rather than using the yarn classic (`1.22.x`) CLI as a proxy. When the releases are made available, users could select a specific release with `engines.yarn` in `package.json` like this:

```
{
  “engines”: {
    “yarn”: “3.4.x”
  }
}
```

In this scenario, the "You don't need to specify Yarn engine" warning messages no longer make sense. This PR removes that messaging and restriction.
