### PR TITLE
Use the web_url to ensure we use the new domain names

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ end
 def successful_body(app, options = {})
   retry_limit = options[:retry_limit] || 100
   path = options[:path] ? "/#{options[:path]}" : ''
-  web_url = app.send(:platform_api).app.info(app.name).fetch("web_url")
+  web_url = app.platform_api.app.info(app.name).fetch("web_url")
   Excon.get("#{web_url}#{path}",
               idempotent:     true,
               expects:        200,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,8 @@ end
 def successful_body(app, options = {})
   retry_limit = options[:retry_limit] || 100
   path = options[:path] ? "/#{options[:path]}" : ''
-  Excon.get("#{app.web_url}#{path}",
+  web_url = app.send(:platform_api).app.info(app.name).fetch("web_url")
+  Excon.get("#{web_url}#{path}",
               idempotent:     true,
               expects:        200,
               retry_interval: 0.5,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ end
 def successful_body(app, options = {})
   retry_limit = options[:retry_limit] || 100
   path = options[:path] ? "/#{options[:path]}" : ''
-  Excon.get("http://#{app.name}.herokuapp.com#{path}",
+  Excon.get("#{app.web_url}#{path}",
               idempotent:     true,
               expects:        200,
               retry_interval: 0.5,


### PR DESCRIPTION
CI has been failing (example: https://github.com/heroku/heroku-buildpack-nodejs/actions/runs/5314918171/jobs/9638438314) due to the hatchet tests assuming an app's `web_url` to be `#{app_name}.herokuapp.com`. That's not always the case anymore. See the Heroku changelog entry that describes the new naming scheme: https://devcenter.heroku.com/changelog-items/2640.