### PR TITLE
Rename release workflow and drop QA dispatch input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Buildpack
 
 on:
   # Auto-trigger when the "Prepare release" PR (created by the
@@ -9,12 +9,6 @@ on:
     types:
       - closed
   workflow_dispatch:
-    inputs:
-      qa:
-        description: "QA mode (staging registry, -qa tag suffix, draft releases)"
-        required: true
-        default: true
-        type: boolean
 
 permissions:
   id-token: write
@@ -35,6 +29,3 @@ jobs:
     uses: heroku/languages-github-actions/.github/workflows/_classic-buildpack-publish.yml@latest
     with:
       buildpack_id: "heroku/nodejs"
-      # `inputs.qa` is unset on `pull_request`, so coerce to false — auto-triggered
-      # publishes always go to production. Manual dispatches pass the input through.
-      qa: ${{ inputs.qa || false }}


### PR DESCRIPTION
Follow-up to #1653 applying review feedback that landed on the still-open Python caller (heroku/heroku-buildpack-python#2099):

- Rename the workflow to "Release Buildpack" for consistency with the CNB release workflows.
- Remove the `workflow_dispatch` `qa` input. QA staging publishes remain an optional feature of the reusable `_classic-buildpack-publish.yml` (the `qa` input is `required: false`, defaults to `false`), so QA can be exercised from a test buildpack when needed rather than exposed on every classic buildpack caller.
- Drop the now-unused `qa` `with:` input.

W-22295409