### PR TITLE
Relocate the pnpm install command into lib/package_managers/pnpm.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,6 +30,8 @@ source "$BP_DIR/lib/environment.sh"
 source "$BP_DIR/lib/failures.sh"
 # shellcheck source=lib/package_managers/npm.sh
 source "$BP_DIR/lib/package_managers/npm.sh"
+# shellcheck source=lib/package_managers/pnpm.sh
+source "$BP_DIR/lib/package_managers/pnpm.sh"
 # shellcheck source=lib/_failures.sh
 source "$BP_DIR/lib/_failures.sh"
 # shellcheck source=lib/runtimes/nodejs.sh
@@ -510,7 +512,7 @@ build_dependencies() {
   elif $YARN; then
     yarn_node_modules "$BUILD_DIR"
   elif $PNPM; then
-    pnpm_install "$BUILD_DIR" "$CACHE_DIR"
+    package_managers::pnpm::install_dependencies "$BUILD_DIR" "$CACHE_DIR"
   elif $PREBUILD; then
     echo "Prebuild detected (node_modules already exists)"
     npm_rebuild "$BUILD_DIR"

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -275,53 +275,6 @@ npm_prune_devdependencies() {
   fi
 }
 
-pnpm_install() {
-  local build_dir=${1:-}
-  local cache_dir=${2:-}
-
-  echo "Running 'pnpm install' with pnpm-lock.yaml"
-  cd "$build_dir" || return
-
-  pnpm_install_args=("install" "--prod=false" "--frozen-lockfile")
-
-  if [ -n "$PNPM_INSTALL_REPORTER" ]; then
-    case "$PNPM_INSTALL_REPORTER" in
-      default|ndjson|append-only|silent)
-        pnpm_install_args+=("--reporter=$PNPM_INSTALL_REPORTER")
-        ;;
-      *)
-        echo "Warning: Invalid PNPM_INSTALL_REPORTER value '$PNPM_INSTALL_REPORTER'. Valid values: default, ndjson, append-only, silent"
-        echo "Proceeding with default reporter"
-        ;;
-    esac
-  fi
-
-  monitor "install_dependencies" pnpm "${pnpm_install_args[@]}" 2>&1
-
-  # prune the store when the counter reaches zero to clean up errant package versions which may have been upgraded/removed
-  counter=$(load_pnpm_prune_store_counter "$cache_dir")
-  if (( counter == 0 )); then
-    echo "Cleaning up pnpm store"
-    # pnpm <9.12.0 errors with `ENOENT: ... scandir '<store>/v*/files'`
-    # when the store has no fetched package files (e.g. an install with
-    # no external dependencies), because pnpm only creates that
-    # directory on first download. Treat any ENOENT-on-scandir of the
-    # store's `vN/files` directory during prune as a benign empty-store
-    # no-op; surface every other failure so we don't mask unrelated
-    # prune errors. Fixed upstream in pnpm/pnpm#8555.
-    # TODO: remove when minimum supported pnpm is >= 9.12.0.
-    local prune_output prune_exit=0
-    prune_output=$(mktemp)
-    trap "rm -f '$prune_output' >/dev/null" RETURN
-    pnpm store prune >"$prune_output" 2>&1 || prune_exit=$?
-    if (( prune_exit != 0 )) && ! grep -qE "ENOENT.*scandir" "$prune_output"; then
-      cat "$prune_output"
-      return "$prune_exit"
-    fi
-  fi
-  save_pnpm_prune_store_counter "$cache_dir" "$(( counter - 1 ))"
-}
-
 pnpm_prune_devdependencies() {
   local build_dir=${1:-}
 

--- a/lib/package_managers/pnpm.sh
+++ b/lib/package_managers/pnpm.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Enable strict mode for ShellCheck but restore the caller's options at the end of the file
+# (see epilogue) so they don't bleed into un-migrated scripts that source this lib. The
+# caller's flags are read from `$-` (the current shell); a `$(set +o)` capture runs in a
+# command-substitution subshell where bash always forces errexit off, so it would later
+# restore errexit as disabled even when the caller had it on. pipefail has no `$-` letter, so
+# it is captured separately (it is reported correctly inside command substitution).
+# shellcheck disable=SC2034 # both are consumed by the epilogue
+__pnpm_saved_flags="$-"
+__pnpm_saved_pipefail="$(set +o | grep pipefail)"
+set -euo pipefail
+
+package_managers::pnpm::install_dependencies() {
+	local build_dir=${1:-}
+	local cache_dir=${2:-}
+
+	echo "Running 'pnpm install' with pnpm-lock.yaml"
+	cd "${build_dir}" || return
+
+	pnpm_install_args=("install" "--prod=false" "--frozen-lockfile")
+
+	if [[ -n "${PNPM_INSTALL_REPORTER}" ]]; then
+		case "${PNPM_INSTALL_REPORTER}" in
+			default | ndjson | append-only | silent)
+				pnpm_install_args+=("--reporter=${PNPM_INSTALL_REPORTER}")
+				;;
+			*)
+				echo "Warning: Invalid PNPM_INSTALL_REPORTER value '${PNPM_INSTALL_REPORTER}'. Valid values: default, ndjson, append-only, silent"
+				echo "Proceeding with default reporter"
+				;;
+		esac
+	fi
+
+	monitor "install_dependencies" pnpm "${pnpm_install_args[@]}" 2>&1
+
+	# prune the store when the counter reaches zero to clean up errant package versions which may have been upgraded/removed
+	counter=$(load_pnpm_prune_store_counter "${cache_dir}")
+	if ((counter == 0)); then
+		echo "Cleaning up pnpm store"
+		# pnpm <9.12.0 errors with `ENOENT: ... scandir '<store>/v*/files'`
+		# when the store has no fetched package files (e.g. an install with
+		# no external dependencies), because pnpm only creates that
+		# directory on first download. Treat any ENOENT-on-scandir of the
+		# store's `vN/files` directory during prune as a benign empty-store
+		# no-op; surface every other failure so we don't mask unrelated
+		# prune errors. Fixed upstream in pnpm/pnpm#8555.
+		# TODO: remove when minimum supported pnpm is >= 9.12.0.
+		local prune_output prune_exit=0
+		prune_output=$(mktemp)
+		# shellcheck disable=SC2064 # expand prune_output now so the RETURN trap removes this exact temp file
+		trap "rm -f '${prune_output}' >/dev/null" RETURN
+		pnpm store prune >"${prune_output}" 2>&1 || prune_exit=$?
+		if ((prune_exit != 0)) && ! grep -qE "ENOENT.*scandir" "${prune_output}"; then
+			cat "${prune_output}"
+			return "${prune_exit}"
+		fi
+	fi
+	save_pnpm_prune_store_counter "${cache_dir}" "$((counter - 1))"
+}
+
+# Restore the sourcing shell's original options (see preamble). errexit/nounset come from the
+# saved `$-`; pipefail from its own saved `set +o` line.
+case "${__pnpm_saved_flags}" in *e*) set -e ;; *) set +e ;; esac
+case "${__pnpm_saved_flags}" in *u*) set -u ;; *) set +u ;; esac
+eval "${__pnpm_saved_pipefail}"
+unset __pnpm_saved_flags __pnpm_saved_pipefail

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@
 MIGRATED_FILES = \
 	lib/failures.sh \
 	lib/package_managers/npm.sh \
+	lib/package_managers/pnpm.sh \
 	lib/runtimes/nodejs.sh
 
 .PHONY: lint lint-scripts check-format format

--- a/test/unit
+++ b/test/unit
@@ -918,6 +918,7 @@ source "$(pwd)"/lib/json.sh
 source "$(pwd)"/lib/json.sh
 source "$(pwd)"/lib/failures.sh
 source "$(pwd)"/lib/package_managers/npm.sh
+source "$(pwd)"/lib/package_managers/pnpm.sh
 source "$(pwd)"/lib/runtimes/nodejs.sh
 source "$(pwd)"/lib/monitor.sh
 source "$(pwd)"/lib/output.sh


### PR DESCRIPTION
The classic buildpack's error handling is being migrated off the legacy global \`ERR\` trap and onto call-site failure classification, one command at a time. Before a command's error handling can be reworked, the command itself has to live in a file that is opted into \`shfmt\` and \`shellcheck enable=all\` and carries the strict-mode preamble/epilogue that migrated libs use.

This relocates the \`pnpm install\` command into its own migrated lib, \`lib/package_managers/pnpm.sh\`, as \`package_managers::pnpm::install_dependencies\`, so a follow-up change can move its failure handling onto the \`failure::emit\` framework. It is deliberately behavior-neutral: the command is lifted verbatim, renamed to the folder-mirroring namespace, its single call site updated, and the file registered in \`MIGRATED_FILES\`. No error-handling logic changes here and user-facing messages are unchanged.

W-23369552