### PR TITLE
Also export `UV_USE_IO_URING` for later buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Export `UV_USE_IO_URING=0` for later buildpacks to prevent timeouts.
 
 ## [v271] - 2024-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-- Export `UV_USE_IO_URING=0` for later buildpacks to prevent timeouts.
+## [v272] - 2024-11-21
+
+- Export `UV_USE_IO_URING=0` for later buildpacks to prevent timeouts. ([#1351](https://github.com/heroku/heroku-buildpack-nodejs/pull/1351))
 
 ## [v271] - 2024-11-20
 
@@ -953,7 +955,8 @@ Accepts `cacheDirectories` array in package.json to override default `node_modul
 
 - Documented at https://devcenter.heroku.com/articles/nodejs-support#cache-behavior
 
-[unreleased]: https://github.com/heroku/heroku-buildpack-nodejs/compare/v271...main
+[unreleased]: https://github.com/heroku/heroku-buildpack-nodejs/compare/v272...main
+[v272]: https://github.com/heroku/heroku-buildpack-nodejs/compare/v271...v272
 [v271]: https://github.com/heroku/heroku-buildpack-nodejs/compare/v270...v271
 [v270]: https://github.com/heroku/heroku-buildpack-nodejs/compare/v269...v270
 [v269]: https://github.com/heroku/heroku-buildpack-nodejs/compare/v268...v269

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -104,12 +104,20 @@ write_export() {
   # this may occur in situations outside of Heroku, such as running the
   # buildpacks locally.
   if [ -w "$bp_dir" ]; then
-
     echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > "$bp_dir/export"
     echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> "$bp_dir/export"
     # shellcheck disable=SC2016
     echo 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' >> "$bp_dir/export"
 
+    # 2024-11-21:
+    # Set UV_USE_IO_URING for later buildpacks to prevent build timeouts when
+    # running `yarn install` on some Amazon Linux 2023 releases. This may be
+    # removed in the future when a fixed AL2023 release is available
+    # (~2024-12-09 or later).
+    #
+    # See https://github.com/npm/cli/issues/7814#issuecomment-2488626736
+    # → https://github.com/amazonlinux/amazon-linux-2023/issues/840#issuecomment-2485782075
+    # → https://lore.kernel.org/io-uring/3d913aef-8c44-4f50-9bdf-7d9051b08941@app.fastmail.com/T/#m57570b5f8f2fc00d5a17cfe18ffeeba9fc23a43d
     echo 'export UV_USE_IO_URING=${UV_USE_IO_URING:-0}' >> "$bp_dir/export"
   fi
 }

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -104,9 +104,12 @@ write_export() {
   # this may occur in situations outside of Heroku, such as running the
   # buildpacks locally.
   if [ -w "$bp_dir" ]; then
+
     echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > "$bp_dir/export"
     echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> "$bp_dir/export"
     # shellcheck disable=SC2016
     echo 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' >> "$bp_dir/export"
+
+    echo 'export UV_USE_IO_URING=${UV_USE_IO_URING:-0}' >> "$bp_dir/export"
   fi
 }


### PR DESCRIPTION
Buildpacks that run `npm install` or `yarn install` after the Node.js buildpack runs won't get the default value we set in #1347. This also exports the value for later buildpacks.