### PR TITLE
Relocate pnpm binary installation into lib/package_managers/pnpm.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -354,7 +354,7 @@ install_bins() {
     fi
 
     install_start=$(build_data::current_unix_realtime)
-    install_pnpm "$pnpm_version"
+    package_managers::pnpm::install_binary "$pnpm_version"
     build_data::set_duration "install_pnpm_binary_time" "$install_start"
     if [ "$using_default_pnpm" == true ]; then
       output::warning <<-EOF

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -2,30 +2,6 @@
 
 # Compiled from: https://github.com/heroku/buildpacks-nodejs/tree/main/crates/nodejs-data
 
-install_pnpm() {
-  local version="$1"
-  echo "Downloading and installing pnpm ($version)"
-  # npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
-  # to the currently-active npm when that npm still accepts it.
-  local unsafe_perm=()
-  if package_managers::npm::supports_unsafe_perm; then
-    unsafe_perm=(--unsafe-perm)
-  fi
-  if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "pnpm@$version"; then
-    build_data::set_string "failure" "pnpm-install-failed"
-    output::error <<-EOF
-			Unable to install pnpm $version.
-			Does pnpm $version exist? (https://help.heroku.com/8MEL050H)
-			Is $version valid semver? (https://help.heroku.com/0ZIOF3ST)
-			Is pnpm $version compatible with this Node.js version?
-		EOF
-    false
-  fi
-  # Verify pnpm works before capturing and ensure its stderr is inspectable later
-  suppress_output pnpm --version
-  echo "Using pnpm $(pnpm --version)"
-}
-
 suppress_output() {
   local TMP_COMMAND_OUTPUT
   TMP_COMMAND_OUTPUT=$(mktemp)

--- a/lib/package_managers/pnpm.sh
+++ b/lib/package_managers/pnpm.sh
@@ -59,6 +59,32 @@ package_managers::pnpm::install_dependencies() {
 	save_pnpm_prune_store_counter "${cache_dir}" "$((counter - 1))"
 }
 
+function package_managers::pnpm::install_binary() {
+	local version="$1"
+	echo "Downloading and installing pnpm (${version})"
+	# npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
+	# to the currently-active npm when that npm still accepts it.
+	local unsafe_perm=()
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside; a non-match just omits the flag
+	if package_managers::npm::supports_unsafe_perm; then
+		unsafe_perm=(--unsafe-perm)
+	fi
+	if ! suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "pnpm@${version}"; then
+		build_data::set_string "failure" "pnpm-install-failed"
+		output::error <<-EOF
+			Unable to install pnpm ${version}.
+			Does pnpm ${version} exist? (https://help.heroku.com/8MEL050H)
+			Is ${version} valid semver? (https://help.heroku.com/0ZIOF3ST)
+			Is pnpm ${version} compatible with this Node.js version?
+		EOF
+		false
+	fi
+	# Verify pnpm works before capturing and ensure its stderr is inspectable later
+	suppress_output pnpm --version
+	# shellcheck disable=SC2312 # the preceding suppress_output already verified pnpm works, so masking its exit here is intentional (matches pre-migration behavior)
+	echo "Using pnpm $(pnpm --version)"
+}
+
 # Restore the sourcing shell's original options (see preamble). errexit/nounset come from the
 # saved `$-`; pipefail from its own saved `set +o` line.
 case "${__pnpm_saved_flags}" in *e*) set -e ;; *) set +e ;; esac


### PR DESCRIPTION
The classic buildpack's error handling is being migrated off the legacy
global `ERR` trap onto per-command, call-site failure classification. Before
a command's error handler can be moved onto that framework, the command
itself needs to live alongside its package manager's other logic rather than
in the catch-all `lib/binaries.sh`.

This relocates the pnpm binary installation into `lib/package_managers/pnpm.sh`,
mirroring where the npm and yarn binary installs already live. It is a
behavior-neutral move — the build errors and their messages are unchanged —
so it can land ahead of the error-handler work that follows.

W-23400617