### PR TITLE
Prepare v213 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+## v213 (2023-05-24)
+
 - Added node version 20.2.0.
 - Added yarn version 4.0.0-rc.44.
 


### PR DESCRIPTION
This releases new Node.js and Yarn versions under the v213 tag.