### PR TITLE
Export `NODE_OPTIONS` env default to downstream buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Export default `NODE_OPTIONS` settings to downstream buildpacks if environment variable is not already set. ([#1293](https://github.com/heroku/heroku-buildpack-nodejs/pull/1293)) 
 
 ## [v257] - 2024-07-09
 

--- a/bin/compile
+++ b/bin/compile
@@ -130,10 +130,10 @@ log_project_info "$BUILD_DIR"
 ### Compile
 
 create_env() {
-  write_profile "$BP_DIR" "$BUILD_DIR"
-  write_export "$BP_DIR" "$BUILD_DIR"
   export_env_dir "$ENV_DIR"
   create_default_env "$YARN"
+  write_profile "$BP_DIR" "$BUILD_DIR"
+  write_export "$BP_DIR" "$BUILD_DIR"
 }
 
 header "Creating runtime environment" | output "$LOG_FILE"

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -106,5 +106,9 @@ write_export() {
   if [ -w "$bp_dir" ]; then
     echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > "$bp_dir/export"
     echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> "$bp_dir/export"
+    # only export this if the user hasn't configured a NODE_OPTIONS env variable
+    if [[ -z $NODE_OPTIONS ]]; then
+      echo "export NODE_OPTIONS=\"--max_old_space_size=2560\"" >> "$bp_dir/export"
+    fi
   fi
 }

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -106,9 +106,7 @@ write_export() {
   if [ -w "$bp_dir" ]; then
     echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > "$bp_dir/export"
     echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> "$bp_dir/export"
-    # only export this if the user hasn't configured a NODE_OPTIONS env variable
-    if [[ -z $NODE_OPTIONS ]]; then
-      echo "export NODE_OPTIONS=\"--max_old_space_size=2560\"" >> "$bp_dir/export"
-    fi
+    # shellcheck disable=SC2016
+    echo 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' >> "$bp_dir/export"
   fi
 }

--- a/test/run
+++ b/test/run
@@ -1150,6 +1150,20 @@ testMultiExport() {
   assertFileContains "/node_modules/.bin" "${bp_dir}/export"
   assertFileContains "export NODE_HOME=" "${bp_dir}/export"
   assertFileContains "/.heroku/node\"" "${bp_dir}/export"
+  assertFileContains "export NODE_OPTIONS=\"--max_old_space_size=2560\"" "${bp_dir}/export"
+  assertCapturedSuccess
+
+  env_dir=$(mktmpdir)
+  echo "--optimize_for_size" > "$env_dir/NODE_OPTIONS"
+
+  compile "stable-node" "$(mktmpdir)" "$env_dir"
+  assertFileContains "export PATH=" "${bp_dir}/export"
+  assertFileContains "/.heroku/node/bin" "${bp_dir}/export"
+  assertFileContains "/.heroku/yarn/bin" "${bp_dir}/export"
+  assertFileContains "/node_modules/.bin" "${bp_dir}/export"
+  assertFileContains "export NODE_HOME=" "${bp_dir}/export"
+  assertFileContains "/.heroku/node\"" "${bp_dir}/export"
+  assertFileNotContains "export NODE_OPTIONS=\"--max_old_space_size=2560\"" "${bp_dir}/export"
   assertCapturedSuccess
 }
 

--- a/test/run
+++ b/test/run
@@ -1150,20 +1150,8 @@ testMultiExport() {
   assertFileContains "/node_modules/.bin" "${bp_dir}/export"
   assertFileContains "export NODE_HOME=" "${bp_dir}/export"
   assertFileContains "/.heroku/node\"" "${bp_dir}/export"
-  assertFileContains "export NODE_OPTIONS=\"--max_old_space_size=2560\"" "${bp_dir}/export"
-  assertCapturedSuccess
-
-  env_dir=$(mktmpdir)
-  echo "--optimize_for_size" > "$env_dir/NODE_OPTIONS"
-
-  compile "stable-node" "$(mktmpdir)" "$env_dir"
-  assertFileContains "export PATH=" "${bp_dir}/export"
-  assertFileContains "/.heroku/node/bin" "${bp_dir}/export"
-  assertFileContains "/.heroku/yarn/bin" "${bp_dir}/export"
-  assertFileContains "/node_modules/.bin" "${bp_dir}/export"
-  assertFileContains "export NODE_HOME=" "${bp_dir}/export"
-  assertFileContains "/.heroku/node\"" "${bp_dir}/export"
-  assertFileNotContains "export NODE_OPTIONS=\"--max_old_space_size=2560\"" "${bp_dir}/export"
+  # shellcheck disable=SC2016
+  assertFileContains 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' "${bp_dir}/export"
   assertCapturedSuccess
 }
 


### PR DESCRIPTION
If the user has not set a custom `NODE_OPTIONS` environment variable, we automatically set `NODE_OPTIONS="--max_old_space_size=2560"` in the build environment. This setting helps to mitigate OOM issues that sometimes occur when asset compilation tools are used. 

This setting is currently limited to the Node.js Buildpack's environment. To propagate this setting to downstream buildpacks such as the Ruby Buildpack (which sometimes requires Node to run asset compilation tasks too), this PR writes the setting to the `<buildpack_dir>/export` file. It will not export the setting if the user already has a custom `NODE_OPTIONS` environment variable.