### PR TITLE
Update default Node version to 20.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+## v227 (2023-10-26)
+
 - Added Yarn version 4.0.0.
 - Added Node.js version 21.1.0.
 - Added Node.js version 20.9.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- Update default node version to 20.x
+
 ## v227 (2023-10-26)
 
 - Added Yarn version 4.0.0.

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -72,7 +72,7 @@ install_nodejs() {
   local code resolve_result
 
   if [[ -z "$version" ]]; then
-      version="18.x"
+      version="20.x"
   fi
 
   if [[ -n "$NODE_BINARY_URL" ]]; then

--- a/test/run
+++ b/test/run
@@ -179,7 +179,7 @@ testYarnRun() {
 }
 
 testNoVersion() {
-  local default_version="18"
+  local default_version="20"
   compile "no-version"
   assertCaptured "engines.node (package.json):  unspecified"
   assertCaptured "Resolving node version ${default_version}.x"


### PR DESCRIPTION
As of [2023-10-24](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-10-24-version-2090-iron-lts-richardlau), Node.js 20.x is now the LTS version.

[W-14390734](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001dS1fkYAC/view)