### PR TITLE
Fix yarn inventory automation changelog step

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Rebuild Inventory
         run: "list_versions yarn > inventory/yarn.toml"
       - name: Update Changelog
-        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/\[Unreleased\]\s+/[Unreleased]\n\n- {}/' CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/## main\s+/## main\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4.2.4
         with:


### PR DESCRIPTION
As noted in https://github.com/heroku/heroku-buildpack-nodejs/pull/1076#issuecomment-1486798132, the yarn inventory updates weren't making it into the changelog. The changelog step edit in #1074 only applied to the node.js job, not the yarn one.