### PR TITLE
Further reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,4 @@ package.json @colincasey
 package-lock.json @colincasey
 pnpm-lock.yaml @colincasey
 yarn.lock @colincasey
+/.github/workflows/ @colincasey


### PR DESCRIPTION
We already request language owner review for various automation and Dependabot related PRs, to reduce the amount of review request notification noise sent to the language owner team alias.

This adds the GitHub Actions workflow directory to this list too, so that Dependabot PRs that bump the Actions versions are treated the same as the language-specific Dependabot PRs.

GUS-W-18951033.