### PR TITLE
Skip dev dependency pruning on tests with PNPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Skip pnpm pruning if `NODE_ENV` is not set to `production` or if `PNPM_SKIP_PRUNING` is set to `true` ([#1259](https://github.com/heroku/heroku-buildpack-nodejs/pull/1259))
 
 ## [v248] - 2024-05-10
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -340,6 +340,16 @@ pnpm_prune_devdependencies() {
 
   cd "$build_dir" || return
 
+    if [ "$NODE_ENV" == "test" ]; then
+    echo "Skipping because NODE_ENV is 'test'"
+    meta_set "skipped-prune" "true"
+    return 0
+  elif [ "$NODE_ENV" != "production" ]; then
+    echo "Skipping because NODE_ENV is not 'production'"
+    meta_set "skipped-prune" "true"
+    return 0
+  fi
+
   pnpm_version=$(pnpm --version)
   pnpm_major_version=$(echo "$pnpm_version" | cut -d "." -f 1)
   pnpm_minor_version=$(echo "$pnpm_version" | cut -d "." -f 2)

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -340,12 +340,16 @@ pnpm_prune_devdependencies() {
 
   cd "$build_dir" || return
 
-    if [ "$NODE_ENV" == "test" ]; then
+  if [ "$NODE_ENV" == "test" ]; then
     echo "Skipping because NODE_ENV is 'test'"
     meta_set "skipped-prune" "true"
     return 0
   elif [ "$NODE_ENV" != "production" ]; then
     echo "Skipping because NODE_ENV is not 'production'"
+    meta_set "skipped-prune" "true"
+    return 0
+  elif [ "$PNPM_SKIP_PRUNING" == "true" ]; then
+    echo "Skipping because PNPM_SKIP_PRUNING is '$PNPM_SKIP_PRUNING'"
     meta_set "skipped-prune" "true"
     return 0
   fi

--- a/test/run
+++ b/test/run
@@ -1952,6 +1952,43 @@ testPnpmSafePruningSupport() {
   assertCapturedSuccess
 }
 
+testPnpmSkipPruning() {
+  cache_dir=$(mktmpdir)
+
+  # skip pruning in test environment
+  env_dir=$(mktmpdir)
+  echo "test" > "$env_dir/NODE_ENV"
+  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
+  assertCaptured "Pruning devDependencies"
+  assertCaptured "Skipping because NODE_ENV is 'test'"
+  assertCapturedSuccess
+
+  # skip pruning in non-production environment
+  env_dir=$(mktmpdir)
+  echo "development" > "$env_dir/NODE_ENV"
+  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
+  assertCaptured "Pruning devDependencies"
+  assertCaptured "Skipping because NODE_ENV is not 'production'"
+  assertCapturedSuccess
+
+  # skip pruning if explicitly configured to do so
+  env_dir=$(mktmpdir)
+  echo "true" > "$env_dir/PNPM_SKIP_PRUNING"
+  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
+  assertCaptured "Pruning devDependencies"
+  assertCaptured "Skipping because PNPM_SKIP_PRUNING is 'true'"
+  assertCapturedSuccess
+
+  # otherwise, prune away
+  env_dir=$(mktmpdir)
+  echo "production" > "$env_dir/NODE_ENV"
+  echo "false" > "$env_dir/PNPM_SKIP_PRUNING"
+  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
+  assertCaptured "Pruning devDependencies"
+  assertCaptured "- dotenv 16.4.5"
+  assertCapturedSuccess
+}
+
 # Utils
 
 pushd "$(dirname 0)" >/dev/null


### PR DESCRIPTION
Matches functionality already present for Yarn and NPM. Didn't include an additional flag to skip
pruning in contexts where it's needed at runtime,
as it's not necessary for my specific use-case and I wasn't sure of naming conventions here.

Unfortunately it's impossible for me to run unit tests on this at the moment. Several tests are failing locally, but those same tests also fail under the main branch, so I have to assume it's related to my dev environment (docker on an arm64 mac). Ideally, running on CI will give us useful information.

I can confirm that it works in our actual use-case.