### PR TITLE
Add npm 12 install-block error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Added Node.js 26.4.0 (linux-amd64)
+- Added clearer `npm install` build errors for npm 12's new install-blocking defaults: blocked install scripts (`ESTRICTALLOWSCRIPTS`), git dependencies (`EALLOWGIT`), and remote-URL dependencies (`EALLOWREMOTE`), with guidance on approving scripts or adjusting `.npmrc`. ([#1683](https://github.com/heroku/heroku-buildpack-nodejs/pull/1683))
 
 ## [v355] - 2026-06-24
 

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -240,6 +240,29 @@ function npm::_handle_npm_install_failure() {
 		return 0
 	fi
 
+	# npm EALLOWREMOTE — new in npm 12. Remote-URL/tarball dependencies (direct or transitive) are
+	# refused unless allow-remote is set. Error code is `EALLOW${TYPE}` from arborist.
+	if grep -qiE 'npm (ERR!|error) code EALLOWREMOTE' "${log_file}"; then
+		__failure["id"]="npm-allow-remote-blocked"
+		__failure["classification"]="user"
+		__failure["detail"]="EALLOWREMOTE: $(npm::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: Unable to install dependencies using npm.
+
+				npm refused to fetch a dependency that points to a remote URL (e.g. an
+				https tarball), because remote dependencies are disabled by default in
+				npm 12+. Check the log output above for the offending package.
+
+				Either replace it with a published registry version, or set "allow-remote"
+				in your .npmrc to permit it.
+
+				Docs: https://docs.npmjs.com/cli/v11/using-npm/config#allow-remote
+			EOF
+		)
+		return 0
+	fi
+
 	# TODO: classify additional npm codes present in error-message.js but not yet handled here,
 	# e.g. ETARGET (no matching version), ERESOLVE (dependency conflict), ENOSPC (disk full).
 	# Add each as its own matcher above, verified against npm source per the version-spread loop.

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -193,6 +193,30 @@ function npm::_handle_npm_install_failure() {
 		return 0
 	fi
 
+	# npm ESTRICTALLOWSCRIPTS — new in npm 12. Install scripts are blocked unless covered by the
+	# "allowScripts" policy in package.json. Code surfaces on the `npm error code <CODE>` line.
+	if grep -qiE 'npm (ERR!|error) code ESTRICTALLOWSCRIPTS' "${log_file}"; then
+		__failure["id"]="npm-strict-allow-scripts"
+		__failure["classification"]="user"
+		__failure["detail"]="ESTRICTALLOWSCRIPTS: $(npm::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: Unable to install dependencies using npm.
+
+				npm blocked one or more dependency install scripts because they are not
+				covered by the "allowScripts" policy in your package.json. Native modules
+				that compile on install (e.g. via node-gyp) will not be built until you
+				approve them.
+
+				Run \`npm approve-scripts <package>\` locally to review and allow the trusted
+				packages listed above, then commit the updated package.json and redeploy.
+
+				Docs: https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts
+			EOF
+		)
+		return 0
+	fi
+
 	# TODO: classify additional npm codes present in error-message.js but not yet handled here,
 	# e.g. ETARGET (no matching version), ERESOLVE (dependency conflict), ENOSPC (disk full).
 	# Add each as its own matcher above, verified against npm source per the version-spread loop.

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -217,6 +217,29 @@ function npm::_handle_npm_install_failure() {
 		return 0
 	fi
 
+	# npm EALLOWGIT — new in npm 12. Git dependencies (direct or transitive) are refused unless
+	# allow-git is set. Error code is `EALLOW${TYPE}` from arborist build-ideal-tree.js.
+	if grep -qiE 'npm (ERR!|error) code EALLOWGIT' "${log_file}"; then
+		__failure["id"]="npm-allow-git-blocked"
+		__failure["classification"]="user"
+		__failure["detail"]="EALLOWGIT: $(npm::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: Unable to install dependencies using npm.
+
+				npm refused to fetch a dependency that points to a git repository, because
+				git dependencies are disabled by default in npm 12+. Check the log output
+				above for the offending package.
+
+				Either replace it with a published registry version, or set "allow-git" in
+				your .npmrc to permit it.
+
+				Docs: https://docs.npmjs.com/cli/v11/using-npm/config#allow-git
+			EOF
+		)
+		return 0
+	fi
+
 	# TODO: classify additional npm codes present in error-message.js but not yet handled here,
 	# e.g. ETARGET (no matching version), ERESOLVE (dependency conflict), ENOSPC (disk full).
 	# Add each as its own matcher above, verified against npm source per the version-spread loop.

--- a/test/unit
+++ b/test/unit
@@ -656,6 +656,16 @@ testHandleNpmInstallFlatmapStream() {
   assertContains "${result[message]}" "flatmap-stream module has been removed"
 }
 
+testHandleNpmInstallStrictAllowScripts() {
+  local -A result
+  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/estrictallowscripts.log" result
+  assertEquals "classifier should return 0 on a match" "0" "$?"
+  assertEquals "npm-strict-allow-scripts" "${result[id]}"
+  assertEquals "user" "${result[classification]}"
+  assertContains "${result[detail]}" "ESTRICTALLOWSCRIPTS:"
+  assertContains "${result[message]}" "npm approve-scripts"
+}
+
 testHandleNpmInstallNoMatchReturnsNonZero() {
   local -A result
   # `clean.log` is a successful install; the classifier should not match and should leave the

--- a/test/unit
+++ b/test/unit
@@ -675,6 +675,15 @@ testHandleNpmInstallAllowGitBlocked() {
   assertContains "${result[message]}" "git repository"
 }
 
+testHandleNpmInstallAllowRemoteBlocked() {
+  local -A result
+  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowremote.log" result
+  assertEquals "npm-allow-remote-blocked" "${result[id]}"
+  assertContains "${result[detail]}" "EALLOWREMOTE:"
+  assertEquals "user" "${result[classification]}"
+  assertContains "${result[message]}" "remote URL"
+}
+
 testHandleNpmInstallNoMatchReturnsNonZero() {
   local -A result
   # `clean.log` is a successful install; the classifier should not match and should leave the

--- a/test/unit
+++ b/test/unit
@@ -666,6 +666,15 @@ testHandleNpmInstallStrictAllowScripts() {
   assertContains "${result[message]}" "npm approve-scripts"
 }
 
+testHandleNpmInstallAllowGitBlocked() {
+  local -A result
+  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowgit.log" result
+  assertEquals "npm-allow-git-blocked" "${result[id]}"
+  assertContains "${result[detail]}" "EALLOWGIT:"
+  assertEquals "user" "${result[classification]}"
+  assertContains "${result[message]}" "git repository"
+}
+
 testHandleNpmInstallNoMatchReturnsNonZero() {
   local -A result
   # `clean.log` is a successful install; the classifier should not match and should leave the

--- a/test/unit-fixtures/npm-failures/eallowgit.log
+++ b/test/unit-fixtures/npm-failures/eallowgit.log
@@ -1,0 +1,4 @@
+npm error code EALLOWGIT
+npm error Fetching packages of type "git" have been disabled
+npm error Refusing to fetch "is-positive@github:kevva/is-positive"
+npm error A complete log of this run can be found in: /root/.npm/_logs/2026-06-16T00_00_00_000Z-debug-0.log

--- a/test/unit-fixtures/npm-failures/eallowremote.log
+++ b/test/unit-fixtures/npm-failures/eallowremote.log
@@ -1,0 +1,3 @@
+npm error code EALLOWREMOTE
+npm error Fetching packages of type "remote" have been disabled
+npm error A complete log of this run can be found in: /root/.npm/_logs/2026-06-16T00_00_00_000Z-debug-0.log

--- a/test/unit-fixtures/npm-failures/estrictallowscripts.log
+++ b/test/unit-fixtures/npm-failures/estrictallowscripts.log
@@ -1,0 +1,5 @@
+npm error code ESTRICTALLOWSCRIPTS
+npm error --strict-allow-scripts: 1 package(s) have install scripts not covered by allowScripts:
+npm error   bcrypt@5.1.1 (install: (install scripts present))
+npm error Approve them with `npm approve-scripts`, deny them with `npm deny-scripts`, or bypass this check with `--dangerously-allow-all-scripts`.
+npm error A complete log of this run can be found in: /root/.npm/_logs/2026-06-16T00_00_00_000Z-debug-0.log


### PR DESCRIPTION
npm 12 turns three previously-permissive install behaviors into hard, install-blocking errors by default: install scripts (`ESTRICTALLOWSCRIPTS`), git dependencies (`EALLOWGIT`), and remote-URL/tarball dependencies (`EALLOWREMOTE`). Once npm 12 reaches users' builds, apps relying on any of these will start failing at `npm install`/`npm ci` with npm's terse error codes and no Heroku-specific guidance.

This teaches the buildpack's npm failure classifier to recognize each of the three codes and surface a clear, actionable build error — pointing users at `npm approve-scripts` for blocked scripts and at the relevant `.npmrc` settings for git/remote dependencies — so they can opt specific dependencies back in rather than hitting an opaque failure. This deliberately matches npm's intent (guide users to grant explicit permission) instead of disabling the new protections buildpack-wide.

Fixes W-23160933
