### PR TITLE
Prepare release v220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## main
 
+## v220 (2023-09-13)
+
 - Added Node.js version 20.6.0.
+- Added Node.js version 20.6.1.
+
 ## v219 (2023-08-10)
 
 - Added Node.js version 16.20.2.


### PR DESCRIPTION
This will bring in new Node.js versions `20.6.0` and `20.6.1`.