### PR TITLE
Update default Node.js version to 22.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Update default Node.js version to 22.x
 - Added Node.js version 22.11.0.
 
 ## [v268] - 2024-10-25
@@ -23,7 +24,7 @@
 
 - Added Node.js version 22.9.0.
 - Added Yarn version 4.5.0.
-- Fixed application directory used for `COREPACK_HOME` in CI env ([#1320](https://github.com/heroku/heroku-buildpack-nodejs/pull/1320)) 
+- Fixed application directory used for `COREPACK_HOME` in CI env ([#1320](https://github.com/heroku/heroku-buildpack-nodejs/pull/1320))
 - Fail on conflicting package manager metadata in package.json. ([#1317](https://github.com/heroku/heroku-buildpack-nodejs/pull/1317))
 
 ## [v264] - 2024-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Update default Node.js version to 22.x
+- Update default Node.js version to 22.x ([#1341](https://github.com/heroku/heroku-buildpack-nodejs/pull/1341))
 - Added Node.js version 22.11.0.
 
 ## [v268] - 2024-10-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Update default Node.js version to 22.x ([#1341](https://github.com/heroku/heroku-buildpack-nodejs/pull/1341))
+- Updated default Node.js version to 22.x ([#1341](https://github.com/heroku/heroku-buildpack-nodejs/pull/1341))
 - Added Node.js version 22.11.0.
 
 ## [v268] - 2024-10-25

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -72,7 +72,7 @@ install_nodejs() {
   local code resolve_result
 
   if [[ -z "$version" ]]; then
-      version="20.x"
+      version="22.x"
   fi
 
   if [[ -n "$NODE_BINARY_URL" ]]; then
@@ -90,7 +90,7 @@ install_nodejs() {
 
     echo "Downloading and installing node $number..."
 
-    if [[ "$number" == "22.5.0" ]]; then 
+    if [[ "$number" == "22.5.0" ]]; then
       warn_about_node_version_22_5_0
     fi
   fi

--- a/test/run
+++ b/test/run
@@ -179,7 +179,7 @@ testYarnRun() {
 }
 
 testNoVersion() {
-  local default_version="20"
+  local default_version="22"
   compile "no-version"
   assertCaptured "engines.node (package.json):   unspecified"
   assertCaptured "Resolving node version ${default_version}.x"


### PR DESCRIPTION
Node.js 22.x is now the Active LTS release line as of 10-29-2024 ([source](https://github.com/nodejs/Release)). In accordance with our support policy, it should be the default version.

Fixes #1339 