### PR TITLE
Update inventory related entries in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@ buildpack.toml @joshwlewis @colincasey
 CHANGELOG.md @joshwlewis @colincasey
 Cargo.toml @joshwlewis @colincasey
 Cargo.lock @joshwlewis @colincasey
-inventory.toml @joshwlewis @colincasey
+inventory/ @joshwlewis @colincasey


### PR DESCRIPTION
Corrects the inventory-file related `CODEOWNERS` entry to match the actual naming of the files in this repo:
- `inventory/node.toml`
- `inventory/yarn.toml`

(Only the CNB uses `inventory.toml`)

GUS-W-14941625.