### PR TITLE
Fix author/committer for inventory update PRs

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -37,8 +37,9 @@ jobs:
           title: "Update Node.js Engine Inventory"
           commit-message: "Update Inventory for heroku/nodejs engine\n\n${{ steps.set-diff-msg.outputs.msg }}"
           branch: update-nodejs-inventory
-          labels: "automation"
           body: "Automated pull-request to update heroku/nodejs engine inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"
@@ -78,8 +79,9 @@ jobs:
           title: "Update Node.js Yarn Inventory"
           commit-message: "Update Inventory for heroku/nodejs yarn\n\n${{ steps.set-diff-msg.outputs.msg }}"
           branch: update-yarn-inventory
-          labels: "automation"
           body: "Automated pull-request to update heroku/nodejs yarn inventory:\n\n${{ steps.set-diff-msg.outputs.msg }}"
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
       - name: Configure PR
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"


### PR DESCRIPTION
Currently the inventory update PRs don't use the bot user for the commit author, but instead the Josh's user, eg:
https://github.com/heroku/heroku-buildpack-nodejs/pull/1150/commits/9bd0ec175def5bbd4f88e155345eb4cea0f13be5

Now the author is set to our bot user, the same way we do in other repos, eg:
https://github.com/heroku/languages-github-actions/blob/5dde4b7d832209dc8d6862d083a41a18d72c7c32/.github/workflows/_buildpacks-prepare-release.yml#L104-L106

In addition, the `automation` label is no longer set, for the same reasons as:
https://github.com/heroku/languages-github-actions/pull/109

GUS-W-14283836.