### PR TITLE
Group minor/patch version Ruby Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - "dependencies"
+      - "ruby"
+      - "skip changelog"
+    groups:
+      ruby-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github actions"
+      - "skip changelog"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -2,7 +2,7 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, reopened, edited, labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -10,15 +10,10 @@ permissions:
 jobs:
   check-changelog:
     runs-on: ubuntu-latest
-    if: |
-      !contains(github.event.pull_request.body, '[skip changelog]') &&
-      !contains(github.event.pull_request.body, '[changelog skip]') &&
-      !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
-      !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-      !contains(github.event.pull_request.labels.*.name, 'automation')
+    if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Check that CHANGELOG is touched
         run: |
           git fetch origin ${{ github.base_ref }} --depth 1 && \


### PR DESCRIPTION
Ruby minor/patch dependencies will now be grouped, using the new Dependabot grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

This hasn't been enabled for the GitHub Actions dependencies, since they all use major pinning (since we only use the official actions like `actions/checkout`).

In addition, the check changelog skipping strategy has been updated to use the `skip changelog` label for (a) explicitness, (b) to allow removing the label in situations where we realise a changelog entry is required, (c) for consistency with other repos.

Lastly, the redundant `gomod` entry in the Dependabot config has been removed (a leftover from #1061).

GUS-W-14303554.