### PR TITLE
Support Heroku CI tests with pnpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add support for auto-detecting `pnpm test` during Heroku CI runs. ([#1308](https://github.com/heroku/heroku-buildpack-nodejs/pull/1308))
 
 ## [v262] - 2024-08-12
 
@@ -25,7 +26,7 @@
 
 ## [v258] - 2024-07-10
 
-- Export default `NODE_OPTIONS` settings to downstream buildpacks if environment variable is not already set. ([#1293](https://github.com/heroku/heroku-buildpack-nodejs/pull/1293)) 
+- Export default `NODE_OPTIONS` settings to downstream buildpacks if environment variable is not already set. ([#1293](https://github.com/heroku/heroku-buildpack-nodejs/pull/1293))
 
 ## [v257] - 2024-07-09
 

--- a/bin/test
+++ b/bin/test
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 BUILD_DIR=${1:-}
-if yarn --version > /dev/null 2>&1; then
+if pnpm --version > /dev/null 2>&1; then
+  cd "$BUILD_DIR" && pnpm test
+elif yarn --version > /dev/null 2>&1; then
   cd "$BUILD_DIR" && yarn test
 else
   cd "$BUILD_DIR" && npm test


### PR DESCRIPTION
Folks using `pnpm` and Heroku CI may be surprised with strange error messages like `This project is configured to use ${result.spec.name} because ${result.target} has a "packageManager" field`. This is because our `bin/test` script is trying to run `npm test` on an app managed with `pnpm`.

Resolves #1307.

/cc @julianduque 