### PR TITLE
ci: add shellcheck/shfmt lint tooling and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,20 @@ env:
   NO_COLOR: 1
 
 jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install shfmt
+        run: |
+          SHFMT_VERSION=v3.10.0
+          curl -fsSL -o /usr/local/bin/shfmt \
+            "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
+          chmod +x /usr/local/bin/shfmt
+      - name: Lint migrated files
+        run: make lint
+
   unit-test:
     runs-on: ubuntu-24.04
     container:

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ lint: lint-scripts check-format
 
 lint-scripts:
 	@if [ -n "$(strip $(MIGRATED_FILES))" ]; then \
-		shellcheck --check-sourced --color=always $(MIGRATED_FILES); \
+		shellcheck --check-sourced $(MIGRATED_FILES); \
 	else \
 		echo "lint-scripts: no migrated files yet"; \
 	fi
@@ -42,12 +42,6 @@ build-resolver-linux: .build
 	mv ./resolve-version/target/x86_64-unknown-linux-musl/release/resolve-version lib/vendor/resolve-version-linux
 
 test: heroku-22-build heroku-24-build heroku-26-build
-
-shellcheck:
-	@shellcheck -x bin/compile bin/detect bin/release bin/test bin/test-compile
-	@shellcheck -x lib/*.sh
-	@shellcheck -x ci-profile/**
-	@shellcheck -x etc/**
 
 # Use `make -j4 heroku-26-build` to run all suites in parallel.
 # Ctrl-C cleanly terminates all parallel jobs when using make -j.

--- a/makefile
+++ b/makefile
@@ -1,3 +1,34 @@
+# Files migrated to tabs + shellcheck enable=all + namespace::function naming.
+# Add a file here only once it passes `make lint` cleanly. This list is the single
+# source of truth for what gets linted/formatted (CI invokes these targets, it does
+# not maintain its own list). It is empty until the first file is migrated.
+MIGRATED_FILES =
+
+.PHONY: lint lint-scripts check-format format
+
+lint: lint-scripts check-format
+
+lint-scripts:
+	@if [ -n "$(strip $(MIGRATED_FILES))" ]; then \
+		shellcheck --check-sourced --color=always $(MIGRATED_FILES); \
+	else \
+		echo "lint-scripts: no migrated files yet"; \
+	fi
+
+check-format:
+	@if [ -n "$(strip $(MIGRATED_FILES))" ]; then \
+		shfmt --diff $(MIGRATED_FILES); \
+	else \
+		echo "check-format: no migrated files yet"; \
+	fi
+
+format:
+	@if [ -n "$(strip $(MIGRATED_FILES))" ]; then \
+		shfmt --write --list $(MIGRATED_FILES); \
+	else \
+		echo "format: no migrated files yet"; \
+	fi
+
 build-resolvers: build-resolver-linux
 
 .build:


### PR DESCRIPTION
Second of three stacked PRs for the error-handling and lint-tooling migration. This one establishes the lint infrastructure so the bash-logic PR that follows can be gated by CI from its first commit.

> Stacked on #1669 — review/merge that first. The diff against `main` will shrink to just this PR's changes once #1669 lands.

The buildpack has no enforced shell linting today (the legacy `make shellcheck` target is unused and already non-green). This PR adds an opt-in, per-file linting path so the migration can roll out incrementally with green CI throughout:

- A `MIGRATED_FILES` allowlist in the makefile is the single source of truth for what gets linted and formatted. It starts **empty** — files are added to it only once they pass cleanly, in the subsequent migration PR.
- `lint` / `lint-scripts` / `check-format` / `format` make targets wrap `shellcheck --check-sourced` and `shfmt`. Each guards against an empty allowlist so `make lint` is a green no-op until the first file is migrated (rather than erroring on missing input files).
- A CI `lint` job installs `shfmt` (ubuntu-24.04 ships `shellcheck`) and runs `make lint`. CI owns no file list of its own — it just invokes the target.

W-23025951