### PR TITLE
Route Node.js download & checksum failures through failure::emit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Migrated Node.js version-resolution build errors (unresolvable version, invalid semver requirement) onto the call-site failure-classification framework. The error messages are unchanged. ([#1687](https://github.com/heroku/heroku-buildpack-nodejs/pull/1687))
+- Migrated Node.js download and checksum-validation build errors onto the failure-classification framework, and removed the obsolete AWS proxy (`NO_PROXY=amazonaws.com`) build warning, which dated to when Node.js binaries were served from an S3 mirror. ([#1688](https://github.com/heroku/heroku-buildpack-nodejs/pull/1688))
 
 ## [v356] - 2026-06-25
 

--- a/bin/compile
+++ b/bin/compile
@@ -111,7 +111,6 @@ handle_failure() {
     fail_yarn_lockfile_outdated "$LOG_FILE"
     fail_yarn_install "$LOG_FILE" "$BUILD_DIR"
     log_other_failures "$LOG_FILE"
-    warn_aws_proxy "$BUILD_DIR"
     warn_untracked_dependencies "$LOG_FILE"
     warn_angular_resolution "$LOG_FILE"
     warn_missing_devdeps "$LOG_FILE" "$BUILD_DIR"

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -740,12 +740,6 @@ warn() {
   echo ""
 }
 
-warn_aws_proxy() {
-  if { [[ -n "$HTTP_PROXY" ]] || [[ -n "$HTTPS_PROXY" ]]; } && [[ "$NO_PROXY" != "amazonaws.com" ]]; then
-    warn "Your build may fail if NO_PROXY is not set to amazonaws.com" "https://devcenter.heroku.com/articles/troubleshooting-node-deploys#aws-proxy-error"
-  fi
-}
-
 warn_node_engine() {
   local node_engine=${1:-}
   if [ "$node_engine" == "" ]; then

--- a/lib/runtimes/nodejs.sh
+++ b/lib/runtimes/nodejs.sh
@@ -109,23 +109,7 @@ function runtimes::nodejs::_install() {
 
 	output_file="/tmp/node.tar.gz"
 	if ! curl "${download_url}" --no-progress-meter --location --fail --max-time 30 --retry 5 --retry-connrefused --connect-timeout 5 -o "${output_file}"; then
-		build_data::set_string "failure" "node-download-failed"
-		output::error <<-EOF
-			Error: Unable to download Node.js.
-
-			Failed to download Node.js from:
-			${download_url}
-
-			In some cases, this happens due to a temporary network
-			issue or an outage with the Node.js distribution server.
-
-			Confirm the download url ({url}) works then try building again
-			to see if the error resolves itself.
-
-			If that doesn't help, check the Node.js status page:
-			https://status.nodejs.org/
-		EOF
-		return 1
+		runtimes::nodejs::_fail_node_download "${download_url}"
 	fi
 
 	if [[ -z "${NODE_BINARY_URL}" ]]; then
@@ -133,19 +117,11 @@ function runtimes::nodejs::_install() {
 		"sha256")
 			echo "Validating checksum"
 			if ! echo "${checksum_value} ${output_file}" | sha256sum --check --status; then
-				build_data::set_string "failure" "checksum-validation-failed"
-				output::error <<-EOF
-					Checksum validation failed for Node.js ${version} - ${checksum_type}:${checksum_value}
-				EOF
-				return 1
+				runtimes::nodejs::_fail_checksum_validation "${version}" "${checksum_type}" "${checksum_value}"
 			fi
 			;;
 		*)
-			build_data::set_string "failure" "unsupported-checksum"
-			output::error <<-EOF
-				Unsupported checksum for Node.js ${version} - ${checksum_type}:${checksum_value}
-			EOF
-			return 1
+			runtimes::nodejs::_fail_unsupported_checksum "${version}" "${checksum_type}" "${checksum_value}"
 			;;
 		esac
 	fi
@@ -199,6 +175,69 @@ function runtimes::nodejs::_warn_known_bad_release() {
 		pinning to an earlier version of Node.js (e.g.; 22.4.1).
 		https://github.com/nodejs/node/pull/53934
 	EOF
+}
+
+# Emits the classified failure for a Node.js download error and exits. Called directly at the
+# failure site (not via the log classifier) because the buildpack already knows exactly what
+# failed here — no log inspection is needed to identify it.
+function runtimes::nodejs::_fail_node_download() {
+	local download_url="${1}"
+	local -A failure
+	failure["id"]="node-download-failed"
+	failure["classification"]="buildpack"
+	failure["detail"]="${download_url}"
+	failure["message"]=$(
+		cat <<-EOF
+			Error: Unable to download Node.js.
+
+			Failed to download Node.js from:
+			${download_url}
+
+			In some cases, this happens due to a temporary network
+			issue or an outage with the Node.js distribution server.
+
+			Confirm the download url (${download_url}) works then try building again
+			to see if the error resolves itself.
+
+			If that doesn't help, check the Node.js status page:
+			https://status.nodejs.org/
+		EOF
+	)
+	failure::emit failure
+}
+
+# Emits the classified failure for a Node.js checksum mismatch and exits. See
+# runtimes::nodejs::_fail_node_download for why this is called directly at the failure site.
+function runtimes::nodejs::_fail_checksum_validation() {
+	local version="${1}"
+	local checksum_type="${2}"
+	local checksum_value="${3}"
+	local -A failure
+	failure["id"]="checksum-validation-failed"
+	failure["classification"]="buildpack"
+	failure["message"]=$(
+		cat <<-EOF
+			Checksum validation failed for Node.js ${version} - ${checksum_type}:${checksum_value}
+		EOF
+	)
+	failure::emit failure
+}
+
+# Emits the classified failure for an unsupported Node.js checksum type and exits. See
+# runtimes::nodejs::_fail_node_download for why this is called directly at the failure site.
+function runtimes::nodejs::_fail_unsupported_checksum() {
+	local version="${1}"
+	local checksum_type="${2}"
+	local checksum_value="${3}"
+	local -A failure
+	failure["id"]="unsupported-checksum"
+	failure["classification"]="buildpack"
+	failure["message"]=$(
+		cat <<-EOF
+			Unsupported checksum for Node.js ${version} - ${checksum_type}:${checksum_value}
+		EOF
+	)
+	failure::emit failure
 }
 
 # Pure classifier for Node.js install failures.

--- a/lib/runtimes/nodejs.sh
+++ b/lib/runtimes/nodejs.sh
@@ -116,8 +116,10 @@ function runtimes::nodejs::_install() {
 		case "${checksum_type}" in
 		"sha256")
 			echo "Validating checksum"
-			if ! echo "${checksum_value} ${output_file}" | sha256sum --check --status; then
-				runtimes::nodejs::_fail_checksum_validation "${version}" "${checksum_type}" "${checksum_value}"
+			local actual_checksum
+			actual_checksum=$(sha256sum "${output_file}" | cut -d " " -f 1)
+			if [[ "${actual_checksum}" != "${checksum_value}" ]]; then
+				runtimes::nodejs::_fail_checksum_validation "${version}" "${checksum_type}" "${checksum_value}" "${actual_checksum}"
 			fi
 			;;
 		*)
@@ -212,9 +214,11 @@ function runtimes::nodejs::_fail_checksum_validation() {
 	local version="${1}"
 	local checksum_type="${2}"
 	local checksum_value="${3}"
+	local actual_checksum="${4}"
 	local -A failure
 	failure["id"]="checksum-validation-failed"
 	failure["classification"]="buildpack"
+	failure["detail"]="${checksum_type} expected:${checksum_value} actual:${actual_checksum}"
 	failure["message"]=$(
 		cat <<-EOF
 			Checksum validation failed for Node.js ${version} - ${checksum_type}:${checksum_value}
@@ -232,6 +236,7 @@ function runtimes::nodejs::_fail_unsupported_checksum() {
 	local -A failure
 	failure["id"]="unsupported-checksum"
 	failure["classification"]="buildpack"
+	failure["detail"]="${checksum_type}:${checksum_value}"
 	failure["message"]=$(
 		cat <<-EOF
 			Unsupported checksum for Node.js ${version} - ${checksum_type}:${checksum_value}

--- a/test/run-general
+++ b/test/run-general
@@ -217,16 +217,6 @@ testErrorYarnAndPnpmAndNpmLockfiles() {
 }
 
 
-testWarnAwsProxyHttps() {
-  env_dir=$(mktmpdir)
-  echo "http://localhost:5001" > $env_dir/HTTPS_PROXY
-  compile "node-14" "$(mktmpdir)" $env_dir
-  assertCaptured "Your build may fail if NO_PROXY is not set to amazonaws.com"
-  assertCapturedError
-}
-
-
-
 testWarnNoStart() {
   compile "no-start"
   assertCaptured "may not specify any way to start"

--- a/test/unit
+++ b/test/unit
@@ -764,11 +764,13 @@ testFailChecksumValidationEmitsDetailedMessage() {
   local out capture
   capture=$(mktemp)
   _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_checksum_validation "20.0.0" "sha256" "abc123"
+    runtimes::nodejs::_fail_checksum_validation "20.0.0" "sha256" "abc123" "def456"
 
   assertContains "$out" "Checksum validation failed for Node.js 20.0.0 - sha256:abc123"
   assertContains "$(cat "$capture")" "failure=checksum-validation-failed"
   assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  # Detail records both the expected and the actual (mismatched) checksum for observability.
+  assertContains "$(cat "$capture")" "failure_detail=sha256 expected:abc123 actual:def456"
   rm -f "$capture"
 }
 
@@ -781,6 +783,7 @@ testFailUnsupportedChecksumEmitsDetailedMessage() {
   assertContains "$out" "Unsupported checksum for Node.js 20.0.0 - sha512:abc123"
   assertContains "$(cat "$capture")" "failure=unsupported-checksum"
   assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  assertContains "$(cat "$capture")" "failure_detail=sha512:abc123"
   rm -f "$capture"
 }
 

--- a/test/unit
+++ b/test/unit
@@ -728,6 +728,62 @@ testHandleNodeInstallInvalidSemver() {
   assertEquals "stable" "${result[detail]}"
 }
 
+# Captures build_data writes and emitted message for one of the runtimes::nodejs::_fail_*
+# functions, which emit a classified failure directly at the failure site (see Design B). Runs
+# in a subshell with `fail`/`build_data::set_string` stubbed so emit doesn't kill the runner.
+# Usage: _capture_node_fail <out_var> <capture_file> <fn> [args...]
+_capture_node_fail() {
+  local out_var="$1"
+  local capture="$2"
+  shift 2
+  printf -v "$out_var" '%s' "$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >> "$capture"; }
+    "$@" 2>&1 || true
+  )"
+}
+
+testFailNodeDownloadEmitsDetailedMessage() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::_fail_node_download "https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
+
+  # The detailed, verbatim message reaches the user via failure::emit.
+  assertContains "$out" "Error: Unable to download Node.js."
+  assertContains "$out" "https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
+  assertContains "$out" "https://status.nodejs.org/"
+  # Classification + detail are recorded as build data.
+  assertContains "$(cat "$capture")" "failure=node-download-failed"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  assertContains "$(cat "$capture")" "failure_detail=https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
+  rm -f "$capture"
+}
+
+testFailChecksumValidationEmitsDetailedMessage() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::_fail_checksum_validation "20.0.0" "sha256" "abc123"
+
+  assertContains "$out" "Checksum validation failed for Node.js 20.0.0 - sha256:abc123"
+  assertContains "$(cat "$capture")" "failure=checksum-validation-failed"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  rm -f "$capture"
+}
+
+testFailUnsupportedChecksumEmitsDetailedMessage() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::_fail_unsupported_checksum "20.0.0" "sha512" "abc123"
+
+  assertContains "$out" "Unsupported checksum for Node.js 20.0.0 - sha512:abc123"
+  assertContains "$(cat "$capture")" "failure=unsupported-checksum"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  rm -f "$capture"
+}
+
 testExtractErrorDetailReturnsFirstDescriptiveLine() {
   # Skips the bare `code <CODE>` line and the "complete log" noise, strips the
   # `npm error `/`npm ERR! ` prefix (but keeps any keyword like `notsup` that follows).


### PR DESCRIPTION
Completes Phase 1 of the migration. Node.js binary download failures and checksum-validation failures now emit through `failure::emit` directly at the failure site, recording structured failure metadata (including the actual mismatched checksum) for observability. The detailed user-facing messages are preserved, and a latent uninterpolated `{url}` placeholder in the download error is fixed.

This also removes the AWS proxy build warning that advised setting `NO_PROXY=amazonaws.com`. That advice dates to when Node.js binaries were served from an S3 mirror (added in #782); downloads now come directly from nodejs.org, so the warning pointed users at a host the build never contacts.

Third of three stacked PRs; based on #1687.

W-23231098