### PR TITLE
Fix npm 12 build failure from removed --unsafe-perm flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `npm install` failing on npm 12, which removed the `--unsafe-perm` flag the buildpack was passing. ([#1704](https://github.com/heroku/heroku-buildpack-nodejs/pull/1704))
 - Relocated the npm binary installation (`npm@<version>` bootstrap) into `lib/package_managers/npm.sh` as part of the error-handling migration. This is a behavior-neutral move; the build errors and their messages are unchanged. ([#1701](https://github.com/heroku/heroku-buildpack-nodejs/pull/1701))
 - Improved the Node.js version-resolution build errors, and added error handling for previously-unclassified resolver failures. ([#1698](https://github.com/heroku/heroku-buildpack-nodejs/pull/1698))
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -7,6 +7,13 @@ install_yarn() {
   local version=${2:-1.22.x}
   local number url code resolve_result
 
+  # npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
+  # to the currently-active npm when that npm still accepts it.
+  local unsafe_perm=()
+  if package_managers::npm::supports_unsafe_perm; then
+    unsafe_perm=(--unsafe-perm)
+  fi
+
   if [[ -n "$YARN_BINARY_URL" ]]; then
     url="$YARN_BINARY_URL"
     echo "Downloading and installing yarn from $url"
@@ -19,7 +26,7 @@ install_yarn() {
 			EOF
       false
     fi
-    if ! suppress_output npm install --unsafe-perm --quiet --no-audit --no-progress -g "$package_name@$version"; then
+    if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "$package_name@$version"; then
       build_data::set_string "failure" "yarn-install-failed"
       output::error <<-EOF
 				Unable to install yarn $version.
@@ -42,7 +49,13 @@ install_yarn() {
 install_pnpm() {
   local version="$1"
   echo "Downloading and installing pnpm ($version)"
-  if ! suppress_output npm install --unsafe-perm --quiet --no-audit --no-progress -g "pnpm@$version"; then
+  # npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
+  # to the currently-active npm when that npm still accepts it.
+  local unsafe_perm=()
+  if package_managers::npm::supports_unsafe_perm; then
+    unsafe_perm=(--unsafe-perm)
+  fi
+  if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "pnpm@$version"; then
     build_data::set_string "failure" "pnpm-install-failed"
     output::error <<-EOF
 			Unable to install pnpm $version.

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -213,6 +213,13 @@ npm_rebuild() {
   local build_dir=${1:-}
   local production=${NPM_CONFIG_PRODUCTION:-false}
 
+  # npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
+  # to the currently-active npm when that npm still accepts it.
+  local unsafe_perm=()
+  if package_managers::npm::supports_unsafe_perm; then
+    unsafe_perm=(--unsafe-perm)
+  fi
+
   if [ -e "$build_dir/package.json" ]; then
     cd "$build_dir" || return
     echo "Rebuilding any native modules"
@@ -222,7 +229,7 @@ npm_rebuild() {
     else
       echo "Installing any new modules (package.json)"
     fi
-    monitor "npm_rebuild" npm install --production="$production" --unsafe-perm --userconfig "$build_dir/.npmrc" 2>&1
+    monitor "npm_rebuild" npm install --production="$production" "${unsafe_perm[@]}" --userconfig "$build_dir/.npmrc" 2>&1
   else
     echo "Skipping (no package.json)"
   fi

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -45,7 +45,11 @@ function package_managers::npm::install_dependencies() {
 		fi
 		npm_command+=(install)
 	fi
-	npm_command+=(--production="${production}" --unsafe-perm --userconfig "${build_dir}/.npmrc")
+	npm_command+=(--production="${production}" --userconfig "${build_dir}/.npmrc")
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside; a non-match just omits the flag
+	if package_managers::npm::supports_unsafe_perm; then
+		npm_command+=(--unsafe-perm)
+	fi
 
 	local log_file
 	log_file=$(mktemp)
@@ -104,6 +108,14 @@ function package_managers::npm::install_dependencies() {
 
 function package_managers::npm::version_major() {
 	npm --version | cut -d "." -f 1
+}
+
+# npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG. Returns 0 when the
+# active npm still accepts the flag (major < 12), 1 otherwise. Callers gate --unsafe-perm on this.
+function package_managers::npm::supports_unsafe_perm() {
+	local major
+	major="$(package_managers::npm::version_major)"
+	[[ "${major}" -lt 12 ]]
 }
 
 # Pure classifier for npm dependency-install failures.
@@ -325,6 +337,14 @@ function package_managers::npm::install_binary() {
 function package_managers::npm::_install_binary() {
 	local version="$1"
 
+	# The global installs below run with the currently-active (pre-bootstrap) npm, so gate
+	# --unsafe-perm on its version: npm 12 removed the flag and rejects it with EUNKNOWNCONFIG.
+	local unsafe_perm=()
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside; a non-match just omits the flag
+	if package_managers::npm::supports_unsafe_perm; then
+		unsafe_perm=(--unsafe-perm)
+	fi
+
 	# XXX: Workaround for https://github.com/heroku/heroku-buildpack-nodejs/issues/1590
 	# Node 22.22.2 fails to install npm >= 11.11.0 with a MODULE_NOT_FOUND error for `promise-retry`.
 	# Installing an intermediate npm version (~11.10.0) first avoids the issue.
@@ -347,7 +367,7 @@ function package_managers::npm::_install_binary() {
 		fi
 		if [[ "${major}" == "11" ]] && [[ "${minor}" -ge 11 ]]; then
 			echo "Installing npm@~11.10.0 to workaround Node.js 22.22.2 regression (https://github.com/npm/cli/issues/9151)"
-			if ! suppress_output npm install --unsafe-perm --quiet --no-audit --no-progress -g "npm@~11.10.0"; then
+			if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "npm@~11.10.0"; then
 				build_data::set_string "failure" "npm-node-22.22.2-workaround-failed"
 				output::error <<-EOF
 					Unable to install intermediate npm ~11.10.0 for Node.js 22.22.2 workaround.
@@ -359,7 +379,7 @@ function package_managers::npm::_install_binary() {
 		fi
 	fi
 
-	if ! suppress_output npm install --unsafe-perm --quiet --no-audit --no-progress -g "npm@${version}"; then
+	if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "npm@${version}"; then
 		build_data::set_string "failure" "npm-install-failed"
 		output::error <<-EOF
 			Unable to install npm ${version}.

--- a/test/fixtures/npm-12-unsafe-perm/package-lock.json
+++ b/test/fixtures/npm-12-unsafe-perm/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "npm-12-unsafe-perm",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-12-unsafe-perm",
+      "version": "1.0.0",
+      "dependencies": {
+        "@heroku/linewrap": "^1.0"
+      },
+      "engines": {
+        "node": "^24.15.0",
+        "npm": "12.x"
+      }
+    },
+    "node_modules/@heroku/linewrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@heroku/linewrap/-/linewrap-1.0.0.tgz",
+      "integrity": "sha512-qPeQp2DnALUwWKaL6ZXfnOw/lHp+zNg5V8whx5c/Y10HMWYjuQFqKupgoJgyuEYjnvYwoZTarW280+aOXWQLCQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/test/fixtures/npm-12-unsafe-perm/package.json
+++ b/test/fixtures/npm-12-unsafe-perm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "npm-12-unsafe-perm",
+  "version": "1.0.0",
+  "description": "Reproduces npm 12 --unsafe-perm removal (heroku/heroku-buildpack-nodejs#1702)",
+  "dependencies": {
+    "@heroku/linewrap": "^1.0"
+  },
+  "engines": {
+    "node": "^24.15.0",
+    "npm": "12.x"
+  }
+}

--- a/test/run-npm
+++ b/test/run-npm
@@ -164,6 +164,16 @@ testNode22Npm11BootstrapRegressionWorkaround() {
   assertCapturedSuccess
 }
 
+# https://github.com/heroku/heroku-buildpack-nodejs/issues/1702
+# npm 12 removed the --unsafe-perm flag; the buildpack must not pass it.
+testNpm12UnsafePermRemoved() {
+  compile "npm-12-unsafe-perm"
+  assertCaptured "npm 12"
+  assertNotCaptured "Unknown cli flag"
+  assertNotCaptured "EUNKNOWNCONFIG"
+  assertCapturedSuccess
+}
+
 testUserConfig() {
   compile "userconfig"
   assertCaptured "www.google.com"

--- a/test/unit
+++ b/test/unit
@@ -694,6 +694,26 @@ testHandleNpmInstallNoMatchReturnsNonZero() {
   assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
+# npm 12 removed --unsafe-perm; the gate helper decides whether callers may pass it. Stub `npm`
+# in a subshell so `version_major` reads a controlled version without a real npm install.
+testSupportsUnsafePermForNpm11() {
+  local rc
+  (
+    npm() { echo "11.16.0"; }
+    package_managers::npm::supports_unsafe_perm
+  ) && rc=0 || rc=$?
+  assertEquals "npm 11 should still support --unsafe-perm" "0" "${rc}"
+}
+
+testSupportsUnsafePermForNpm12() {
+  local rc
+  (
+    npm() { echo "12.0.0"; }
+    package_managers::npm::supports_unsafe_perm
+  ) && rc=0 || rc=$?
+  assertEquals "npm 12 should not support --unsafe-perm" "1" "${rc}"
+}
+
 testFailNoVersionResolvedEmitsDetailedMessage() {
   local out capture
   capture=$(mktemp)


### PR DESCRIPTION
npm 12 removed the `--unsafe-perm` CLI flag and now rejects it with
`EUNKNOWNCONFIG`. Any app that bootstraps npm 12 (e.g. Node 26 / `npm >=11`
on heroku-26) fails during dependency installation before its own scripts
run, so this affects unmodified apps purely because of the npm upgrade.

The buildpack now only passes `--unsafe-perm` to npm versions that still
accept it, restoring successful builds on npm 12 while leaving behavior
unchanged on older npm.

Fixes #1702, W-23381172