### PR TITLE
Fix failing integration test

### DIFF
--- a/test/run
+++ b/test/run
@@ -1798,7 +1798,7 @@ testPnpm8Nuxt() {
   assertCaptured "> nuxt prepare"
   assertCaptured "> pnpm-8-nuxt@ build"
   assertCaptured "> nuxt build"
-  assertCapturedSuccess
+  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
 }
 
 testPnpmEngine() {
@@ -1901,12 +1901,12 @@ testPnpmCacheComplex() {
   compile "pnpm-8-nuxt" "$cache_dir"
   assertNotCaptured "Restoring cache"
   assertCaptured "- pnpm cache"
-  assertCapturedSuccess
+  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
 
   compile "pnpm-8-nuxt" "$cache_dir"
   assertCaptured "Restoring cache"
   assertCaptured "- pnpm cache"
-  assertCapturedSuccess
+  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
 }
 
 testPnpmWithNoPackageManagerEntry() {


### PR DESCRIPTION
Explicitly checking the exit code instead of using `assertCapturedSuccess` since tests started failing because the following message is now emitted to `stderr` by the `browserlist` package:

```
WARN  Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```