### PR TITLE
Use new binary name from heroku/buildpacks-nodejs

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Rebuild Inventory
         run: "generate_inventory node > inventory/node.toml"
       - name: Update Changelog
-        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/## main\s+/## main\n\n- {}/' CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/## main\s+/## main\n\n{}/' CHANGELOG.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5.0.1
         with:
@@ -51,7 +51,7 @@ jobs:
       - name: Rebuild Inventory
         run: "generate_inventory yarn > inventory/yarn.toml"
       - name: Update Changelog
-        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/## main\s+/## main\n\n- {}/' CHANGELOG.md
+        run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/## main\s+/## main\n\n{}/' CHANGELOG.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5.0.1
         with:

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           toolchain: stable
       - name: Install Rust Inventory Binaries
-        run: cargo install heroku-nodejs-utils --bin diff_versions --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
+        run: cargo install heroku-nodejs-utils --bin diff_versions --bin generate_inventory --git https://github.com/heroku/buildpacks-nodejs
       - id: set-diff-msg
         name: Set Diff Message
         run: echo "::set-output name=msg::$(diff_versions node inventory/node.toml)"
       - name: Rebuild Inventory
-        run: "list_versions node > inventory/node.toml"
+        run: "generate_inventory node > inventory/node.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/## main\s+/## main\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request
@@ -44,12 +44,12 @@ jobs:
         with:
           toolchain: stable
       - name: Install Rust Inventory Binaries
-        run: cargo install heroku-nodejs-utils --bin diff_versions --bin list_versions --git https://github.com/heroku/buildpacks-nodejs
+        run: cargo install heroku-nodejs-utils --bin diff_versions --bin generate_inventory --git https://github.com/heroku/buildpacks-nodejs
       - id: set-diff-msg
         name: Set Diff Message
         run: echo "::set-output name=msg::$(diff_versions yarn inventory/yarn.toml)"
       - name: Rebuild Inventory
-        run: "list_versions yarn > inventory/yarn.toml"
+        run: "generate_inventory yarn > inventory/yarn.toml"
       - name: Update Changelog
         run: echo "${{ steps.set-diff-msg.outputs.msg }}" | xargs -r -I '{}' perl -i -p -e 's/## main\s+/## main\n\n- {}/' CHANGELOG.md
       - name: Create Pull Request


### PR DESCRIPTION
Inventory automation has been failing ([example](https://github.com/heroku/heroku-buildpack-nodejs/actions/runs/5262905080)), because `list_versions` is now `generate_inventory` as of https://github.com/heroku/buildpacks-nodejs/pull/524.