### PR TITLE
Classify git dependency error in npm

### DIFF
--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -667,6 +667,19 @@ log_other_failures() {
     return 0
   fi
 
+  if grep -q "npm error code 128" "$log_file" && grep -q "An unknown git error occurred" "$log_file"; then
+    meta_set "failure" "npm-install-git-dependency"
+    warn "npm Git dependency error (code 128)
+
+       This error indicates an issue related to Git operations when attempting to install
+       an npm package specified as a Git dependency in \`package.json\`.
+
+       The error details above should contain more information about which package is causing the
+       issue during dependency installation as well as the specific problem that Git encountered.
+    "
+    fail
+  fi
+
   if grep -q "npm error code EUSAGE" "$log_file"; then
     if grep -q "Please update your lock file" "$log_file"; then
       meta_set "failure" "npm-lockfile-out-of-sync"

--- a/test/fixtures/error-npm-git-error/README.md
+++ b/test/fixtures/error-npm-git-error/README.md
@@ -1,0 +1,1 @@
+A fake README, to keep npm from polluting stderr.

--- a/test/fixtures/error-npm-git-error/package.json
+++ b/test/fixtures/error-npm-git-error/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "error-npm-git-error",
+  "engines": {
+    "node": "22.x"
+  },
+  "dependencies": {
+    "@ccasey/not-a-repository": "git+ssh://github.com/ccasey/not-a-repository.git"
+  }
+}

--- a/test/run
+++ b/test/run
@@ -2147,6 +2147,14 @@ testErrorNpmLockfileOutOfSync() {
   assertFileContains "failure=npm-lockfile-out-of-sync" "$log_file"
 }
 
+testErrorNpmGitDependency() {
+  log_file=$(mktemp)
+  BUILDPACK_LOG_FILE="$log_file" compile "error-npm-git-error"
+  assertCaptured "npm Git dependency error (code 128)"
+  assertCapturedError
+  assertFileContains "failure=npm-install-git-dependency" "$log_file"
+}
+
 # Utils
 
 pushd "$(dirname 0)" >/dev/null


### PR DESCRIPTION
- detects when `npm install` is executed and a git dependency error occurs
- provides an error message with appropriate detail
- classifies the error as `npm-install-git-dependency`

[W-19282318](https://gus.lightning.force.com/a07EE00002JlICCYA3)