### PR TITLE
Skip checksum for custom Node.js binary url

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -84,16 +84,19 @@ install_nodejs() {
     echo "Unable to download node: $code" && false
   fi
 
-  case "$checksum_name" in
-    "sha256")
-      if ! echo "$digest $output_file" | sha256sum --check --status; then
-        echo "Checksum validation failed for Node.js $number - $checksum_name:$digest" && false
-      fi
-      ;;
-    *)
-      echo "Unsupported checksum for Node.js $number - $checksum_name:$digest" && false
-      ;;
-  esac
+  if [[ -z "$NODE_BINARY_URL" ]]; then
+    case "$checksum_name" in
+      "sha256")
+        echo "Validating checksum"
+        if ! echo "$digest $output_file" | sha256sum --check --status; then
+          echo "Checksum validation failed for Node.js $number - $checksum_name:$digest" && false
+        fi
+        ;;
+      *)
+        echo "Unsupported checksum for Node.js $number - $checksum_name:$digest" && false
+        ;;
+    esac
+  fi
 
   rm -rf "${dir:?}"/*
   tar xzf /tmp/node.tar.gz --strip-components 1 -C "$dir"

--- a/test/run
+++ b/test/run
@@ -203,9 +203,11 @@ testCustomNodeBinaryURL() {
   cache=$(mktmpdir)
   env_dir=$(mktmpdir)
 
-  echo "testurl" > $env_dir/NODE_BINARY_URL
+  echo "https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-x64.tar.gz" > $env_dir/NODE_BINARY_URL
   compile "node-14" $cache $env_dir
-  assertCaptured "from testurl"
+  assertCaptured "from https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-x64.tar.gz"
+  assertNotCaptured "Validating checksum"
+  assertCapturedSuccess
 }
 
 testDisableCache() {


### PR DESCRIPTION
This PR skips the checksum validation if `NODE_BINARY_URL` is used because, unlike when a Node.js version in resolved from the inventory file, when a user provides `NODE_BINARY_URL` there is no checksum information.

Test coverage has also been expanded to cover this scenario.

Fixes #1446 
[W-19263750](https://gus.lightning.force.com/a07EE00002JelRTYAZ)