### PR TITLE
Add pnpm caching

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -197,7 +197,8 @@ fi
 ### Configure package manager cache directories
 [ ! "$YARN_CACHE_FOLDER" ] && YARN_CACHE_FOLDER=$(mktemp -d -t yarncache.XXXXX)
 [ ! "$NPM_CONFIG_CACHE" ] && NPM_CONFIG_CACHE=$(mktemp -d -t npmcache.XXXXX)
-export YARN_CACHE_FOLDER NPM_CONFIG_CACHE
+[ ! "$PNPM_CONFIG_CACHE" ] && PNPM_CONFIG_CACHE=$(mktemp -d -t pnpmcache.XXXXX)
+export YARN_CACHE_FOLDER NPM_CONFIG_CACHE PNPM_CONFIG_CACHE
 
 install_bins() {
   local node_engine npm_engine yarn_engine node_version package_manager
@@ -266,7 +267,7 @@ install_bins() {
       warn "Currently pnpm installation is only supported through the 'packageManager' field in package.json"
       fail
     fi
-    monitor "install-pnpm-using-corepack" install_pnpm_using_corepack_package_manager "$package_manager" "$node_version"
+    monitor "install-pnpm-using-corepack" install_pnpm_using_corepack_package_manager "$package_manager" "$node_version" "$PNPM_CONFIG_CACHE"
   fi
 
   if $YARN; then
@@ -320,7 +321,7 @@ restore_cache() {
   elif [[ "$cache_status" == "valid" ]]; then
     header "Restoring cache"
     if [[ "$cache_directories" == "" ]]; then
-      restore_default_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$YARN_CACHE_FOLDER" "$NPM_CONFIG_CACHE"
+      restore_default_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$YARN_CACHE_FOLDER" "$NPM_CONFIG_CACHE" "$PNPM_CONFIG_CACHE"
     else
       restore_custom_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$cache_directories"
     fi
@@ -393,7 +394,7 @@ cache_build() {
     :
   elif [[ "$cache_directories" == "" ]]; then
     header "Caching build"
-    save_default_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$YARN_CACHE_FOLDER" "$NPM_CONFIG_CACHE"
+    save_default_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$YARN_CACHE_FOLDER" "$NPM_CONFIG_CACHE" "$PNPM_CONFIG_CACHE"
   else
     header "Caching build"
     save_custom_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$cache_directories"

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -145,9 +145,11 @@ install_yarn_using_corepack_package_manager() {
 install_pnpm_using_corepack_package_manager() {
   local package_manager="$1"
   local node_version="$2"
+  local pnpm_cache="$3"
   install_corepack_package_manager "$package_manager" "$node_version"
   suppress_output pnpm --version
   echo "Using pnpm $(pnpm --version)"
+  pnpm config set store-dir "$pnpm_cache" 2>&1
 }
 
 install_corepack_package_manager() {

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -49,6 +49,7 @@ restore_default_cache_directories() {
   local cache_dir=${2:-}
   local yarn_cache_dir=${3:-}
   local npm_cache=${4:-}
+  local pnpm_cache_dir=${5:-}
 
   if [[ "$YARN" == "true" ]]; then
     if has_yarn_cache "$build_dir"; then
@@ -66,6 +67,15 @@ restore_default_cache_directories() {
       echo "- yarn cache"
     else
       echo "- yarn cache (not cached - skipping)"
+    fi
+  elif [[ "$PNPM" == "true" ]]; then
+    if [[ -d "$cache_dir/node/cache/pnpm" ]]; then
+      rm -rf "$pnpm_cache_dir"
+      mv "$cache_dir/node/cache/pnpm" "$pnpm_cache_dir"
+      echo "- pnpm cache"
+      meta_set "pnpm_cache" "true"
+    else
+      echo "- pnpm cache (not cached - skipping)"
     fi
   elif [[ "$USE_NPM_INSTALL" == "false" ]]; then
     if [[ -d "$cache_dir/node/cache/npm" ]]; then
@@ -131,6 +141,7 @@ save_default_cache_directories() {
   local cache_dir=${2:-}
   local yarn_cache_dir=${3:-}
   local npm_cache=${4:-}
+  local pnpm_cache_dir=${5:-}
 
   if [[ "$YARN" == "true" ]]; then
     if [[ -d "$yarn_cache_dir" ]]; then
@@ -140,6 +151,11 @@ save_default_cache_directories() {
         mv "$yarn_cache_dir" "$cache_dir/node/cache/yarn"
       fi
       echo "- yarn cache"
+    fi
+  elif [[ "$PNPM" == "true" ]]; then
+    if [[ -d "$pnpm_cache_dir" ]]; then
+      mv "$pnpm_cache_dir" "$cache_dir/node/cache/pnpm"
+      echo "- pnpm cache"
     fi
   elif [[ "$USE_NPM_INSTALL" == "false" ]]; then
     if [[ -d "$npm_cache" ]]; then

--- a/test/run
+++ b/test/run
@@ -1846,6 +1846,32 @@ testPnpmStorePruning() {
   assertEquals "Expected pnpm prune store counter to be $(( default_counter_value - 1 )); was <${counter}>" "$(( default_counter_value - 1 ))" "${counter}"
 }
 
+testPnpmCacheSimple() {
+  cache_dir=$(mktmpdir)
+  compile "pnpm-7-pnp" "$cache_dir"
+  assertNotCaptured "Restoring cache"
+  assertCaptured "- pnpm cache"
+  assertCapturedSuccess
+
+  compile "pnpm-7-pnp" "$cache_dir"
+  assertCaptured "Restoring cache"
+  assertCaptured "- pnpm cache"
+  assertCapturedSuccess
+}
+
+testPnpmCacheComplex() {
+  cache_dir=$(mktmpdir)
+  compile "pnpm-8-nuxt" "$cache_dir"
+  assertNotCaptured "Restoring cache"
+  assertCaptured "- pnpm cache"
+  assertCapturedSuccess
+
+  compile "pnpm-8-nuxt" "$cache_dir"
+  assertCaptured "Restoring cache"
+  assertCaptured "- pnpm cache"
+  assertCapturedSuccess
+}
+
 # Utils
 
 pushd "$(dirname 0)" >/dev/null


### PR DESCRIPTION
These changes build on top of [existing pnpm support](https://github.com/heroku/heroku-buildpack-nodejs/pull/1224) to allow `pnpm` dependencies to be saved and restored between builds.