### PR TITLE
Do not monitor processes that are no longer running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Do not monitor memory usage of processes that were killed.
 
 ## [v270] - 2024-11-13
 

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -18,7 +18,8 @@ monitor_memory_usage() {
   # set the peak memory usage to 0 to start
   peak="0"
 
-  while true; do
+  # sample memory while the process is running.
+  while test -d /proc/"$pid"; do
     sleep .1
 
     # check the memory usage


### PR DESCRIPTION
Some users are experiencing build timeouts when the monitor.sh continually tries to sample a process that has been killed.