### PR TITLE
Relocate the yarn binary installation into lib/package_managers/yarn.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -32,6 +32,8 @@ source "$BP_DIR/lib/failures.sh"
 source "$BP_DIR/lib/package_managers/npm.sh"
 # shellcheck source=lib/package_managers/pnpm.sh
 source "$BP_DIR/lib/package_managers/pnpm.sh"
+# shellcheck source=lib/package_managers/yarn.sh
+source "$BP_DIR/lib/package_managers/yarn.sh"
 # shellcheck source=lib/_failures.sh
 source "$BP_DIR/lib/_failures.sh"
 # shellcheck source=lib/runtimes/nodejs.sh
@@ -323,7 +325,7 @@ install_bins() {
     build_data::set_string "build_step" "install-yarn"
     yarn_version="$(echo "$package_manager" | cut -d '@' -f 2 | cut -d "#" -f 1)"
     install_start=$(build_data::current_unix_realtime)
-    install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_version"
+    package_managers::yarn::install_binary "$BUILD_DIR/.heroku/yarn" "$yarn_version"
     build_data::set_duration "install_yarn_binary_time" "$install_start"
   else
     # Download yarn if there is a yarn.lock file or if the user
@@ -332,7 +334,7 @@ install_bins() {
     if $YARN || [ -n "$yarn_engine" ]; then
       build_data::set_string "build_step" "install-yarn"
       install_start=$(build_data::current_unix_realtime)
-      install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
+      package_managers::yarn::install_binary "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
       build_data::set_duration "install_yarn_binary_time" "$install_start"
     fi
   fi

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -2,50 +2,6 @@
 
 # Compiled from: https://github.com/heroku/buildpacks-nodejs/tree/main/crates/nodejs-data
 
-install_yarn() {
-  local dir="$1"
-  local version=${2:-1.22.x}
-  local number url code resolve_result
-
-  # npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
-  # to the currently-active npm when that npm still accepts it.
-  local unsafe_perm=()
-  if package_managers::npm::supports_unsafe_perm; then
-    unsafe_perm=(--unsafe-perm)
-  fi
-
-  if [[ -n "$YARN_BINARY_URL" ]]; then
-    url="$YARN_BINARY_URL"
-    echo "Downloading and installing yarn from $url"
-  else
-    echo "Downloading and installing yarn ($version)"
-    if ! package_name=$(determine_yarn_package_name "$version"); then
-      build_data::set_string "failure" "yarn-resolve-failed"
-      output::error <<-EOF
-				Unable to resolve yarn version '$version' via npm info
-			EOF
-      false
-    fi
-    if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "$package_name@$version"; then
-      build_data::set_string "failure" "yarn-install-failed"
-      output::error <<-EOF
-				Unable to install yarn $version.
-				Does yarn $version exist? (https://help.heroku.com/8MEL050H)
-				Is $version valid semver? (https://help.heroku.com/0ZIOF3ST)
-				Is yarn $version compatible with this Node.js version?
-			EOF
-      false
-    fi
-  fi
-  # Verify yarn works before capturing and ensure its stderr is inspectable later
-  suppress_output yarn --version
-  if $YARN_2; then
-    echo "Using yarn $(yarn --version)"
-  else
-    echo "Installed yarn $(yarn --version)"
-  fi
-}
-
 install_pnpm() {
   local version="$1"
   echo "Downloading and installing pnpm ($version)"
@@ -81,35 +37,4 @@ suppress_output() {
     return "$exit_code"
   }
   return 0
-}
-
-# Yarn 2+ (aka: "berry") is hosted under a different npm package so we need to do some
-# extra checking to determine the correct package name.
-determine_yarn_package_name() {
-  local version="$1"
-  local NPM_INFO_OUTPUT exit_code
-  NPM_INFO_OUTPUT=$(mktemp)
-
-  trap "rm -rf '$NPM_INFO_OUTPUT' >/dev/null" RETURN
-
-  npm info "yarn@$version" version >"$NPM_INFO_OUTPUT" 2>&1
-  exit_code=$?
-
-  if [[ $exit_code -eq 0 ]]; then
-    # There are a couple of 2.x versions in the yarn package list, but that should be okay
-    # since we're using npm to install the binaries. The previous inventory resolver never
-    # handled this case well.
-    echo "yarn"
-    return 0
-  fi
-
-  # If nothing is returned for the yarn package list for the given version, it must be @yarnpkg/cli-dist
-  if grep -q "E404" "$NPM_INFO_OUTPUT"; then
-    echo "@yarnpkg/cli-dist"
-    return 0
-  fi
-
-  # Handle unexpected output on stderr so it's not captured by command substitution
-  cat "$NPM_INFO_OUTPUT" >&2
-  return "$exit_code"
 }

--- a/lib/package_managers/yarn.sh
+++ b/lib/package_managers/yarn.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Enable strict mode for ShellCheck but restore the caller's options at the end of the file
+# (see epilogue) so they don't bleed into un-migrated scripts that source this lib. The
+# caller's flags are read from `$-` (the current shell); a `$(set +o)` capture runs in a
+# command-substitution subshell where bash always forces errexit off, so it would later
+# restore errexit as disabled even when the caller had it on. pipefail has no `$-` letter, so
+# it is captured separately (it is reported correctly inside command substitution).
+# shellcheck disable=SC2034 # both are consumed by the epilogue
+__yarn_saved_flags="$-"
+__yarn_saved_pipefail="$(set +o | grep pipefail)"
+set -euo pipefail
+
+function package_managers::yarn::install_binary() {
+	local dir="${1}"
+	local version=${2:-1.22.x}
+	local package_name url installed_version
+
+	# npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
+	# to the currently-active npm when that npm still accepts it.
+	local unsafe_perm=()
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside; a non-match just omits the flag
+	if package_managers::npm::supports_unsafe_perm; then
+		unsafe_perm=(--unsafe-perm)
+	fi
+
+	if [[ -n "${YARN_BINARY_URL}" ]]; then
+		url="${YARN_BINARY_URL}"
+		echo "Downloading and installing yarn from ${url}"
+	else
+		echo "Downloading and installing yarn (${version})"
+		# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
+		if ! package_name=$(package_managers::yarn::_determine_package_name "${version}"); then
+			build_data::set_string "failure" "yarn-resolve-failed"
+			output::error <<-EOF
+				Unable to resolve yarn version '${version}' via npm info
+			EOF
+			false
+		fi
+		if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "${package_name}@${version}"; then
+			build_data::set_string "failure" "yarn-install-failed"
+			output::error <<-EOF
+				Unable to install yarn ${version}.
+				Does yarn ${version} exist? (https://help.heroku.com/8MEL050H)
+				Is ${version} valid semver? (https://help.heroku.com/0ZIOF3ST)
+				Is yarn ${version} compatible with this Node.js version?
+			EOF
+			false
+		fi
+	fi
+	# Verify yarn works before capturing and ensure its stderr is inspectable later
+	suppress_output yarn --version
+	installed_version="$(yarn --version)"
+	# shellcheck disable=SC2154 # YARN_2 is a global set by the caller (bin/compile)
+	if ${YARN_2}; then
+		echo "Using yarn ${installed_version}"
+	else
+		echo "Installed yarn ${installed_version}"
+	fi
+}
+
+# Yarn 2+ (aka: "berry") is hosted under a different npm package so we need to do some
+# extra checking to determine the correct package name.
+function package_managers::yarn::_determine_package_name() {
+	local version="${1}"
+	local NPM_INFO_OUTPUT exit_code
+	NPM_INFO_OUTPUT=$(mktemp)
+
+	# shellcheck disable=SC2064 # expand NPM_INFO_OUTPUT now so the RETURN trap removes this exact temp file
+	trap "rm -rf '${NPM_INFO_OUTPUT}' >/dev/null" RETURN
+
+	npm info "yarn@${version}" version >"${NPM_INFO_OUTPUT}" 2>&1
+	exit_code=$?
+
+	if [[ ${exit_code} -eq 0 ]]; then
+		# There are a couple of 2.x versions in the yarn package list, but that should be okay
+		# since we're using npm to install the binaries. The previous inventory resolver never
+		# handled this case well.
+		echo "yarn"
+		return 0
+	fi
+
+	# If nothing is returned for the yarn package list for the given version, it must be @yarnpkg/cli-dist
+	if grep -q "E404" "${NPM_INFO_OUTPUT}"; then
+		echo "@yarnpkg/cli-dist"
+		return 0
+	fi
+
+	# Handle unexpected output on stderr so it's not captured by command substitution
+	cat "${NPM_INFO_OUTPUT}" >&2
+	return "${exit_code}"
+}
+
+# Restore the sourcing shell's original options (see preamble). errexit/nounset come from the
+# saved `$-`; pipefail from its own saved `set +o` line.
+case "${__yarn_saved_flags}" in *e*) set -e ;; *) set +e ;; esac
+case "${__yarn_saved_flags}" in *u*) set -u ;; *) set +u ;; esac
+eval "${__yarn_saved_pipefail}"
+unset __yarn_saved_flags __yarn_saved_pipefail

--- a/makefile
+++ b/makefile
@@ -6,6 +6,7 @@ MIGRATED_FILES = \
 	lib/failures.sh \
 	lib/package_managers/npm.sh \
 	lib/package_managers/pnpm.sh \
+	lib/package_managers/yarn.sh \
 	lib/runtimes/nodejs.sh
 
 .PHONY: lint lint-scripts check-format format

--- a/test/unit
+++ b/test/unit
@@ -624,6 +624,31 @@ testFailuresLibDoesNotLeakErrexit() {
   assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
 }
 
+testYarnLibDoesNotLeakShellOptions() {
+  # Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated yarn lib: sourcing
+  # it must restore the caller's nounset rather than leaving `set -u` on.
+  local nounset_after
+  nounset_after=$(
+    set +u
+    # shellcheck source=/dev/null
+    source "$(pwd)/lib/package_managers/yarn.sh"
+    set -o | awk '$1 == "nounset" { print $2 }'
+  )
+  assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
+}
+
+testYarnLibDoesNotLeakErrexit() {
+  # Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the yarn lib.
+  local errexit_after
+  errexit_after=$(
+    set -e
+    # shellcheck source=/dev/null
+    source "$(pwd)/lib/package_managers/yarn.sh"
+    case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
+  )
+  assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
+}
+
 testHandleNpmInstallEbadplatform() {
   local -A result
   package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log" result
@@ -939,6 +964,7 @@ source "$(pwd)"/lib/json.sh
 source "$(pwd)"/lib/failures.sh
 source "$(pwd)"/lib/package_managers/npm.sh
 source "$(pwd)"/lib/package_managers/pnpm.sh
+source "$(pwd)"/lib/package_managers/yarn.sh
 source "$(pwd)"/lib/runtimes/nodejs.sh
 source "$(pwd)"/lib/monitor.sh
 source "$(pwd)"/lib/output.sh


### PR DESCRIPTION
The error-handling migration reorganizes the buildpack's shell code by package
manager and opts each relocated file into `shellcheck --enable=all` + `shfmt`, so
that failure handling can later be moved to the call site one command at a time.

This moves the yarn binary install out of the catch-all `lib/binaries.sh` and into
`lib/package_managers/yarn.sh`, alongside the already-relocated npm and pnpm
commands. The functions are namespaced (`package_managers::yarn::*`) to mirror the
folder path, and the file joins the lint/format scope.

This is a behavior-neutral move: the install logic, build-data keys, and all
user-facing error messages are unchanged. The inline error handling is carried over
as-is; routing it through the failure-classification framework is left to a
follow-up.

W-23398752
