### PR TITLE
Set yarn-2-with-node-modules node engine to 20.x

### DIFF
--- a/test/fixtures/yarn-2-with-node-modules/package.json
+++ b/test/fixtures/yarn-2-with-node-modules/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "engines": {
+    "node": "20.x"
+  },
   "dependencies": {
     "lodash": "^4.16.4",
     "typescript": "^3.9.3"


### PR DESCRIPTION
With the upcoming [default node version change](https://github.com/heroku/heroku-buildpack-nodejs/pull/1341), this particular test fixture causes a test failure ([due to this deprecation warning](https://nodejs.org/api/deprecations.html#DEP0047)).

Explicitly set the node engine version to `20.x` for now (to prepare the fixture for the upcoming upgrade).