### PR TITLE
Inline multiple-lockfiles fix steps into build error (cover pnpm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Removed the `Build succeeded!` log line from the build output. In multi-buildpack builds this misleadingly implied the entire build had succeeded when only the Node.js buildpack had finished. ([#1672](https://github.com/heroku/heroku-buildpack-nodejs/pull/1672))
-
+- Improved the multiple-lockfiles build error message: it now inlines actionable, per-package-manager fix steps (covering npm, Yarn, and pnpm) instead of linking out to a knowledge base article. ([#1673](https://github.com/heroku/heroku-buildpack-nodejs/pull/1673))
 
 ## [v353] - 2026-06-15
 

--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -109,6 +109,36 @@ fail_iojs_unsupported() {
   fi
 }
 
+# Builds the "keep one, remove the rest" fix instructions for a multiple-lockfiles error.
+# Given the detected package manager names as arguments (e.g. "npm" "pnpm" "Yarn"), it prints
+# one block per package manager listing the exact `git rm` command needed to remove the other
+# lockfiles, so the advice is specific to the lockfiles actually present in the application.
+multiple_lockfiles_fix_steps() {
+  local managers=("$@")
+
+  declare -A lockfiles=(
+    ["npm"]="package-lock.json"
+    ["pnpm"]="pnpm-lock.yaml"
+    ["Yarn"]="yarn.lock"
+  )
+
+  local keep other remove
+  for keep in "${managers[@]}"; do
+    remove=()
+    for other in "${managers[@]}"; do
+      if [ "$other" != "$keep" ]; then
+        remove+=("${lockfiles["$other"]}")
+      fi
+    done
+
+    echo "       If you use $keep:"
+    echo "       \$ git rm ${remove[*]}"
+    echo "       \$ git commit -m \"Remove unused lockfiles\""
+    echo "       \$ git push heroku main"
+    echo ""
+  done
+}
+
 fail_multiple_lockfiles() {
   local build_dir="${1:-}"
   local has_modern_lockfile=false
@@ -135,16 +165,22 @@ fail_multiple_lockfiles() {
     warn "Multiple lockfiles found
 
        Multiple package managers ($(IFS=','; printf '%s' "${package_managers_sorted[*]}")) have created lockfiles for this application,
-       but only one can be used to install dependencies. Installing dependencies using the wrong package manager can result in missing
-       packages or subtle bugs in production.
+       but only one can be used to install dependencies. This usually happens when a project standardizes on one
+       package manager, but a dependency is later added with a different one and the extra lockfile is committed.
+       Installing dependencies with the wrong package manager can result in missing packages or subtle, hard to
+       debug bugs in production.
 
-       Only one of the following package manager lockfiles are supported at a time:
-       - ${lockfiles["npm"]}
-       - ${lockfiles["Yarn"]}
-       - ${lockfiles["pnpm"]}
+       Only one of the following package manager lockfiles is supported at a time:
+       - ${lockfiles["npm"]} (npm)
+       - ${lockfiles["Yarn"]} (Yarn)
+       - ${lockfiles["pnpm"]} (pnpm)
 
-       Please delete the lockfile(s) that should not be in use.
-    " https://help.heroku.com/0KU2EM53
+       Keep the lockfile for the package manager you use and delete the rest, then commit and redeploy:
+
+$(multiple_lockfiles_fix_steps "${package_managers_sorted[@]}")
+
+       To stop the extra lockfiles from being committed again, add them to your .gitignore file.
+    "
     fail
   fi
 
@@ -159,13 +195,15 @@ fail_multiple_lockfiles() {
        can result in missing packages or subtle bugs in production.
 
        Please make sure there is only one of the following files in your
-       application directory:
+       application directory, then commit and redeploy:
 
        - yarn.lock
        - pnpm-lock.yaml
        - package-lock.json
        - npm-shrinkwrap.json
-    " https://help.heroku.com/0KU2EM53
+
+       To stop the extra lockfiles from being committed again, add them to your .gitignore file.
+    "
     fail
   fi
 }

--- a/test/run-general
+++ b/test/run-general
@@ -189,7 +189,10 @@ testErrorYarnAndNpmLockfiles() {
   assertNotCaptured "Creating runtime environment"
   assertCaptured "Multiple lockfiles found"
   assertCaptured "Multiple package managers (npm,Yarn) have created lockfiles for this application"
-  assertCaptured "https://help.heroku.com/0KU2EM53"
+  assertCaptured "If you use npm:"
+  assertCaptured "git rm yarn.lock"
+  assertCaptured "If you use Yarn:"
+  assertCaptured "git rm package-lock.json"
   assertCapturedError
 }
 
@@ -198,7 +201,6 @@ testErrorYarnAndNpmShrinkwrap() {
   compile "yarn-and-shrinkwrap-lockfiles"
   assertNotCaptured "Creating runtime environment"
   assertCaptured "Multiple lockfiles conflicting with npm-shrinkwrap.json"
-  assertCaptured "https://help.heroku.com/0KU2EM53"
   assertCapturedError
 }
 
@@ -208,7 +210,8 @@ testErrorYarnAndPnpmAndNpmLockfiles() {
   assertNotCaptured "Creating runtime environment"
   assertCaptured "Multiple lockfiles found"
   assertCaptured "Multiple package managers (npm,pnpm,Yarn) have created lockfiles for this application"
-  assertCaptured "https://help.heroku.com/0KU2EM53"
+  assertCaptured "If you use pnpm:"
+  assertCaptured "git rm package-lock.json yarn.lock"
   assertCapturedError
 }
 

--- a/test/unit
+++ b/test/unit
@@ -486,6 +486,49 @@ testGetYarnMajorVersionNoVersion() {
   rm -rf "$build_dir"
 }
 
+testMultipleLockfilesFixStepsTwoManagers() {
+  local expected
+  expected="$(cat <<-'EOF'
+       If you use npm:
+       $ git rm yarn.lock
+       $ git commit -m "Remove unused lockfiles"
+       $ git push heroku main
+
+       If you use Yarn:
+       $ git rm package-lock.json
+       $ git commit -m "Remove unused lockfiles"
+       $ git push heroku main
+
+EOF
+)"
+
+  assertEquals "$expected" "$(multiple_lockfiles_fix_steps npm Yarn)"
+}
+
+testMultipleLockfilesFixStepsThreeManagers() {
+  local expected
+  expected="$(cat <<-'EOF'
+       If you use npm:
+       $ git rm pnpm-lock.yaml yarn.lock
+       $ git commit -m "Remove unused lockfiles"
+       $ git push heroku main
+
+       If you use pnpm:
+       $ git rm package-lock.json yarn.lock
+       $ git commit -m "Remove unused lockfiles"
+       $ git push heroku main
+
+       If you use Yarn:
+       $ git rm package-lock.json pnpm-lock.yaml
+       $ git commit -m "Remove unused lockfiles"
+       $ git push heroku main
+
+EOF
+)"
+
+  assertEquals "$expected" "$(multiple_lockfiles_fix_steps npm pnpm Yarn)"
+}
+
 BP_DIR="$(pwd)"
 
 # the modules to be tested
@@ -500,6 +543,7 @@ source "$(pwd)"/lib/output.sh
 source "$(pwd)"/lib/kvstore.sh
 source "$(pwd)"/lib/features.sh
 source "$(pwd)"/lib/yarn-2.sh
+source "$(pwd)"/lib/failure.sh
 source "$(pwd)"/profile/WEB_CONCURRENCY.sh
 
 # testing utils


### PR DESCRIPTION
When a build fails with multiple package-manager lockfiles, the error pointed users at KB article help.heroku.com/0KU2EM53 for the fix. That article predates pnpm support and never mentioned it, so pnpm users hit a dead end, and the link is an extra web request that LLMs and offline readers can't follow.

This inlines the guidance directly into the error message so it's self-contained and covers all three package managers. Rather than a generic example, the message now lists the exact `git rm` command for each lockfile actually detected in the app — e.g. "If you use npm: git rm pnpm-lock.yaml yarn.lock". Once this ships, KB article 0KU2EM53 can be archived.

The per-manager step generation is extracted into a `multiple_lockfiles_fix_steps()` helper so it can be unit tested in isolation.

Fixes W-22919167