### PR TITLE
Prepare v212 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+## v212 (2023-05-09)
+
 - Added node version 20.1.0.
 - Added yarn version 4.0.0-rc.43, 3.5.1.
 - Drop all support and references to the now end-of-life heroku-18.


### PR DESCRIPTION
Prepares v212 for release, which will include:

- node version 20.1.0.
- yarn versions 4.0.0-rc.43, 3.5.1.
- Drop all support and references to the `heroku-18` stack.