### PR TITLE
Prepare v216 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+## v216 (2023-07-07)
+
 - Added Node.js version 20.4.0.
 - Added Yarn version 3.6.1.
 


### PR DESCRIPTION
This prepares v216, which will include new Node.js and Yarn versions.