### PR TITLE
Drop the plugin check; it's no longer working

### DIFF
--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -3,19 +3,6 @@
 set -e
 
 BP_NAME=${1:-"heroku/nodejs"}
-
-# if buildpack-registry CLI plugin is not installed, show a help message and exit
-if ! heroku plugins | grep -q "buildpack-registry"; then
-  echo "Releasing the buildpack requires the buildpack-registry CLI plugin."
-  echo "https://github.com/heroku/languages-team/blob/main/languages/nodejs/buildpack.md"
-  echo ""
-  echo "heroku plugins:install buildpack-registry"
-  echo ""
-  echo "Current CLI plugins:"
-  heroku plugins
-  exit 1
-fi
-
 curVersion=$(heroku buildpacks:versions "$BP_NAME" | awk 'FNR == 3 { print $1 }')
 newVersion="v$((curVersion + 1))"
 


### PR DESCRIPTION
`etc/publish.sh` does a check to make sure the `buildpack-registry` plugin is installed. However, `heroku plugins` hasn't been reliably listing `buildpack-registry` as a plugin, even when the commands from the `buildpack-registry` plugin are present and available, so this bit of code has been blocking releases. 