### PR TITLE
fix: do not ignore errors when checking npm/yarn output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Report errors when checking `npm` and `yarn` output ([#1147](https://github.com/heroku/heroku-buildpack-nodejs/pull/1147))
+
 ## v223 (2023-10-04)
 
 - Added Node.js version 20.8.0.


### PR DESCRIPTION
Dropping stderr/stdout on the floor results in mysterious buildpack failures in certain cases. For instance, if there is a `.yarnrc.yml` that requires an environment variable, `yarn --version` will output an error, but then the existing code would just silence that, causing users to think that the yarn install failed with no real recourse.