### PR TITLE
Add `node_version_major` to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix control code escaping for buildpack metrics. ([#1464](https://github.com/heroku/heroku-buildpack-nodejs/pull/1464))
+- Add `node_version_major` to buildpack metrics. ([#1465](https://github.com/heroku/heroku-buildpack-nodejs/pull/1465))
 
 ## [v304] - 2025-08-15
 

--- a/bin/compile
+++ b/bin/compile
@@ -258,6 +258,7 @@ install_bins() {
 
   node_version="$(node --version)"
   meta_set "node-version" "$node_version"
+  meta_set "node-version-major" "$(get_node_major_version)"
 
   if ! has_release_script "$BUILD_DIR" && [[ "$package_manager" == yarn* ]]; then
     meta_set "build-step" "install-yarn-using-corepack"

--- a/bin/report
+++ b/bin/report
@@ -164,6 +164,7 @@ kv_pair "cached_bower_components" "$(meta_get "cached-bower-components")"
 kv_pair "custom_cache_dirs" "$(meta_get "node-custom-cache-dirs")"
 
 # pull execution data from the build
+kv_pair "node_version_major" "$(meta_get "node-version-major")"
 kv_pair "install_node_binary_time" "$(meta_get "install-node-binary-time")"
 kv_pair "install_node_binary_memory" "$(meta_get "install-node-binary-memory")"
 kv_pair "install_npm_binary_time" "$(meta_get "install-npm-binary-time")"

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -161,8 +161,8 @@ install_corepack_package_manager() {
   local package_manager="$1"
   local node_version="$2"
 
-  node_major_version=$(echo "$node_version" | cut -d "." -f 1 | sed 's/^v//')
-  node_minor_version=$(echo "$node_version" | cut -d "." -f 2)
+  node_major_version=$(get_node_major_version)
+  node_minor_version=$(get_node_minor_version)
 
   # Corepack is available in: v16.9.0, v14.19.0
   if (( node_major_version >= 17 )) || (( node_major_version == 14 && node_minor_version >= 19 )) || (( node_major_version >= 16 && node_minor_version >= 9 )); then

--- a/test/run
+++ b/test/run
@@ -1648,6 +1648,7 @@ testBinReportSuccess() {
   # check for all the fields that should be included in this report
   assertCaptured "stack: '$STACK'"
   assertCaptured "node_version: 'v14.21.3'"
+  assertCaptured "node_version_major: 14"
   assertCaptured "npm_version: '6.14.18'"
   assertCaptured "corepack_version: '0.15.1'"
   assertCaptured "node_version_request: '14.x'"


### PR DESCRIPTION
Also cleans up some call sites that need to examine node major and minor numbers.