### PR TITLE
Fix classic vs CNB specific entries in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,6 @@
 
 # However, request review from the language owners instead for files that are updated
 # by Dependabot or inventory/release automation, to reduce team review request noise.
-buildpack.toml @joshwlewis @colincasey
 CHANGELOG.md @joshwlewis @colincasey
-Cargo.toml @joshwlewis @colincasey
-Cargo.lock @joshwlewis @colincasey
+Gemfile.lock @joshwlewis @colincasey
 inventory/ @joshwlewis @colincasey


### PR DESCRIPTION
The entries added in #1205 were accidentally the CNB version of the file (that had `Cargo.lock` etc), not the classic buildpack version of the file that has `Gemfile.lock`.

This corrects #1214 requesting review from the team rather than the language owners.