### PR TITLE
Improve error messaging when installing an incompatible npm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Improved error messaging when installing an incompatible npm version.
+
 ## v219 (2023-08-10)
 
 - Added Node.js version 16.20.2.

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -123,8 +123,10 @@ install_npm() {
     echo "npm $npm_version already installed with node"
   else
     echo "Bootstrapping npm $version (replacing $npm_version)..."
-    if ! npm install --unsafe-perm --quiet -g "npm@$version" 2>@1>/dev/null; then
-      echo "Unable to install npm $version; does it exist?" && false
+    if ! npm install --unsafe-perm --quiet --no-audit --no-progress -g "npm@$version" >/dev/null; then
+      echo "Unable to install npm $version. " \
+        "Does npm $version exist? " \
+        "Is npm $version compatible with this Node.js version?" && false
     fi
     # Verify npm works before capturing and ensure its stderr is inspectable later
     npm --version 2>&1 1>/dev/null

--- a/test/fixtures/npm-version-incompat/README.md
+++ b/test/fixtures/npm-version-incompat/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/npm-version-incompat/package.json
+++ b/test/fixtures/npm-version-incompat/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-buildpack-test-app",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "16.x",
+    "npm": "10.x"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -840,6 +840,13 @@ testNpmVersionSpecific() {
   assertCapturedSuccess
 }
 
+testNpmVersionIncompatible() {
+  compile "npm-version-incompat"
+  assertCaptured "Unable to install npm 10.x"
+  assertCaptured "Is npm 10.x compatible with this Node.js version?"
+  assertCapturedError
+}
+
 testFailingBuild() {
   compile "failing-build"
   assertCaptured "Build failed"

--- a/test/run
+++ b/test/run
@@ -1146,7 +1146,7 @@ testNodeEnvNpmConfigProductionFalse() {
   assertCaptured "preinstall: production"
   assertCaptured "postinstall: production"
   assertCaptured "heroku-postbuild: production"
-  assertCapturedSuccess
+  assertEquals "Expected successful exit code" "0" "${RETURN}"
 }
 
 # Avoid this issue


### PR DESCRIPTION
When installing `npm@10` with `node@16`, users are seeing error messages like this: `Unable to install npm >=9; does it exist?`.

The issue here is that `npm@10` has minimum requirements for the Node.js version it works with: https://github.com/npm/cli/blob/3f9aa452061cde22de1babb33fd9bed8f2b6e3a5/package.json#L257

The `npm` command emits an error message explaining the issue that looks like this:

```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@10.0.0
npm ERR! notsup Not compatible with your version of node/npm: npm@10.0.0
npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
npm ERR! notsup Actual:   {"npm":"8.5.0","node":"v16.14.0"}
```

However, due to the use of shell redirection in the buildpack, the error message never makes it to the user.

This PR drops the stderr redirection so that the underlying error message does appear. In order prevent other needless output on stderr, `--no-progress` and `--no-audit` have been added to the install command.

I've also added another hint to the final error message about compatibility.

Related: 
[KB article explaining the situation and a solution](https://kb.heroku.com/Q7LKFE5P/unable-to-install-npm-does-it-exist)
[GUS Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001a3kaYYAQ/view)

