### PR TITLE
Add install_bins output baseline assertions to hatchet specs

### DIFF
--- a/spec/ci/corepack_spec.rb
+++ b/spec/ci/corepack_spec.rb
@@ -4,6 +4,20 @@ describe "corepack support" do
   it "should be able to run an app that installs pnpm using corepack" do
     app = Hatchet::Runner.new("spec/fixtures/repos/corepack-pnpm")
     app.deploy do |app|
+      expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+        remote: -----> Installing binaries
+        remote:        engines\.node \(package\.json\):   unspecified
+        remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+        remote:        engines\.pnpm \(package\.json\):   unspecified \(use default\)
+        remote:        packageManager \(package\.json\): pnpm@9\.0\.6
+        remote:
+        remote:        No Node\.js version specified, resolving current LTS version\.\.\.
+        remote:        Downloading and installing node .+\.\.\.
+        remote:        Validating checksum
+        remote:        Using default npm version: .+
+        remote:        Downloading and installing pnpm \(9\.0\.6\)
+        remote:        Using pnpm .+
+      REGEX
       expect(successful_body(app).strip).to eq("Hello from corepack-pnpm")
     end
   end
@@ -11,8 +25,21 @@ describe "corepack support" do
   it "should be able to run an app that installs yarn using corepack" do
     app = Hatchet::Runner.new("spec/fixtures/repos/corepack-yarn")
     app.deploy do |app|
+      expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+        remote: -----> Installing binaries
+        remote:        engines\.node \(package\.json\):   unspecified
+        remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+        remote:        engines\.yarn \(package\.json\):   unspecified \(use default\)
+        remote:        packageManager \(package\.json\): yarn@4\.1\.1
+        remote:
+        remote:        No Node\.js version specified, resolving current LTS version\.\.\.
+        remote:        Downloading and installing node .+\.\.\.
+        remote:        Validating checksum
+        remote:        Using default npm version: .+
+        remote:        Downloading and installing yarn .+
+        remote:        Using yarn .+
+      REGEX
       expect(successful_body(app).strip).to eq("Hello from corepack-yarn")
     end
   end
 end
-

--- a/spec/ci/node_10_spec.rb
+++ b/spec/ci/node_10_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v10.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   10.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 10.x...
+          remote:        Downloading and installing node 10.24.1...
+          remote:        Validating checksum
+          remote:        Using default npm version: 6.14.12
+        OUTPUT
       end
     end
 

--- a/spec/ci/node_12_spec.rb
+++ b/spec/ci/node_12_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v12.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   12.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 12.x...
+          remote:        Downloading and installing node 12.22.12...
+          remote:        Validating checksum
+          remote:        Using default npm version: 6.14.16
+        OUTPUT
       end
     end
 

--- a/spec/ci/node_14_spec.rb
+++ b/spec/ci/node_14_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v14.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   14.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 14.x...
+          remote:        Downloading and installing node 14.21.3...
+          remote:        Validating checksum
+          remote:        Using default npm version: 6.14.18
+        OUTPUT
       end
     end
 

--- a/spec/ci/node_15_spec.rb
+++ b/spec/ci/node_15_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v15.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   15.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 15.x...
+          remote:        Downloading and installing node 15.14.0...
+          remote:        Validating checksum
+          remote:        Using default npm version: 7.7.6
+        OUTPUT
       end
     end
 

--- a/spec/ci/node_16_spec.rb
+++ b/spec/ci/node_16_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v16.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   16.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 16.x...
+          remote:        Downloading and installing node 16.20.2...
+          remote:        Validating checksum
+          remote:        Using default npm version: 8.19.4
+        OUTPUT
       end
     end
   end

--- a/spec/ci/node_17_spec.rb
+++ b/spec/ci/node_17_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v17.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   17.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 17.x...
+          remote:        Downloading and installing node 17.9.1...
+          remote:        Validating checksum
+          remote:        Using default npm version: 8.11.0
+        OUTPUT
       end
     end
   end

--- a/spec/ci/node_18_spec.rb
+++ b/spec/ci/node_18_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v18.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   18.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 18.x...
+          remote:        Downloading and installing node 18.20.8...
+          remote:        Validating checksum
+          remote:        Using default npm version: 10.8.2
+        OUTPUT
       end
     end
   end

--- a/spec/ci/node_19_spec.rb
+++ b/spec/ci/node_19_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v19.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   19.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 19.x...
+          remote:        Downloading and installing node 19.9.0...
+          remote:        Validating checksum
+          remote:        Using default npm version: 9.6.3
+        OUTPUT
       end
     end
   end

--- a/spec/ci/node_20_spec.rb
+++ b/spec/ci/node_20_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v20.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+          remote: -----> Installing binaries
+          remote:        engines\.node \(package\.json\):   20\.x
+          remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+          remote:
+          remote:        Resolving node version 20\.x\.\.\.
+          remote:        Downloading and installing node 20\.\d+\.\d+\.\.\.
+          remote:        Validating checksum
+          remote:        Using default npm version: .+
+        REGEX
       end
     end
   end

--- a/spec/ci/node_21_spec.rb
+++ b/spec/ci/node_21_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v21.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   21.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 21.x...
+          remote:        Downloading and installing node 21.7.3...
+          remote:        Validating checksum
+          remote:        Using default npm version: 10.5.0
+        OUTPUT
       end
     end
   end

--- a/spec/ci/node_22_spec.rb
+++ b/spec/ci/node_22_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v22.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+          remote: -----> Installing binaries
+          remote:        engines\.node \(package\.json\):   22\.x
+          remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+          remote:
+          remote:        Resolving node version 22\.x\.\.\.
+          remote:        Downloading and installing node 22\.\d+\.\d+\.\.\.
+          remote:        Validating checksum
+          remote:        Using default npm version: .+
+        REGEX
       end
     end
   end

--- a/spec/ci/node_23_spec.rb
+++ b/spec/ci/node_23_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v23.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> Installing binaries
+          remote:        engines.node (package.json):   23.x
+          remote:        engines.npm (package.json):    unspecified (use default)
+          remote:
+          remote:        Resolving node version 23.x...
+          remote:        Downloading and installing node 23.11.1...
+          remote:        Validating checksum
+          remote:        Using default npm version: 10.9.2
+        OUTPUT
       end
     end
   end

--- a/spec/ci/node_24_spec.rb
+++ b/spec/ci/node_24_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v24.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+          remote: -----> Installing binaries
+          remote:        engines\.node \(package\.json\):   24\.x
+          remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+          remote:
+          remote:        Resolving node version 24\.x\.\.\.
+          remote:        Downloading and installing node 24\.\d+\.\d+\.\.\.
+          remote:        Validating checksum
+          remote:        Using default npm version: .+
+        REGEX
       end
     end
   end

--- a/spec/ci/node_25_spec.rb
+++ b/spec/ci/node_25_spec.rb
@@ -9,6 +9,16 @@ describe "Hello World for Node v25.x" do
     it "should deploy successfully" do
       app.deploy do |app|
         expect(successful_body(app).strip).to eq("Hello, world!")
+        expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+          remote: -----> Installing binaries
+          remote:        engines\.node \(package\.json\):   25\.x
+          remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+          remote:
+          remote:        Resolving node version 25\.x\.\.\.
+          remote:        Downloading and installing node 25\.\d+\.\d+\.\.\.
+          remote:        Validating checksum
+          remote:        Using default npm version: .+
+        REGEX
       end
     end
   end

--- a/spec/ci/pnpm_spec.rb
+++ b/spec/ci/pnpm_spec.rb
@@ -4,7 +4,20 @@ describe "pnpm support" do
   it "should successfully deploy a pnpm workspace with pruned devDependencies" do
     app = Hatchet::Runner.new("spec/fixtures/repos/pnpm-workspace")
     app.deploy do |app|
-      expect(app.output).to include("Using pnpm")
+      expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+        remote: -----> Installing binaries
+        remote:        engines\.node \(package\.json\):   unspecified
+        remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+        remote:        engines\.pnpm \(package\.json\):   unspecified \(use default\)
+        remote:        packageManager \(package\.json\): pnpm@9\.5\.0
+        remote:
+        remote:        No Node\.js version specified, resolving current LTS version\.\.\.
+        remote:        Downloading and installing node .+\.\.\.
+        remote:        Validating checksum
+        remote:        Using default npm version: .+
+        remote:        Downloading and installing pnpm \(9\.5\.0\)
+        remote:        Using pnpm .+
+      REGEX
       expect(app.output).to include("Running 'pnpm install' with pnpm-lock.yaml")
       expect(app.output).to include("Pruning devDependencies")
       expect(app.output).to include("devDependencies: skipped because NODE_ENV is set to production")

--- a/spec/ci/yarn2_spec.rb
+++ b/spec/ci/yarn2_spec.rb
@@ -6,6 +6,36 @@ describe "yarn2 examples" do
   it "pnp zero-install with should deploy successfully and not use the cache" do
     app = Hatchet::Runner.new("spec/fixtures/repos/yarn2-pnp-zero-install")
     app.deploy do |app|
+      expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+        remote: -----> Installing binaries
+        remote:        engines\.node \(package\.json\):   unspecified
+        remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+        remote:        engines\.yarn \(package\.json\):   unspecified \(use default\)
+        remote:        packageManager \(package\.json\): yarn@3\.1\.1
+        remote:
+        remote:         !     Yarn release script may conflict with "packageManager"
+        remote:
+        remote:               The package\.json file indicates the target version of Yarn to install with:
+        remote:               - "packageManager": "yarn@3\.1\.1"
+        remote:
+        remote:               But the \.yarnrc\.yml configuration indicates a vendored release of Yarn should be used with:
+        remote:               - yarnPath: "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:
+        remote:               This will cause the buildpack to install yarn@3\.1\.1 but, when running Yarn commands, the vendored release
+        remote:               at "\.yarn/releases/yarn-3\.1\.1\.cjs" will be executed instead\.
+        remote:
+        remote:               To ensure we install the version of Yarn you want, choose only one of the following actions:
+        remote:               - Remove the "packageManager" field from package\.json
+        remote:               - Remove the "yarnPath" configuration from \.yarnrc\.yml and delete the vendored release at "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:               https://devcenter\.heroku\.com/articles/nodejs-support
+        remote:
+        remote:        No Node\.js version specified, resolving current LTS version\.\.\.
+        remote:        Downloading and installing node .+\.\.\.
+        remote:        Validating checksum
+        remote:        Using default npm version: .+
+        remote:        Downloading and installing yarn \(1\.22\.x\)
+        remote:        Using yarn .+
+      REGEX
       expect(successful_body(app).strip).to eq("Hello from yarn2-pnp-zero-install")
 
       run!('git commit --allow-empty -m "deploy again to test cache reuse"')
@@ -21,6 +51,36 @@ describe "yarn2 examples" do
   it "pnp nonzero-install should deploy successfully and reuse the cache" do
     app = Hatchet::Runner.new("spec/fixtures/repos/yarn2-pnp-nonzero-install")
     app.deploy do |app|
+      expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+        remote: -----> Installing binaries
+        remote:        engines\.node \(package\.json\):   unspecified
+        remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+        remote:        engines\.yarn \(package\.json\):   unspecified \(use default\)
+        remote:        packageManager \(package\.json\): yarn@3\.1\.1
+        remote:
+        remote:         !     Yarn release script may conflict with "packageManager"
+        remote:
+        remote:               The package\.json file indicates the target version of Yarn to install with:
+        remote:               - "packageManager": "yarn@3\.1\.1"
+        remote:
+        remote:               But the \.yarnrc\.yml configuration indicates a vendored release of Yarn should be used with:
+        remote:               - yarnPath: "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:
+        remote:               This will cause the buildpack to install yarn@3\.1\.1 but, when running Yarn commands, the vendored release
+        remote:               at "\.yarn/releases/yarn-3\.1\.1\.cjs" will be executed instead\.
+        remote:
+        remote:               To ensure we install the version of Yarn you want, choose only one of the following actions:
+        remote:               - Remove the "packageManager" field from package\.json
+        remote:               - Remove the "yarnPath" configuration from \.yarnrc\.yml and delete the vendored release at "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:               https://devcenter\.heroku\.com/articles/nodejs-support
+        remote:
+        remote:        No Node\.js version specified, resolving current LTS version\.\.\.
+        remote:        Downloading and installing node .+\.\.\.
+        remote:        Validating checksum
+        remote:        Using default npm version: .+
+        remote:        Downloading and installing yarn \(1\.22\.x\)
+        remote:        Using yarn .+
+      REGEX
       expect(successful_body(app).strip).to eq("Hello from yarn2-pnp-nonzero-install")
 
       run!('git commit --allow-empty -m "deploy again to test cache reuse"')
@@ -38,6 +98,36 @@ describe "yarn2 examples" do
   it "node_modules zero install should deploy successfully and reuse the cache" do
     app = Hatchet::Runner.new("spec/fixtures/repos/yarn2-modules-zero-install")
     app.deploy do |app|
+      expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+        remote: -----> Installing binaries
+        remote:        engines\.node \(package\.json\):   unspecified
+        remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+        remote:        engines\.yarn \(package\.json\):   unspecified \(use default\)
+        remote:        packageManager \(package\.json\): yarn@3\.1\.1
+        remote:
+        remote:         !     Yarn release script may conflict with "packageManager"
+        remote:
+        remote:               The package\.json file indicates the target version of Yarn to install with:
+        remote:               - "packageManager": "yarn@3\.1\.1"
+        remote:
+        remote:               But the \.yarnrc\.yml configuration indicates a vendored release of Yarn should be used with:
+        remote:               - yarnPath: "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:
+        remote:               This will cause the buildpack to install yarn@3\.1\.1 but, when running Yarn commands, the vendored release
+        remote:               at "\.yarn/releases/yarn-3\.1\.1\.cjs" will be executed instead\.
+        remote:
+        remote:               To ensure we install the version of Yarn you want, choose only one of the following actions:
+        remote:               - Remove the "packageManager" field from package\.json
+        remote:               - Remove the "yarnPath" configuration from \.yarnrc\.yml and delete the vendored release at "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:               https://devcenter\.heroku\.com/articles/nodejs-support
+        remote:
+        remote:        No Node\.js version specified, resolving current LTS version\.\.\.
+        remote:        Downloading and installing node .+\.\.\.
+        remote:        Validating checksum
+        remote:        Using default npm version: .+
+        remote:        Downloading and installing yarn \(1\.22\.x\)
+        remote:        Using yarn .+
+      REGEX
       expect(successful_body(app).strip).to eq("Hello from yarn2-modules-zero-install")
 
       run!('git commit --allow-empty -m "deploy again to test cache reuse"')
@@ -49,11 +139,41 @@ describe "yarn2 examples" do
   end
 
   # Example uses the node-modules linker (e.g. node standard module resolution)
-  # and does not push dependencies in .yarn/cache. All packages will either be 
+  # and does not push dependencies in .yarn/cache. All packages will either be
   # restored from the buildcache or downloaded.
   it "node_modules nonzero install should deploy successfully and reuse the cache" do
     app = Hatchet::Runner.new("spec/fixtures/repos/yarn2-modules-nonzero-install")
     app.deploy do |app|
+      expect(clean_output(app.output)).to match(Regexp.new(<<~'REGEX'))
+        remote: -----> Installing binaries
+        remote:        engines\.node \(package\.json\):   unspecified
+        remote:        engines\.npm \(package\.json\):    unspecified \(use default\)
+        remote:        engines\.yarn \(package\.json\):   unspecified \(use default\)
+        remote:        packageManager \(package\.json\): yarn@3\.1\.1
+        remote:
+        remote:         !     Yarn release script may conflict with "packageManager"
+        remote:
+        remote:               The package\.json file indicates the target version of Yarn to install with:
+        remote:               - "packageManager": "yarn@3\.1\.1"
+        remote:
+        remote:               But the \.yarnrc\.yml configuration indicates a vendored release of Yarn should be used with:
+        remote:               - yarnPath: "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:
+        remote:               This will cause the buildpack to install yarn@3\.1\.1 but, when running Yarn commands, the vendored release
+        remote:               at "\.yarn/releases/yarn-3\.1\.1\.cjs" will be executed instead\.
+        remote:
+        remote:               To ensure we install the version of Yarn you want, choose only one of the following actions:
+        remote:               - Remove the "packageManager" field from package\.json
+        remote:               - Remove the "yarnPath" configuration from \.yarnrc\.yml and delete the vendored release at "\.yarn/releases/yarn-3\.1\.1\.cjs"
+        remote:               https://devcenter\.heroku\.com/articles/nodejs-support
+        remote:
+        remote:        No Node\.js version specified, resolving current LTS version\.\.\.
+        remote:        Downloading and installing node .+\.\.\.
+        remote:        Validating checksum
+        remote:        Using default npm version: .+
+        remote:        Downloading and installing yarn \(1\.22\.x\)
+        remote:        Using yarn .+
+      REGEX
       expect(successful_body(app).strip).to eq("Hello from yarn2-modules-nonzero-install")
 
       run!('git commit --allow-empty -m "deploy again to test cache reuse"')
@@ -65,4 +185,3 @@ describe "yarn2 examples" do
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,3 +47,14 @@ def run!(cmd)
   raise "Error running command #{cmd.inspect}: #{out}" unless $?.success?
   out
 end
+
+def clean_output(output)
+  output
+    # Remove trailing whitespace characters added by Git:
+    # https://github.com/heroku/hatchet/issues/162
+    .gsub(/ {8}(?=\R)/, '')
+    # Normalize blank remote lines (e.g. "remote:       \n") to "remote:\n".
+    .gsub(/^(remote:)[ \t]+$/, '\1')
+    # Remove ANSI colour codes used in buildpack output (e.g. error messages).
+    .gsub(/\e\[[0-9;]+m/, '')
+end


### PR DESCRIPTION
## Summary

- Adds a `clean_output` helper to `spec_helper.rb` that normalizes build output by stripping trailing whitespace from blank `remote:` lines and removing ANSI color codes, enabling stable output assertions across test runs
- Adds structured output assertions for the "Installing binaries" build phase to all node version specs (10-25), pnpm, corepack, and yarn2 specs
- EOL node versions (10-19, 21, 23) use exact `include` assertions with frozen node/npm versions; active versions (20, 22, 24, 25) use regex assertions with major-pinned version patterns
- Modeled after the [Python buildpack's hatchet test approach](https://github.com/heroku/heroku-buildpack-python/blob/main/spec/hatchet/checks_spec.rb)

This establishes a baseline for a follow-up PR that will refactor the `install_bins` output pipeline to support inline `output::warning` calls without double-indentation.