### PR TITLE
Heroku-20 Stack End-of-life

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ Steps to reproduce the behavior:
 4. See error
 
 **Versions (please complete the following information):**
- - Heroku Stack: [e.g. `heroku-20`]
+ - Heroku Stack: [e.g. `heroku-22`]
  - Node Version: [e.g. `15.0.0`]
  - NPM or Yarn Version: [e.g. `Yarn 1.22.10`]
  - Buildpack Version: [e.g. `heroku/nodejs v175`] (We will try to do our best to support you, but please note that we can only provide support for the latest release of the buildpack.)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       options: --user root
     strategy:
       matrix:
-        stack_number: ["20", "22", "24"]
+        stack_number: ["22", "24"]
     env:
       STACK: heroku-${{ matrix.stack_number }}
     steps:
@@ -33,7 +33,7 @@ jobs:
       options: --user root
     strategy:
       matrix:
-        stack_number: ["20", "22", "24"]
+        stack_number: ["22", "24"]
     env:
       STACK: heroku-${{ matrix.stack_number }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Drop all support and references to the now end-of-life heroku-20.
 
 ## [v290] - 2025-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Drop all support and references to the now end-of-life heroku-20.
+- Drop all support and references to the now end-of-life `heroku-20` stack. ([#1408](https://github.com/heroku/heroku-buildpack-nodejs/pull/1408))
 
 ## [v290] - 2025-04-24
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ make test
 Or to just test a specific stack:
 
 ```
-make heroku-20-build
 make heroku-22-build
+make heroku-24-build
 ```
 
 The tests are run via the vendored

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -480,7 +480,7 @@ log_other_failures() {
     meta_set "failure" "libc6-incompatibility"
     warn "This Node.js version is not compatible with the current stack.
 
-       For Node.js versions 18 and greater, heroku-20 or newer is required.
+       For Node.js versions 18 and greater, heroku-22 or newer is required.
        Consider updating to a stack that is compatible with the Node.js version
        or pinning the Node.js version to be compatible with the current
        stack." https://help.heroku.com/R7DTSTD0

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ build-resolver-linux: .build
 	cargo install heroku-nodejs-utils --root .build --bin resolve_version --git https://github.com/heroku/buildpacks-nodejs --target x86_64-unknown-linux-musl --profile release
 	mv .build/bin/resolve_version lib/vendor/resolve-version-linux
 
-test: heroku-22-build heroku-20-build heroku-24-build
+test: heroku-22-build heroku-24-build
 
 test-binary:
 	go test -v ./cmd/... -tags=integration
@@ -29,11 +29,6 @@ heroku-24-build:
 heroku-22-build:
 	@echo "Running tests in docker (heroku-22-build)..."
 	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-22" heroku/heroku:22-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
-	@echo ""
-
-heroku-20-build:
-	@echo "Running tests in docker (heroku-20-build)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=heroku-20" heroku/heroku:20-build bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
 	@echo ""
 
 hatchet:

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -3,8 +3,8 @@ require_relative "../spec_helper"
 describe "Stack Changes" do
   #Test upgrading stack invalidates the cache
   it "should not restore cached directories" do
-    Hatchet::Runner.new("default-node", stack: "heroku-20").deploy do |app, heroku|
-      app.update_stack("heroku-22")
+    Hatchet::Runner.new("default-node", stack: "heroku-22").deploy do |app, heroku|
+      app.update_stack("heroku-24")
       app.commit!
       app.push!
       expect(app.output).to include("Cached directories were not restored due to a change in version of node, npm, yarn or stack")
@@ -13,8 +13,8 @@ describe "Stack Changes" do
 
 #Test cache for regular deploys is used on repeated deploys
   it "should not restore cache if the stack did not change" do
-    Hatchet::Runner.new('default-node', stack: "heroku-20").deploy do |app, heroku|
-      app.update_stack("heroku-20")
+    Hatchet::Runner.new('default-node', stack: "heroku-22").deploy do |app, heroku|
+      app.update_stack("heroku-24")
       app.commit!
       app.push!
       expect(app.output).to_not include("Cached directories were not restored due to a change in version of node, npm, yarn or stack")


### PR DESCRIPTION
As [announced here](https://devcenter.heroku.com/changelog-items/3230), the `heroku-20` stack is no longer supported for builds on Heroku. This PR drops all references for the now end-of-life stack.