### PR TITLE
Add inventory update automation

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,6 +1,5 @@
 name: Update Inventory
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '00 4 * * 1-5'

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -24,9 +24,9 @@ jobs:
           cargo install heroku-nodejs-utils --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
       - id: set-diff-msg
         name: Set Diff Message
-        run: echo "::set-output name=msg::$(./diff_versions node inventory/node.toml)"
+        run: echo "::set-output name=msg::$(diff_versions node inventory/node.toml)"
       - name: Rebuild Inventory
-        run: "./list_versions node > inventory/node.toml"
+        run: "list_versions node > inventory/node.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request
@@ -55,9 +55,9 @@ jobs:
           cargo install heroku-nodejs-utils --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
       - id: set-diff-msg
         name: Set Diff Message
-        run: echo "::set-output name=msg::$(./diff_versions yarn inventory/yarn.toml)"
+        run: echo "::set-output name=msg::$(diff_versions yarn inventory/yarn.toml)"
       - name: Rebuild Inventory
-        run: "./list_versions yarn > inventory/yarn.toml"
+        run: "list_versions yarn > inventory/yarn.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -11,16 +11,12 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - id: install-rust-toolchain
-        name: Install Rust Toolchain
+      - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - id: install-rust-inventory-binaries
-        name: Install Rust Inventory Binaries
-        run: |
-          cargo install heroku-nodejs-utils --bin diff_versions --git https://github.com/heroku/buildpacks-nodejs
-          cargo install heroku-nodejs-utils --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
+      - name: Install Rust Inventory Binaries
+        run: cargo install heroku-nodejs-utils --bin diff_versions --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
       - id: set-diff-msg
         name: Set Diff Message
         run: echo "::set-output name=msg::$(diff_versions node inventory/node.toml)"
@@ -29,7 +25,7 @@ jobs:
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v4.2.4
         with:
           title: "Update Node.js Engine Inventory"
           commit-message: "Update Inventory for heroku/nodejs-engine\n\n${{ steps.set-diff-msg.outputs.msg }}"
@@ -47,11 +43,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - id: install-rust-inventory-binaries
-        name: Install Rust Inventory Binaries
-        run: |
-          cargo install heroku-nodejs-utils --bin diff_versions --git https://github.com/heroku/buildpacks-nodejs
-          cargo install heroku-nodejs-utils --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
+      - name: Install Rust Inventory Binaries
+        run: cargo install heroku-nodejs-utils --bin diff_versions --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
       - id: set-diff-msg
         name: Set Diff Message
         run: echo "::set-output name=msg::$(diff_versions yarn inventory/yarn.toml)"
@@ -60,7 +53,7 @@ jobs:
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v4.2.4
         with:
           title: "Update Node.js Yarn Inventory"
           commit-message: "Update Inventory for heroku/nodejs-yarn\n\n${{ steps.set-diff-msg.outputs.msg }}"

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,0 +1,70 @@
+name: Update Inventory
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 4 * * 1-5'
+
+jobs:
+  update-nodejs-inventory:
+    name: Update Node.js Engine Inventory
+    runs-on: pub-hk-ubuntu-22.04-small
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - id: install-rust-toolchain
+        name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - id: install-rust-inventory-binaries
+        name: Install Rust Inventory Binaries
+        run: |
+          cargo install heroku-nodejs-utils --bin diff_versions --git https://github.com/heroku/buildpacks-nodejs
+          cargo install heroku-nodejs-utils --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
+      - id: set-diff-msg
+        name: Set Diff Message
+        run: echo "::set-output name=msg::$(./diff_versions node inventory/node.toml)"
+      - name: Rebuild Inventory
+        run: "./list_versions node > inventory/node.toml"
+      - name: Update Changelog
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update Node.js Engine Inventory"
+          commit-message: "Update Inventory for heroku/nodejs-engine\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          branch: update-nodejs-inventory
+          labels: "automation"
+          body: "Automated pull-request to update heroku/nodejs-engine inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+  update-yarn-inventory:
+    name: Update Node.js Yarn Inventory
+    runs-on: pub-hk-ubuntu-22.04-small
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - id: install-rust-toolchain
+        name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - id: install-rust-inventory-binaries
+        name: Install Rust Inventory Binaries
+        run: |
+          cargo install heroku-nodejs-utils --bin diff_versions --git https://github.com/heroku/buildpacks-nodejs
+          cargo install heroku-nodejs-utils --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
+      - id: set-diff-msg
+        name: Set Diff Message
+        run: echo "::set-output name=msg::$(./diff_versions yarn inventory/yarn.toml)"
+      - name: Rebuild Inventory
+        run: "./list_versions yarn > inventory/yarn.toml"
+      - name: Update Changelog
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update Node.js Yarn Inventory"
+          commit-message: "Update Inventory for heroku/nodejs-yarn\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          branch: update-yarn-inventory
+          labels: "automation"
+          body: "Automated pull-request to update heroku/nodejs-yarn inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"


### PR DESCRIPTION
This adds automatic inventory updates automation via GitHub actions. This is nearly identical to what we have in https://github.com/heroku/buildpacks-nodejs/blob/main/.github/workflows/inventory.yml, except that the binaries must be installed from git, and the paths to the inventories and changelogs are different. This automation will check for new node and yarn binaries that exist in our mirror, add them to the inventory, and open a pull request if there are any changes.

Example PRs as a result of this automation: https://github.com/heroku/heroku-buildpack-nodejs/pull/1073, https://github.com/heroku/heroku-buildpack-nodejs/pull/1072

[W-10657880](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000m3GcWYAU)