### PR TITLE
refactor: namespace npm.sh functions as package_managers::npm::

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -515,7 +515,7 @@ build_dependencies() {
     echo "Prebuild detected (node_modules already exists)"
     npm_rebuild "$BUILD_DIR"
   else
-    npm::install_dependencies "$BUILD_DIR"
+    package_managers::npm::install_dependencies "$BUILD_DIR"
   fi
 
   build_data::set_string "build_step" "build-script"

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -770,7 +770,7 @@ warn_old_npm() {
 
   npm_version="$(npm --version)"
 
-  if [ "$(npm_version_major)" -lt "2" ]; then
+  if [ "$(package_managers::npm::version_major)" -lt "2" ]; then
     # Emit immediately rather than via warning(), whose $warnings buffer is only flushed by
     # failure_message on a failed build — so a migrated failure that bypasses the legacy
     # handler, or a successful build, would never surface this warning.
@@ -788,7 +788,7 @@ warn_old_npm_lockfile() {
 
   npm_version="$(npm --version)"
 
-  if $npm_lock && [ "$(npm_version_major)" -lt "5" ]; then
+  if $npm_lock && [ "$(package_managers::npm::version_major)" -lt "5" ]; then
     warn "This version of npm ($npm_version) does not support package-lock.json. Please
        update your npm version in package.json." "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
   fi

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -50,7 +50,7 @@ install_npm() {
 
   # If the user has not specified a version of npm, but has an npm lockfile
   # upgrade them to npm 5.x if a suitable version was not installed with Node
-  if $npm_lock && [ "$version" == "" ] && [ "$(npm_version_major)" -lt "5" ]; then
+  if $npm_lock && [ "$version" == "" ] && [ "$(package_managers::npm::version_major)" -lt "5" ]; then
     echo "Detected package-lock.json: defaulting npm to version 5.x.x"
     version="5.x.x"
   fi

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -198,7 +198,7 @@ should_use_npm_ci() {
   local major
 
   npm_version=$(npm --version)
-  major=$(npm_version_major)
+  major=$(package_managers::npm::version_major)
 
   # We should only run `npm ci` if all of the manifest files are there, and we are running at least npm 6.x
   # `npm ci` was introduced in the 5.x line in 5.7.0, but this sees very little usage, < 5% of builds

--- a/lib/failures.sh
+++ b/lib/failures.sh
@@ -13,7 +13,7 @@ __failures_saved_pipefail="$(set +o | grep pipefail)"
 set -euo pipefail
 
 # Records a classified failure in build data, prints its message, and exits the build. This is
-# the only side-effecting layer; classifiers (e.g. npm::_handle_npm_install_failure) stay pure
+# the only side-effecting layer; classifiers (e.g. package_managers::npm::_handle_npm_install_failure) stay pure
 # by filling an associative array that is passed here by name.
 #
 # The named array may define:

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -14,11 +14,11 @@ set -euo pipefail
 # Installs app dependencies with npm (fresh install path; the prebuild/rebuild path is
 # still handled by lib/dependencies.sh until it is migrated).
 #
-# On failure, the captured output is run through npm::_handle_npm_install_failure and, if a
+# On failure, the captured output is run through package_managers::npm::_handle_npm_install_failure and, if a
 # known failure mode is recognised, failure::emit renders the message, records the
 # classification, and exits. Otherwise a generic npm-install failure is emitted so the build
 # never falls through silently.
-function npm::install_dependencies() {
+function package_managers::npm::install_dependencies() {
 	local build_dir="${1}"
 	local production="${NPM_CONFIG_PRODUCTION:-false}"
 
@@ -84,7 +84,7 @@ function npm::install_dependencies() {
 				EOF
 			)
 			failure::emit failure
-		elif npm::_handle_npm_install_failure "${log_file}" failure; then
+		elif package_managers::npm::_handle_npm_install_failure "${log_file}" failure; then
 			# The classifier fills `failure` by nameref and returns 0 on a match. It is invoked
 			# directly in the `elif` condition (not wrapped in `$(...)`) so its writes survive — a
 			# command substitution runs in a subshell where the nameref updates would be lost.
@@ -115,7 +115,7 @@ function npm_version_major() {
 # the array untouched otherwise. Has no side effects: it does not write build data, print to
 # the build log, or exit. Detail is set to the npm error code plus the first descriptive
 # error line, giving observability a precise discriminator within each failure bucket.
-function npm::_handle_npm_install_failure() {
+function package_managers::npm::_handle_npm_install_failure() {
 	local log_file="${1}"
 	# shellcheck disable=SC2178 # nameref alias to the caller's associative array, not a string
 	local -n __failure="${2}"
@@ -124,7 +124,7 @@ function npm::_handle_npm_install_failure() {
 	if grep -qiE 'npm (ERR!|error) code EBADPLATFORM($| )' "${log_file}"; then
 		__failure["id"]="npm-ebadplatform"
 		__failure["classification"]="user"
-		__failure["detail"]="EBADPLATFORM: $(npm::_extract_error_detail "${log_file}")"
+		__failure["detail"]="EBADPLATFORM: $(package_managers::npm::_extract_error_detail "${log_file}")"
 		__failure["message"]=$(
 			cat <<-EOF
 				Error: Unable to install dependencies using npm.
@@ -142,7 +142,7 @@ function npm::_handle_npm_install_failure() {
 	if grep -qiE 'npm (ERR!|error) code EINVALIDPACKAGENAME($| )' "${log_file}"; then
 		__failure["id"]="npm-package-name-typo"
 		__failure["classification"]="user"
-		__failure["detail"]="EINVALIDPACKAGENAME: $(npm::_extract_error_detail "${log_file}")"
+		__failure["detail"]="EINVALIDPACKAGENAME: $(package_managers::npm::_extract_error_detail "${log_file}")"
 		__failure["message"]=$(
 			cat <<-EOF
 				Error: Unable to install dependencies using npm.
@@ -163,7 +163,7 @@ function npm::_handle_npm_install_failure() {
 		if grep -qi "flatmap-stream" "${log_file}"; then
 			__failure["id"]="flatmap-stream-404"
 			__failure["classification"]="user"
-			__failure["detail"]="E404: $(npm::_extract_error_detail "${log_file}")"
+			__failure["detail"]="E404: $(package_managers::npm::_extract_error_detail "${log_file}")"
 			__failure["message"]=$(
 				cat <<-EOF
 					Error: The flatmap-stream module has been removed from the npm registry.
@@ -180,7 +180,7 @@ function npm::_handle_npm_install_failure() {
 
 		__failure["id"]="module-404"
 		__failure["classification"]="user"
-		__failure["detail"]="E404: $(npm::_extract_error_detail "${log_file}")"
+		__failure["detail"]="E404: $(package_managers::npm::_extract_error_detail "${log_file}")"
 		__failure["message"]=$(
 			cat <<-EOF
 				Error: Unable to install dependencies using npm.
@@ -198,7 +198,7 @@ function npm::_handle_npm_install_failure() {
 	if grep -qiE 'npm (ERR!|error) code ESTRICTALLOWSCRIPTS' "${log_file}"; then
 		__failure["id"]="npm-strict-allow-scripts"
 		__failure["classification"]="user"
-		__failure["detail"]="ESTRICTALLOWSCRIPTS: $(npm::_extract_error_detail "${log_file}")"
+		__failure["detail"]="ESTRICTALLOWSCRIPTS: $(package_managers::npm::_extract_error_detail "${log_file}")"
 		__failure["message"]=$(
 			cat <<-EOF
 				Error: Unable to install dependencies using npm.
@@ -222,7 +222,7 @@ function npm::_handle_npm_install_failure() {
 	if grep -qiE 'npm (ERR!|error) code EALLOWGIT' "${log_file}"; then
 		__failure["id"]="npm-allow-git-blocked"
 		__failure["classification"]="user"
-		__failure["detail"]="EALLOWGIT: $(npm::_extract_error_detail "${log_file}")"
+		__failure["detail"]="EALLOWGIT: $(package_managers::npm::_extract_error_detail "${log_file}")"
 		__failure["message"]=$(
 			cat <<-EOF
 				Error: Unable to install dependencies using npm.
@@ -245,7 +245,7 @@ function npm::_handle_npm_install_failure() {
 	if grep -qiE 'npm (ERR!|error) code EALLOWREMOTE' "${log_file}"; then
 		__failure["id"]="npm-allow-remote-blocked"
 		__failure["classification"]="user"
-		__failure["detail"]="EALLOWREMOTE: $(npm::_extract_error_detail "${log_file}")"
+		__failure["detail"]="EALLOWREMOTE: $(package_managers::npm::_extract_error_detail "${log_file}")"
 		__failure["message"]=$(
 			cat <<-EOF
 				Error: Unable to install dependencies using npm.
@@ -274,8 +274,8 @@ function npm::_handle_npm_install_failure() {
 # Returns the first descriptive npm error line for use as failure detail: the first
 # `npm error`/`npm ERR!` line that carries a human message, skipping the bare `code <CODE>`
 # line and the trailing "complete log" noise, with the prefix and indentation stripped.
-# Internal helper to npm::_handle_npm_install_failure; not meant to be called directly.
-function npm::_extract_error_detail() {
+# Internal helper to package_managers::npm::_handle_npm_install_failure; not meant to be called directly.
+function package_managers::npm::_extract_error_detail() {
 	local log_file="${1}"
 	grep -iE 'npm (ERR!|error) ' "${log_file}" \
 		| grep -ivE 'npm (ERR!|error) code ' \

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -102,7 +102,7 @@ function package_managers::npm::install_dependencies() {
 	build_data::set_duration "install_dependencies_time" "${start}"
 }
 
-function npm_version_major() {
+function package_managers::npm::version_major() {
 	npm --version | cut -d "." -f 1
 }
 

--- a/test/unit
+++ b/test/unit
@@ -626,7 +626,7 @@ testFailuresLibDoesNotLeakErrexit() {
 
 testHandleNpmInstallEbadplatform() {
   local -A result
-  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log" result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log" result
   assertEquals "classifier should return 0 on a match" "0" "$?"
   assertEquals "npm-ebadplatform" "${result[id]}"
   assertEquals "user" "${result[classification]}"
@@ -637,28 +637,28 @@ testHandleNpmInstallEbadplatform() {
 
 testHandleNpmInstallInvalidName() {
   local -A result
-  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/einvalidpackagename.log" result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/einvalidpackagename.log" result
   assertEquals "npm-package-name-typo" "${result[id]}"
   assertContains "${result[detail]}" "EINVALIDPACKAGENAME:"
 }
 
 testHandleNpmInstall404() {
   local -A result
-  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/e404.log" result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/e404.log" result
   assertEquals "module-404" "${result[id]}"
   assertContains "${result[detail]}" "E404:"
 }
 
 testHandleNpmInstallFlatmapStream() {
   local -A result
-  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/flatmap-stream.log" result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/flatmap-stream.log" result
   assertEquals "flatmap-stream-404" "${result[id]}"
   assertContains "${result[message]}" "flatmap-stream module has been removed"
 }
 
 testHandleNpmInstallStrictAllowScripts() {
   local -A result
-  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/estrictallowscripts.log" result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/estrictallowscripts.log" result
   assertEquals "classifier should return 0 on a match" "0" "$?"
   assertEquals "npm-strict-allow-scripts" "${result[id]}"
   assertEquals "user" "${result[classification]}"
@@ -668,7 +668,7 @@ testHandleNpmInstallStrictAllowScripts() {
 
 testHandleNpmInstallAllowGitBlocked() {
   local -A result
-  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowgit.log" result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowgit.log" result
   assertEquals "npm-allow-git-blocked" "${result[id]}"
   assertContains "${result[detail]}" "EALLOWGIT:"
   assertEquals "user" "${result[classification]}"
@@ -677,7 +677,7 @@ testHandleNpmInstallAllowGitBlocked() {
 
 testHandleNpmInstallAllowRemoteBlocked() {
   local -A result
-  npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowremote.log" result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowremote.log" result
   assertEquals "npm-allow-remote-blocked" "${result[id]}"
   assertContains "${result[detail]}" "EALLOWREMOTE:"
   assertEquals "user" "${result[classification]}"
@@ -688,7 +688,7 @@ testHandleNpmInstallNoMatchReturnsNonZero() {
   local -A result
   # `clean.log` is a successful install; the classifier should not match and should leave the
   # array empty. Guard the call so set -e (if active) doesn't abort on the expected non-zero.
-  if npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/clean.log" result; then
+  if package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/clean.log" result; then
     fail "expected classifier to return non-zero for an unrecognised log"
   fi
   assertEquals "array should be left empty on no match" "" "${result[id]:-}"
@@ -896,14 +896,14 @@ testExtractErrorDetailReturnsFirstDescriptiveLine() {
   # Skips the bare `code <CODE>` line and the "complete log" noise, strips the
   # `npm error `/`npm ERR! ` prefix (but keeps any keyword like `notsup` that follows).
   local detail
-  detail=$(npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log")
+  detail=$(package_managers::npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log")
   assertEquals "notsup Unsupported platform for fsevents@2.3.3: wanted {\"os\":\"darwin\",\"arch\":\"any\"} (current: {\"os\":\"linux\",\"arch\":\"x64\"})" "$detail"
 }
 
 testExtractErrorDetailEmptyWhenNoDescriptiveLine() {
   # A log with no `npm error`/`npm ERR!` line at all yields empty detail without erroring.
   local detail
-  detail=$(npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/clean.log")
+  detail=$(package_managers::npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/clean.log")
   assertEquals "" "$detail"
 }
 


### PR DESCRIPTION
During the error-handling migration, the functions in `lib/package_managers/npm.sh` were given a bare `npm::` namespace that doesn't match the file's path. The convention for files in `MIGRATED_FILES` is `namespace::function` naming that mirrors the path — `package_managers::pnpm::install_dependencies` already does this. This aligns every function in `npm.sh` so the namespace is predictable from the file location and consistent across package managers.

The rename covers `install_dependencies` and its failure-classifier helpers, and also `npm_version_major` — that one is unrelated to error handling, but it lives in a migrated file, so it follows the same convention. Its callers in the still-un-migrated `lib/dependencies.sh`, `lib/binaries.sh`, and `lib/_failures.sh` are updated to point at the new name.

Purely a rename — no behavior changes.