### PR TITLE
Export `COREPACK_HOME` to downstream buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Exporting `COREPACK_HOME` to downstream buildpacks to prevent Corepack shims from downloading the requested package manager again in a subsequent buildpack. ([#1374](https://github.com/heroku/heroku-buildpack-nodejs/pull/1374))
 
 ## [v280] - 2025-02-03
 

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -119,5 +119,8 @@ write_export() {
     # → https://github.com/amazonlinux/amazon-linux-2023/issues/840#issuecomment-2485782075
     # → https://lore.kernel.org/io-uring/3d913aef-8c44-4f50-9bdf-7d9051b08941@app.fastmail.com/T/#m57570b5f8f2fc00d5a17cfe18ffeeba9fc23a43d
     echo 'export UV_USE_IO_URING=${UV_USE_IO_URING:-0}' >> "$bp_dir/export"
+
+    # ensure corepack installed binaries are findable by downstream buildpacks
+    echo "export COREPACK_HOME=\"$build_dir/.heroku/corepack\"" >> "$bp_dir/export"
   fi
 }


### PR DESCRIPTION
Other buildpacks  (e.g.; mainly Ruby but it could be others) frequently use the Node.js buildpack to provide asset compilation. In cases where Corepack is used to install and use a Node.js package manager like Yarn or pnpm, downstream buildpacks will not be able to properly find the Corepack downloaded package manager from the Node.js buildpack. This is because Corepack shims for each package manager will check in `COREPACK_HOME` to determine if the requested package manager is already present before downloading.

Exporting the `COREPACK_HOME` environment variable to downstream buildpacks will ensure that Corepack will not attempt to download the requested package manager twice.

This was tested using a newly created Rails 7 app configured with [jsbundling-rails](https://github.com/rails/jsbundling-rails) and containing the following `package.json` + `pnpm-lock.yaml` generated from running `./bin/rails javascript:install`:

```
{
    "packageManager": "pnpm@10.2.0",
    "scripts": {
        "build": "echo 'executed build script from pnpm'"
    }
}
```

Fixes #1373 