### PR TITLE
Remove "Build succeeded!" log line from build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Removed the `Build succeeded!` log line from the build output. In multi-buildpack builds this misleadingly implied the entire build had succeeded when only the Node.js buildpack had finished. ([#1672](https://github.com/heroku/heroku-buildpack-nodejs/pull/1672))
+
 
 ## [v353] - 2026-06-15
 

--- a/bin/compile
+++ b/bin/compile
@@ -585,7 +585,6 @@ build_data::set_string "build_step" "install-metrics-plugin"
 install_plugin "$BP_DIR" "$BUILD_DIR"
 
 build_data::set_string "build_step" "summarize"
-header "Build succeeded!" | output "$LOG_FILE"
 summarize_build | output "$LOG_FILE"
 build_data::set_duration "build_time" "$build_start_time"
 

--- a/spec/ci/multi_buildpack_spec.rb
+++ b/spec/ci/multi_buildpack_spec.rb
@@ -8,7 +8,6 @@ describe "Multi-buildpack pnpm" do
     ]
     Hatchet::Runner.new("spec/fixtures/repos/multi-buildpack-pnpm-rails", buildpacks: buildpacks, stack: "heroku-24").deploy do |app|
       output = clean_output(app.output)
-      expect(output).to include("Build succeeded!")
       expect(output).not_to include("ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY")
       expect(output).to match(/npm_config_store_dir=/)
     end

--- a/test/run-general
+++ b/test/run-general
@@ -270,7 +270,6 @@ testDotHerokuCollision() {
   assertCapturedError
 
   compile "dot-heroku-collision-2"
-  assertCaptured "Build succeeded!"
   assertNotCaptured ".heroku file is checked into this project"
   assertCapturedSuccessWithWarnings
 }


### PR DESCRIPTION
In multi-buildpack builds, the Node.js classic buildpack emits a `Build succeeded!` line when it finishes. With other buildpacks still to run, this misleadingly signals that the *entire* build has succeeded when in fact only the Node.js buildpack has completed.

Per-buildpack enter/exit messaging is better owned by cytokine so it stays consistent across buildpacks, so this line is removed here rather than reworded.

W-22919168