### PR TITLE
Update default output of bin/release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Release script will not contribute a default process type if any `mcp` entries are present in the Procfile. ([#1404](https://github.com/heroku/heroku-buildpack-nodejs/pull/1404))
 
 ## [v292] - 2025-05-09
 

--- a/bin/release
+++ b/bin/release
@@ -3,7 +3,12 @@
 
 BUILD_DIR=${1:-}
 
-if [ ! -f "$BUILD_DIR/Procfile" ]; then
+if [ -f "$BUILD_DIR/Procfile" ] && grep -q -e "^\s*mcp.*:" "$BUILD_DIR/Procfile"; then
+  cat << EOF
+addons: []
+default_process_types: {}
+EOF
+else
   cat << EOF
 addons: []
 default_process_types:

--- a/bin/release
+++ b/bin/release
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-cat << EOF
+BUILD_DIR=${1:-}
+
+if [ ! -f "$BUILD_DIR/Procfile" ]; then
+  cat << EOF
 addons: []
 default_process_types:
   web: npm start
 EOF
+fi

--- a/bin/report
+++ b/bin/report
@@ -76,6 +76,14 @@ has_binary_installed() {
   [[ -x "$(command -v "$1")" ]]
 }
 
+has_procfile_with_web_process() {
+  if [ -f "$BUILD_DIR/Procfile" ] && grep -q -e "^\s*web:" "$BUILD_DIR/Procfile"; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 kv_pair_string "stack" "$STACK"
 
 # the version of installed binaries
@@ -91,6 +99,9 @@ kv_pair_string "npm_version_request" "$(read_json "$BUILD_DIR/package.json" ".en
 kv_pair_string "yarn_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.yarn")"
 kv_pair_string "pnpm_version_request" "$(read_json "$BUILD_DIR/package.json" ".engines.pnpm")"
 kv_pair_string "package_manager_request" "$(read_json "$BUILD_DIR/package.json" ".packageManager")"
+
+# is a procfile with a web process used?
+kv_pair "procfile_with_web_process" "$(has_procfile_with_web_process)"
 
 # build scripts
 kv_pair_string "start_script" "$(read_json "$BUILD_DIR/package.json" ".scripts[\"start\"]")"


### PR DESCRIPTION
Update release script to not contribute a default process type if any `mcp` entries are present in the `Procfile`