### PR TITLE
Fix Release workflow auto-trigger skipping on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,20 @@ jobs:
     # On `pull_request`, only run for the merged auto-generated
     # "Prepare release" PR (branch name set by
     # _classic-buildpack-prepare-release.yml). Manual dispatches always run.
+    #
+    # We intentionally do NOT gate on `head.repo.full_name == github.repository`.
+    # This repo has `delete_branch_on_merge` enabled, and the `prepare-release`
+    # branch is deleted as part of the merge. On the `closed` event the head
+    # branch is already gone, so `pull_request.head.repo` is `null` in the
+    # payload (it is schema-nullable: `head.repo` is `oneOf [repository, null]`,
+    # see https://github.com/octokit/webhooks/blob/main/payload-schemas/api.github.com/common/pull-request.schema.json).
+    # A `null.full_name` comparison short-circuits the whole `&&` to false and
+    # the job silently skips. The `head.ref == 'prepare-release'` +
+    # bot-author checks already scope this tightly (fork PRs can't access
+    # secrets/OIDC on `pull_request` anyway), so the cross-repo check is redundant.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.head.ref == 'prepare-release' &&
        github.event.pull_request.user.login == 'heroku-linguist[bot]')
     uses: heroku/languages-github-actions/.github/workflows/_classic-buildpack-publish.yml@latest


### PR DESCRIPTION
The OIDC-based Release workflow added in #1653 did not auto-publish when the first `Prepare release` PR (#1659, v351) merged — the job silently **skipped**.

## Root cause

The job-level `if` guard included:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

This repo has **`delete_branch_on_merge` enabled**, so the `prepare-release` branch is deleted as part of the merge. On the `pull_request: closed` event the head branch is already gone, and **`pull_request.head.repo` comes back `null`** in the payload.

`head.repo` is officially nullable in GitHub's webhook payload schema — it is defined as `oneOf [repository, null]`:

> https://github.com/octokit/webhooks/blob/main/payload-schemas/api.github.com/common/pull-request.schema.json
> ```json
> "repo": { "oneOf": [ { "$ref": "repository.schema.json" }, { "type": "null" } ] }
> ```

(octokit/webhooks is the source of truth GitHub generates its webhook docs from.)

When `head.repo` is `null`, `head.repo.full_name` evaluates to `null`, `null == "heroku/heroku-buildpack-nodejs"` is `false`, and the entire `&&` chain short-circuits — so the `Release / Publish` job skips with zero steps.

### Evidence from the v351 release

- Run [`26904885080`](https://github.com/heroku/heroku-buildpack-nodejs/actions/runs/26904885080): fired on `pull_request` for `prepare-release`, `triggering_actor: heroku-linguist[bot]`, `conclusion: skipped` (2s, no steps).
- The `prepare-release` branch returns `404` (auto-deleted on merge).
- `release.yml` is byte-identical on `main` and the merge commit, ruling out a stale-workflow issue.
- This was the workflow's **first** auto-trigger attempt — #1653 merged ~1 min before the prepare branch was cut, so the `pull_request` path had never been exercised (prior successful runs were all `workflow_dispatch`).

## Fix

Drop the redundant `head.repo.full_name == github.repository` check. The remaining guards already scope the auto-trigger tightly:

- `head.ref == 'prepare-release'` — only the bot-generated prepare branch
- `user.login == 'heroku-linguist[bot]'` — only the release bot

Fork PRs on `pull_request` cannot access secrets/OIDC anyway, so the cross-repo check added no real protection.