### PR TITLE
Upgrading the Ruby version used by automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: 3.1
           bundler-cache: true
       - name: Run hatchet tests
         run: make hatchet

--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: 3.1
       - name: Run Hatchet destroy
         # Only apps older than 10 minutes are destroyed, to ensure that any
         # in progress CI runs are not interrupted.


### PR DESCRIPTION
Seeing automation failures with:

```
excon-1.2.8 requires ruby version >= 3.1.0, which is incompatible with the
current version, ruby 2.7.8p225
```

e.g.; https://github.com/heroku/heroku-buildpack-nodejs/actions/runs/16682096519/job/47222966798?pr=1445

This PR updates the version of Ruby used in these automation workflows to 3.1.

[W-19271094](https://gus.lightning.force.com/a07EE00002JhXs8YAF)