### PR TITLE
Add support for heroku-26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ Steps to reproduce the behavior:
 4. See error
 
 **Versions (please complete the following information):**
- - Heroku Stack: [e.g. `heroku-22`]
+ - Heroku Stack: [e.g. `heroku-24`]
  - Node Version: [e.g. `15.0.0`]
  - NPM or Yarn Version: [e.g. `Yarn 1.22.10`]
  - Buildpack Version: [e.g. `heroku/nodejs v175`] (We will try to do our best to support you, but please note that we can only provide support for the latest release of the buildpack.)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       options: --user root
     strategy:
       matrix:
-        stack_number: ["22", "24"]
+        stack_number: ["22", "24", "26"]
     env:
       STACK: heroku-${{ matrix.stack_number }}
     steps:
@@ -35,7 +35,7 @@ jobs:
       options: --user root
     strategy:
       matrix:
-        stack_number: ["22", "24"]
+        stack_number: ["22", "24", "26"]
         test_suite: ["npm", "yarn", "pnpm", "general"]
     env:
       STACK: heroku-${{ matrix.stack_number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add support for heroku-26. ([#1607](https://github.com/heroku/heroku-buildpack-nodejs/pull/1607))
 
 ## [v341] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [Unreleased]
 
-- Add support for heroku-26. ([#1607](https://github.com/heroku/heroku-buildpack-nodejs/pull/1607))
 
 ## [v341] - 2026-04-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ There are unit tests that are run with `shunit`. For any change you make, write 
 
 ### Running Tests
 
-To run the tests, run `make test`. You will need Docker installed. This will start a test run of all 3 Heroku stack images that will run serially. If you want to test one stack image (which is usually adequate), run `make heroku-22` (or whatever stack image you'd like to test).
+To run the tests, run `make test`. You will need Docker installed. This will start a test run of all Heroku stack images that will run serially. If you want to test one stack image (which is usually adequate), run `make heroku-24-build` (or whatever stack image you'd like to test).
 
 ## Opening a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Or to just test a specific stack:
 ```
 make heroku-22-build
 make heroku-24-build
+make heroku-26-build
 ```
 
 The tests are run via the vendored

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ build-resolver-linux: .build
 	    cargo build --manifest-path ./resolve-version/Cargo.toml --target x86_64-unknown-linux-musl --profile release
 	mv ./resolve-version/target/x86_64-unknown-linux-musl/release/resolve-version lib/vendor/resolve-version-linux
 
-test: heroku-22-build heroku-24-build
+test: heroku-22-build heroku-24-build heroku-26-build
 
 shellcheck:
 	@shellcheck -x bin/compile bin/detect bin/release bin/test bin/test-compile
@@ -25,6 +25,14 @@ heroku-24-build: heroku-24-npm heroku-24-yarn heroku-24-pnpm heroku-24-general
 
 heroku-24-%:
 	@docker run --platform "linux/amd64" -v $(shell pwd):/buildpack:ro --rm -e "STACK=heroku-24" heroku/heroku:24-build bash -c "cp -r /buildpack ~/buildpack_test; cd ~/buildpack_test/; test/run-$* $(if $(TEST),-- $(TEST),);" 2>&1 | sed "s/^/[heroku-24:$*] /"
+
+# Use `make -j4 heroku-26-build` to run all suites in parallel.
+# Ctrl-C cleanly terminates all parallel jobs when using make -j.
+heroku-26-build: heroku-26-npm heroku-26-yarn heroku-26-pnpm heroku-26-general
+	@true
+
+heroku-26-%:
+	@docker run --platform "linux/amd64" -v $(shell pwd):/buildpack:ro --rm -e "STACK=heroku-26" heroku/heroku:26-build bash -c "cp -r /buildpack ~/buildpack_test; cd ~/buildpack_test/; test/run-$* $(if $(TEST),-- $(TEST),);" 2>&1 | sed "s/^/[heroku-26:$*] /"
 
 heroku-22-build: heroku-22-npm heroku-22-yarn heroku-22-pnpm heroku-22-general
 	@true

--- a/makefile
+++ b/makefile
@@ -18,14 +18,6 @@ shellcheck:
 	@shellcheck -x ci-profile/**
 	@shellcheck -x etc/**
 
-# Use `make -j4 heroku-24-build` to run all suites in parallel.
-# Ctrl-C cleanly terminates all parallel jobs when using make -j.
-heroku-24-build: heroku-24-npm heroku-24-yarn heroku-24-pnpm heroku-24-general
-	@true
-
-heroku-24-%:
-	@docker run --platform "linux/amd64" -v $(shell pwd):/buildpack:ro --rm -e "STACK=heroku-24" heroku/heroku:24-build bash -c "cp -r /buildpack ~/buildpack_test; cd ~/buildpack_test/; test/run-$* $(if $(TEST),-- $(TEST),);" 2>&1 | sed "s/^/[heroku-24:$*] /"
-
 # Use `make -j4 heroku-26-build` to run all suites in parallel.
 # Ctrl-C cleanly terminates all parallel jobs when using make -j.
 heroku-26-build: heroku-26-npm heroku-26-yarn heroku-26-pnpm heroku-26-general
@@ -33,6 +25,14 @@ heroku-26-build: heroku-26-npm heroku-26-yarn heroku-26-pnpm heroku-26-general
 
 heroku-26-%:
 	@docker run --platform "linux/amd64" -v $(shell pwd):/buildpack:ro --rm -e "STACK=heroku-26" heroku/heroku:26-build bash -c "cp -r /buildpack ~/buildpack_test; cd ~/buildpack_test/; test/run-$* $(if $(TEST),-- $(TEST),);" 2>&1 | sed "s/^/[heroku-26:$*] /"
+
+# Use `make -j4 heroku-24-build` to run all suites in parallel.
+# Ctrl-C cleanly terminates all parallel jobs when using make -j.
+heroku-24-build: heroku-24-npm heroku-24-yarn heroku-24-pnpm heroku-24-general
+	@true
+
+heroku-24-%:
+	@docker run --platform "linux/amd64" -v $(shell pwd):/buildpack:ro --rm -e "STACK=heroku-24" heroku/heroku:24-build bash -c "cp -r /buildpack ~/buildpack_test; cd ~/buildpack_test/; test/run-$* $(if $(TEST),-- $(TEST),);" 2>&1 | sed "s/^/[heroku-24:$*] /"
 
 heroku-22-build: heroku-22-npm heroku-22-yarn heroku-22-pnpm heroku-22-general
 	@true

--- a/spec/hatchet/stack_spec.rb
+++ b/spec/hatchet/stack_spec.rb
@@ -3,8 +3,8 @@ require_relative "../spec_helper"
 describe "Stack Changes" do
   #Test upgrading stack invalidates the cache
   it "should not restore cached directories" do
-    Hatchet::Runner.new("default-node", stack: "heroku-22").deploy do |app, heroku|
-      app.update_stack("heroku-24")
+    Hatchet::Runner.new("default-node", stack: "heroku-24").deploy do |app, heroku|
+      app.update_stack("heroku-26")
       app.commit!
       app.push!
       expect(app.output).to include("Cached directories were not restored due to a change in version of node, npm, yarn or stack")
@@ -13,8 +13,8 @@ describe "Stack Changes" do
 
 #Test cache for regular deploys is used on repeated deploys
   it "should not restore cache if the stack did not change" do
-    Hatchet::Runner.new('default-node', stack: "heroku-22").deploy do |app, heroku|
-      app.update_stack("heroku-24")
+    Hatchet::Runner.new('default-node', stack: "heroku-24").deploy do |app, heroku|
+      app.update_stack("heroku-26")
       app.commit!
       app.push!
       expect(app.output).to_not include("Cached directories were not restored due to a change in version of node, npm, yarn or stack")


### PR DESCRIPTION
## Summary

- Add `heroku-26` to the CI test matrix (unit and functional tests)
- Add `heroku-26-build` makefile targets for local Docker-based testing
- Update hatchet stack migration tests from heroku-22→heroku-24 to heroku-24→heroku-26
- Update documentation (README, CONTRIBUTING, bug report template) with current stack references
- Add changelog entry

W-20776127