### PR TITLE
chore: add .editorconfig and .shellcheckrc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# https://editorconfig.org
+root = true
+
+# Baseline for every file. Intentionally omits indent_style so editors don't reformat the
+# indentation of files that haven't been migrated yet.
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Migrated shell files (kept in sync with the makefile's MIGRATED_FILES list). Tabs are used
+# so here-documents can be indented:
+# https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Documents
+[{lib/failures.sh,lib/package_managers/*.sh}]
+binary_next_line = true
+indent_style = tab
+shell_variant = bash
+switch_case_indent = true
+
+[Makefile]
+indent_style = tab
+
+[*.{js,cjs,mjs,ts,json}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,toml}]
+indent_style = space
+indent_size = 2

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+# Enable all checks, including the optional ones that are off by default.
+enable=all


### PR DESCRIPTION
This is the first of three stacked PRs introducing a Python-buildpack-style error-handling and lint framework to the classic Node.js buildpack. Splitting the foundational tooling from the bash logic keeps each diff small and reviewable.

This PR adds only editor/lint configuration, with no runtime or CI behavior change:

- `.editorconfig` documents the file conventions the migration relies on — tabs for the shell files being migrated to the new framework (so here-documents can be indented) and the existing 2-space style for JS/JSON/YAML/TOML. The strict tab block is scoped to migrated paths rather than a blanket `[*.sh]` so editors don't reformat un-migrated scripts on save.
- `.shellcheckrc` sets `enable=all` so the migrated files are linted under the strictest ShellCheck ruleset.

The tab block references `lib/failures.sh` and `lib/package_managers/*.sh`, which arrive in a later PR; EditorConfig globs are harmless until those files exist.

W-23025817