### PR TITLE
Prepare release v227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+## v227 (2023-10-26)
+
 - Added Yarn version 4.0.0.
 - Added Node.js version 21.1.0.
 - Added Node.js version 20.9.0.


### PR DESCRIPTION
This will release new Node.js and Yarn versions.

- Added Yarn version 4.0.0.
- Added Node.js version 21.1.0.
- Added Node.js version 20.9.0.