### PR TITLE
Fix YAML control character escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix control code escaping for buildpack metrics. ([#1464](https://github.com/heroku/heroku-buildpack-nodejs/pull/1464))
 
 ## [v304] - 2025-08-15
 

--- a/bin/report
+++ b/bin/report
@@ -68,7 +68,20 @@ kv_pair_string() {
 	if [[ -n "${value}" ]]; then
 		# Escape any existing single quotes, which for YAML means replacing `'` with `''`.
 		value="${value//\'/\'\'}"
-		echo "${key}: '${value}'"
+		# allowed (✅) and disallowed (❌) hex codes for yaml parser
+		# ❌ \x00-\x08
+		# ✅ \x09
+    #	✅ \x0A
+    #	❌ \x0B
+    #	❌ \x0C
+    #	✅ \x0D
+    # ❌ \x0E-\x1F
+    #	✅ \x20-\x7E
+    # ❌ \x7F-\x84
+    #	✅ \x85
+    # ❌ \x86-\x9F
+    #	✅ \xA0-\xFF
+		echo "${key}: '${value}'" | sed 's/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F]/�/g'
 	fi
 }
 

--- a/test/fixtures/node-14/package.json
+++ b/test/fixtures/node-14/package.json
@@ -10,7 +10,7 @@
     "node": "14.x"
   },
   "scripts": {
-    "build": "echo \"escaping - test if it's working as expected\"",
+    "build": "echo \"escaping - test if it's working as expected including control chars like \u0001-\u0008, \u000B-\u000C, and \u000E-\u001F which are not allowed in yaml.\"",
     "start": "node foo.js"
   }
 }

--- a/test/run
+++ b/test/run
@@ -1652,7 +1652,7 @@ testBinReportSuccess() {
   assertCaptured "corepack_version: '0.15.1'"
   assertCaptured "node_version_request: '14.x'"
   assertCaptured "start_script: 'node foo.js'"
-  assertCaptured "build_script: 'echo \"escaping - test if it''s working as expected\"'"
+  assertCaptured "build_script: 'echo \"escaping - test if it''s working as expected including control chars like �-�, �-�, and �-� which are not allowed in yaml.\"'"
   assertCaptured "package_manager: 'npm'"
   assertCaptured "build_step: 'finished'"
   assertCaptured "cache_status: 'not-found'"


### PR DESCRIPTION
We sometimes see parsing errors in the output produced by `bin/report` around [YAML control characters](https://github.com/go-yaml/yaml/blob/944c86a7d29391925ed6ac33bee98a0516f1287a/readerc.go#L369C4-L376C47). This PR updates the escaping code for string values to account for a subset of these disallowed characters and replaces them with �.

[W-19366387](https://gus.lightning.force.com/a07EE00002KKjWvYAL)