### PR TITLE
Fix test for invalid corepack version error

### DIFF
--- a/test/fixtures/corepack-invalid-package-manager/package.json
+++ b/test/fixtures/corepack-invalid-package-manager/package.json
@@ -12,5 +12,5 @@
   "scripts": {
     "start": "node foo.js"
   },
-  "packageManager": "yarn@999.999.999"
+  "packageManager": "pnpm@999.999.999"
 }

--- a/test/run
+++ b/test/run
@@ -1694,10 +1694,10 @@ testCorepackNotAvailable() {
 
 testCorepackInvalidVersion() {
   compile "corepack-invalid-package-manager"
-  assertCaptured "packageManager (package.json): yarn@999.999.999"
-  assertCaptured "Installing yarn@999.999.999 via corepack 0.20.0"
-  assertCaptured "Error installing yarn version 999.999.999"
-  assertCaptured "Can’t find the yarn version that matches the requested version declared in package.json (999.999.999)"
+  assertCaptured "packageManager (package.json): pnpm@999.999.999"
+  assertCaptured "Installing pnpm@999.999.999 via corepack 0.20.0"
+  assertCaptured "Error installing pnpm version 999.999.999"
+  assertCaptured "Can’t find the pnpm version that matches the requested version declared in package.json (999.999.999)"
   assertCapturedError
 
   compile "corepack-invalid-package-manager-sha"


### PR DESCRIPTION
The integration test suite is failing for the classic Node.js buildpack due to a change in behavior from the Yarn package registry where, if a invalid Yarn version is requested, it nows installs a dummy version of Yarn via corepack that prints a custom error message instead of failing the install. See https://github.com/heroku/heroku-buildpack-nodejs/actions/runs/18191223667/job/51793169553

This PR switches the test to now use `pnpm` for this use case.

[W-19801950](https://gus.lightning.force.com/a07EE00002MkEleYAF)