### PR TITLE
Update CI to Ubuntu 24.04 runner images

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
 
   unit-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: heroku/heroku:${{ matrix.stack_number }}-build
       options: --user root
@@ -27,7 +27,7 @@ jobs:
         run: test/unit
 
   functional-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: heroku/heroku:${{ matrix.stack_number }}-build
       options: --user root
@@ -43,7 +43,7 @@ jobs:
         run: test/run
 
   hatchet-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
@@ -67,7 +67,7 @@ jobs:
         # (assumes the versions between have backwards-compatible APIs)
         version: [14.10.0, latest]
     name: Test Metrics (${{ matrix.version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   hatchet-app-cleaner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-nodejs-inventory:
     name: Update Node.js Engine Inventory
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
           
   update-yarn-inventory:
     name: Update Node.js Yarn Inventory
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Now that Ubuntu 24.04 images are available on GitHub Actions, we can update from the Ubuntu 22.04 images.

See also:
https://github.com/actions/runner-images/issues/9848
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZRd13d2ce2d455470495cbd34cf

GUS-W-16238120.