### PR TITLE
Drop yarn 4 from inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## main
 
-- Added Yarn version 4.0.0.
 ## v226 (2023-10-19)
 
 - Added Node.js version 21.0.0.

--- a/inventory/yarn.toml
+++ b/inventory/yarn.toml
@@ -960,9 +960,3 @@ channel = "release"
 url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0-rc.53.tar.gz"
 etag = "c0d6abdde92df88fc17e0bf8ef57b9a3"
 
-[[releases]]
-version = "4.0.0"
-channel = "release"
-url = "https://heroku-nodebin.s3.us-east-1.amazonaws.com/yarn/release/yarn-v4.0.0.tar.gz"
-etag = "4b6a1f8a77263f5abf02843147aed885"
-


### PR DESCRIPTION
This reverts commit 87820636e63fbd5c78389e1531516d71ff927b63 (#1163).

Yarn 4 builds aren't working, as shown in the CI failures here: https://github.com/heroku/heroku-buildpack-nodejs/pull/1164. This will remove yarn 4 from the inventory, which should prevent those builds. We can bring yarn 4 back in once builds are working again.