### PR TITLE
Fix pnpm store prune ENOENT on installs with no fetched packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Tolerate `ENOENT` from `pnpm store prune` when the pnpm store has no fetched package files, fixing build failures on pnpm <9.12.0 for projects that resolve with no external dependencies. ([#1654](https://github.com/heroku/heroku-buildpack-nodejs/pull/1654))
 
 ## [v350] - 2026-05-21
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -329,7 +329,22 @@ pnpm_install() {
   counter=$(load_pnpm_prune_store_counter "$cache_dir")
   if (( counter == 0 )); then
     echo "Cleaning up pnpm store"
-    suppress_output pnpm store prune
+    # pnpm <9.12.0 errors with `ENOENT: ... scandir '<store>/v*/files'`
+    # when the store has no fetched package files (e.g. an install with
+    # no external dependencies), because pnpm only creates that
+    # directory on first download. Treat any ENOENT-on-scandir of the
+    # store's `vN/files` directory during prune as a benign empty-store
+    # no-op; surface every other failure so we don't mask unrelated
+    # prune errors. Fixed upstream in pnpm/pnpm#8555.
+    # TODO: remove when minimum supported pnpm is >= 9.12.0.
+    local prune_output prune_exit=0
+    prune_output=$(mktemp)
+    trap "rm -f '$prune_output' >/dev/null" RETURN
+    pnpm store prune >"$prune_output" 2>&1 || prune_exit=$?
+    if (( prune_exit != 0 )) && ! grep -qE "ENOENT.*scandir" "$prune_output"; then
+      cat "$prune_output"
+      return "$prune_exit"
+    fi
   fi
   save_pnpm_prune_store_counter "$cache_dir" "$(( counter - 1 ))"
 }

--- a/test/fixtures/pnpm-empty-deps/package.json
+++ b/test/fixtures/pnpm-empty-deps/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-empty-deps",
+  "version": "1.0.0",
+  "packageManager": "pnpm@9.7.1",
+  "engines": {
+    "node": "22.x"
+  }
+}

--- a/test/fixtures/pnpm-empty-deps/pnpm-lock.yaml
+++ b/test/fixtures/pnpm-empty-deps/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/test/run-pnpm
+++ b/test/run-pnpm
@@ -183,6 +183,34 @@ testPnpmStorePruning() {
 }
 
 
+# Regression test: when a project has no dependencies, `pnpm install` does not
+# create the content-addressable file directory (e.g. `<store>/v3/files`) under
+# the store. `pnpm store prune` then errors with `ENOENT: scandir '.../files'`
+# and (because bin/compile runs with `set -o errexit`) fails the build.
+#
+# The fixture pins `pnpm@9.7.1` deliberately: pnpm fixed this in 9.12.0
+# (pnpm/pnpm#8555), so bumping the version here would silently turn this
+# into a smoke test and stop guarding against regressions in the
+# lib/dependencies.sh workaround.
+testPnpmStorePruneWithEmptyStore() {
+  cache_dir=$(mktmpdir)
+
+  # force the next compile to enter the prune branch
+  mkdir -p "$cache_dir"
+  echo "0" > "$cache_dir/pnpm_prune_store_counter"
+
+  compile "pnpm-empty-deps" "$cache_dir"
+  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+  assertCaptured "Cleaning up pnpm store"
+  assertNotCaptured "ENOENT"
+  assertCapturedSuccess
+
+  # the counter should still advance past 0 after the benign ENOENT
+  counter=$(<"$cache_dir/pnpm_prune_store_counter")
+  assertNotEquals "Expected pnpm prune store counter to no longer be 0; was <${counter}>" "0" "${counter}"
+}
+
+
 testPnpmCacheSimple() {
   cache_dir=$(mktmpdir)
   compile "pnpm-7-pnp" "$cache_dir"


### PR DESCRIPTION
## Summary

- `pnpm store prune` errors with `ENOENT: ... scandir '<store>/v*/files'` on pnpm <9.12.0 when the store has no fetched package files (e.g. an install that resolves with no external dependencies). pnpm only creates that directory on first download.
- Fix tolerates the specific `ENOENT-on-scandir` failure during prune as a benign empty-store no-op; every other prune failure still surfaces.
- Fixed upstream in pnpm/pnpm#8555 (released in pnpm 9.12.0); workaround can be removed when the buildpack's minimum supported pnpm is >= 9.12.0.

## Affected pnpm versions (matrix verified locally)

| pnpm version | empty-install `pnpm store prune` |
| --- | --- |
| 7.33.7 | ❌ ENOENT, exit 1 |
| 8.15.9 | ❌ ENOENT, exit 254 |
| 9.7.1 (customer) | ❌ ENOENT, exit 254 |
| 9.11.0 | ❌ ENOENT, exit 254 |
| **9.12.0** | ✅ exit 0 — pnpm/pnpm#8555 lands |
| 10.x, 11.x | ✅ exit 0 |

W-22776243