### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,13 @@
 # Default to requesting pull request reviews from the Heroku Languages team.
 * @heroku/languages
 
-# However, request review from the language owners instead for files that are updated
+# However, request review from the language owner instead for files that are updated
 # by Dependabot or inventory/release automation, to reduce team review request noise.
-CHANGELOG.md @joshwlewis @colincasey
-Gemfile.lock @joshwlewis @colincasey
-inventory/ @joshwlewis @colincasey
+CHANGELOG.md @colincasey
+Gemfile.lock @colincasey
+inventory/ @colincasey
+npm-shrinkwrap.json @colincasey
+package.json @colincasey
+package-lock.json @colincasey
+pnpm-lock.yaml @colincasey
+yarn.lock @colincasey


### PR DESCRIPTION
Adds more files that are updated by Dependabot, to avoid team review being requested for PRs like:
https://github.com/heroku/heroku-buildpack-nodejs/pull/1277

Also updates the owners given Colin now being the Node.js language owner.