### PR TITLE
pnpm support - periodic store pruning

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -360,7 +360,7 @@ build_dependencies() {
   elif $YARN; then
     yarn_node_modules "$BUILD_DIR"
   elif $PNPM; then
-    pnpm_install "$BUILD_DIR"
+    pnpm_install "$BUILD_DIR" "$CACHE_DIR"
   elif $PREBUILD; then
     echo "Prebuild detected (node_modules already exists)"
     npm_rebuild "$BUILD_DIR"

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -194,3 +194,37 @@ save_custom_cache_directories() {
 
   meta_set "node-custom-cache-dirs" "true"
 }
+
+DEFAULT_PNPM_PRUNE_COUNTER_VALUE="40"
+
+load_pnpm_prune_store_counter() {
+  local cache_dir=${1:-}
+
+  if [ -f "$cache_dir/pnpm_prune_store_counter" ]; then
+    counter=$(<"$cache_dir/pnpm_prune_store_counter")
+    if ! is_int "$counter" || (( counter < 0 )); then
+      counter="$DEFAULT_PNPM_PRUNE_COUNTER_VALUE"
+    fi
+  else
+    counter="$DEFAULT_PNPM_PRUNE_COUNTER_VALUE"
+  fi
+
+  echo "$counter"
+}
+
+save_pnpm_prune_store_counter() {
+  local cache_dir=${1:-}
+  local new_value=${2:-}
+
+  if ! is_int "$new_value" || (( new_value < 0 )); then
+    new_value="$DEFAULT_PNPM_PRUNE_COUNTER_VALUE"
+  fi
+
+  echo "$new_value" > "$cache_dir/pnpm_prune_store_counter"
+}
+
+is_int() {
+  case ${1#[-+]} in
+    '' | *[!0-9]*) return 1;;
+  esac
+}

--- a/test/run
+++ b/test/run
@@ -1774,6 +1774,54 @@ testPnpm8Nuxt() {
   assertCapturedSuccess
 }
 
+testPnpmStorePruning() {
+  default_counter_value="40"
+  cache_dir=$(mktmpdir)
+
+  # initial state, no counter exists
+  compile "pnpm-7-pnp" "$cache_dir"
+  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+  assertNotCaptured "Cleaning up pnpm store"
+  assertCapturedSuccess
+  counter=$(<"$cache_dir/pnpm_prune_store_counter")
+  assertEquals "Expected pnpm prune store counter to be $(( default_counter_value - 1 )); was <${counter}>" "$(( default_counter_value - 1 ))" "${counter}"
+
+  # set the counter to right before it triggers the store to be pruned
+  echo "1" > "$cache_dir/pnpm_prune_store_counter"
+  compile "pnpm-7-pnp" "$cache_dir"
+  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+  assertNotCaptured "Cleaning up pnpm store"
+  assertCapturedSuccess
+  counter=$(<"$cache_dir/pnpm_prune_store_counter")
+  assertEquals "Expected pnpm prune store counter to be 0; was <${counter}>" "0" "${counter}"
+
+  # the store should be pruned on the next build and counter reset
+  compile "pnpm-7-pnp" "$cache_dir"
+  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+  assertCaptured "Cleaning up pnpm store"
+  assertCapturedSuccess
+  counter=$(<"$cache_dir/pnpm_prune_store_counter")
+  assertEquals "Expected pnpm prune store counter to be $default_counter_value; was <${counter}>" "$default_counter_value" "${counter}"
+
+  # ensure the cache can't get into a bad state (negative counter) and it resets to the initial state
+  echo "-1" > "$cache_dir/pnpm_prune_store_counter"
+  compile "pnpm-7-pnp" "$cache_dir"
+  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+  assertNotCaptured "Cleaning up pnpm store"
+  assertCapturedSuccess
+  counter=$(<"$cache_dir/pnpm_prune_store_counter")
+  assertEquals "Expected pnpm prune store counter to be $(( default_counter_value - 1 )); was <${counter}>" "$(( default_counter_value - 1 ))" "${counter}"
+
+  # ensure the cache can't get into a bad state (non-integer counter) and it resets to the initial state
+  echo "" > "$cache_dir/pnpm_prune_store_counter"
+  compile "pnpm-7-pnp" "$cache_dir"
+  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+  assertNotCaptured "Cleaning up pnpm store"
+  assertCapturedSuccess
+  counter=$(<"$cache_dir/pnpm_prune_store_counter")
+  assertEquals "Expected pnpm prune store counter to be $(( default_counter_value - 1 )); was <${counter}>" "$(( default_counter_value - 1 ))" "${counter}"
+}
+
 # Utils
 
 pushd "$(dirname 0)" >/dev/null


### PR DESCRIPTION
These changes build on top of https://github.com/heroku/heroku-buildpack-nodejs/pull/1224.  A `counter` is introduced which is decremented on every build. When the `counter=0` then `pnpm store prune` will be executed and the `counter` will be reset.