### PR TITLE
Prepare release v234

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## main
 
+## v234 (2024-01-12)
+
 - Added Node.js version 20.11.0.
+
 ## v233 (2024-01-02)
 
 - Added Node.js version 21.5.0.


### PR DESCRIPTION
This will release Node.js 20.11.0 under the v234 tag.