### PR TITLE
Drop all references and special casing for heroku-18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       image: heroku/heroku:${{ matrix.stack_number }}-build
     strategy:
       matrix:
-        stack_number: ["18", "20", "22"]
+        stack_number: ["20", "22"]
     env:
       STACK: heroku-${{ matrix.stack_number }}
     steps:
@@ -31,7 +31,7 @@ jobs:
       image: heroku/heroku:${{ matrix.stack_number }}-build
     strategy:
       matrix:
-        stack_number: ["18", "20", "22"]
+        stack_number: ["20", "22"]
     env:
       STACK: heroku-${{ matrix.stack_number }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Drop all support and references to the now end-of-life heroku-18.
+
 ## v211 (2023-04-20)
 
 - Add metrics and tests for Node.js 20.x line

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ make test
 Or to just test a specific stack:
 
 ```
-make heroku-18-build
 make heroku-20-build
 make heroku-22-build
 ```

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -72,14 +72,7 @@ install_nodejs() {
   local code resolve_result
 
   if [[ -z "$version" ]]; then
-    # Node.js 18+ is incompatible with ubuntu:18 (and thus heroku-18) because of a libc mismatch:
-    # node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
-    # Fallback to a 16.x default for heroku-18 until heroku-18 or Node.js 16.x are EOL.
-    if [[ "$STACK" == "heroku-18" ]]; then
-      version="16.x"
-    else
       version="18.x"
-    fi
   fi
 
   if [[ -n "$NODE_BINARY_URL" ]]; then

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ build-resolver-linux: .build
 	cargo install heroku-nodejs-utils --root .build --bin resolve_version --git https://github.com/heroku/buildpacks-nodejs --target x86_64-unknown-linux-musl --profile release
 	mv .build/bin/resolve_version lib/vendor/resolve-version-linux
 
-test: heroku-22-build heroku-20-build heroku-18-build
+test: heroku-22-build heroku-20-build
 
 test-binary:
 	go test -v ./cmd/... -tags=integration
@@ -29,11 +29,6 @@ heroku-22-build:
 heroku-20-build:
 	@echo "Running tests in docker (heroku-20-build)..."
 	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-20" heroku/heroku:20-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
-	@echo ""
-
-heroku-18-build:
-	@echo "Running tests in docker (heroku-18-build)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-18" heroku/heroku:18-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
 	@echo ""
 
 hatchet:

--- a/spec/ci/node_18_spec.rb
+++ b/spec/ci/node_18_spec.rb
@@ -12,16 +12,4 @@ describe "Hello World for Node v18.x" do
       end
     end
   end
-
-  context "on an incompatible stack (heroku-18)" do
-    it "should log a stack compatibility message" do
-      Hatchet::Runner.new(
-        "spec/fixtures/repos/node-18",
-        stack: "heroku-18",
-        allow_failure: true
-      ).deploy do |app|
-        expect(app.output).to match("Node.js version is not compatible with the current stack")
-      end
-    end
-  end
 end

--- a/spec/ci/node_19_spec.rb
+++ b/spec/ci/node_19_spec.rb
@@ -12,16 +12,4 @@ describe "Hello World for Node v19.x" do
       end
     end
   end
-
-  context "on an incompatible stack (heroku-18)" do
-    it "should log a stack compatibility message" do
-      Hatchet::Runner.new(
-        "spec/fixtures/repos/node-19",
-        stack: "heroku-18",
-        allow_failure: true
-      ).deploy do |app|
-        expect(app.output).to match("Node.js version is not compatible with the current stack")
-      end
-    end
-  end
 end

--- a/spec/ci/node_20_spec.rb
+++ b/spec/ci/node_20_spec.rb
@@ -12,16 +12,4 @@ describe "Hello World for Node v20.x" do
       end
     end
   end
-
-  context "on an incompatible stack (heroku-18)" do
-    it "should log a stack compatibility message" do
-      Hatchet::Runner.new(
-        "spec/fixtures/repos/node-20",
-        stack: "heroku-18",
-        allow_failure: true
-      ).deploy do |app|
-        expect(app.output).to match("Node.js version is not compatible with the current stack")
-      end
-    end
-  end
 end

--- a/test/run
+++ b/test/run
@@ -180,9 +180,6 @@ testYarnRun() {
 
 testNoVersion() {
   local default_version="18"
-  if [[ $STACK == "heroku-18" ]]; then
-    default_version="16"
-  fi
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
   assertCaptured "Resolving node version ${default_version}.x"


### PR DESCRIPTION
As documented [here](https://help.heroku.com/X5OE6BCA/heroku-18-end-of-life-faq), heroku-18 is no longer supported for builds on heroku. This PR drops all references and special casing for the now end-of-life stack.

Several of our integration tests were failing, since they relied on heroku-18 builds, which are no longer available. This should put the CI pipeline back in working order.