### PR TITLE
Disable `io_uring` use in `libuv`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -64,6 +64,19 @@ export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 export COREPACK_HOME="$BUILD_DIR/.heroku/corepack"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
+# 2024-11-20:
+# We started getting reports on build timeouts on the platform that were unexpected
+# due to the specific versions on Node.js and npm which had been working fine up until
+# this date. After some extensive digging, we believe we narrowed down the cause to
+# a bug in io_uring that affects the Amazon Linux 2023 release. There is a pending fix
+# which will be released around Dec. 9th but, until then, the workaround is set disable
+# the use of io_uring in libuv.
+#
+# See https://github.com/npm/cli/issues/7814#issuecomment-2488626736
+# → https://github.com/amazonlinux/amazon-linux-2023/issues/840#issuecomment-2485782075
+# → https://lore.kernel.org/io-uring/3d913aef-8c44-4f50-9bdf-7d9051b08941@app.fastmail.com/T/#m57570b5f8f2fc00d5a17cfe18ffeeba9fc23a43d
+export UV_USE_IO_URING=${UV_USE_IO_URING:-0}
+
 LOG_FILE=$(mktemp -t node-build-log.XXXXX)
 echo "" > "$LOG_FILE"
 

--- a/test/fixtures/libuv_io_uring_fix/README.md
+++ b/test/fixtures/libuv_io_uring_fix/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/libuv_io_uring_fix/package.json
+++ b/test/fixtures/libuv_io_uring_fix/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "libuv-uring-fix",
+  "version": "0.0.1",
+  "description": "node buildpack integration test app",
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/example/example.git"
+  },
+  "engines": {
+    "node": "22.x"
+  },
+  "scripts": {
+    "build": "echo \"UV_USE_IO_URING is set to $UV_USE_IO_URING\""
+  }
+}

--- a/test/run
+++ b/test/run
@@ -2051,6 +2051,21 @@ testConflictingPackageManagerMetadata() {
   assertCapturedError
 }
 
+testDisableIoUringFix() {
+  compile "libuv_io_uring_fix"
+  assertCaptured "UV_USE_IO_URING is set to 0"
+  assertCapturedSuccess
+}
+
+testDisableIoUringFixUserOverride() {
+  cache_dir=$(mktmpdir)
+  env_dir=$(mktmpdir)
+  echo "1" > "$env_dir/UV_USE_IO_URING"
+  compile "libuv_io_uring_fix" "$cache_dir" "$env_dir"
+  assertCaptured "UV_USE_IO_URING is set to 1"
+  assertCapturedSuccess
+}
+
 # Utils
 
 pushd "$(dirname 0)" >/dev/null


### PR DESCRIPTION
We suspect that this bug in Amazon Linux 2023 is causing build timeouts on the platform:
https://github.com/amazonlinux/amazon-linux-2023/issues/840#issuecomment-2485782075

We were able to reproduce these build timeouts and, following the guidance to set `UV_USE_IO_URING=0` allowed our builds that were timing out to succeed. 