### PR TITLE
Post Honeycomb release marker on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,4 @@ jobs:
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       slack_webhook_url: ${{ secrets.BUILDPACK_RELEASE_FAILURE_WEBHOOK_URL }}
+      honeycomb_api_key: ${{ secrets.HONEYCOMB_API_KEY }}


### PR DESCRIPTION
Passes the `HONEYCOMB_API_KEY` secret through to the shared `_classic-buildpack-publish.yml@latest` workflow as `honeycomb_api_key`, enabling a Honeycomb release marker on the `builds` dataset for each production publish of this classic buildpack.

The shared workflow support landed in heroku/languages-github-actions#369 (released in `v1.11.0`, which `@latest` now resolves to), and this repo's `HONEYCOMB_API_KEY` secret is configured — so once this PR merges, the marker step posts to the `builds` dataset on each production publish. The step is a safe no-op in any context where the secret is absent — it is gated on `env.HONEYCOMB_API_KEY != '' && env.MODE == 'production'` and declared `required: false` in the shared workflow.

## What

- Adds `honeycomb_api_key: ${{ secrets.HONEYCOMB_API_KEY }}` to the `release` job's `secrets:` block, forwarding the repo secret to the shared workflow's optional input.

The marker behavior (opt-in, production-only, idempotent, best-effort) lives in the shared workflow — see #369 for details.

W-22846373
