### PR TITLE
Relocate the npm devDependency pruning into lib/package_managers/npm.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -561,7 +561,7 @@ prune_devdependencies() {
   elif $PNPM; then
     pnpm_prune_devdependencies "$BUILD_DIR"
   else
-    npm_prune_devdependencies "$BUILD_DIR"
+    package_managers::npm::prune_devdependencies "$BUILD_DIR"
   fi
 }
 

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -235,53 +235,6 @@ npm_rebuild() {
   fi
 }
 
-npm_prune_devdependencies() {
-  local npm_version
-  local build_dir=${1:-}
-
-  npm_version=$(npm --version)
-
-  if [ "$NODE_ENV" == "test" ]; then
-    echo "Skipping because NODE_ENV is 'test'"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  elif [ "$NODE_ENV" != "production" ]; then
-    echo "Skipping because NODE_ENV is not 'production'"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  elif [ -n "$NPM_CONFIG_PRODUCTION" ]; then
-    echo "Skipping because NPM_CONFIG_PRODUCTION is '$NPM_CONFIG_PRODUCTION'"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  elif [ "$npm_version" == "5.3.0" ]; then
-    echo "Skipping because npm 5.3.0 fails when running 'npm prune' due to a known issue"
-    echo "https://github.com/npm/npm/issues/17781"
-    echo ""
-    echo "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
-    echo "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  elif [ "$npm_version" == "5.6.0" ] ||
-       [ "$npm_version" == "5.5.1" ] ||
-       [ "$npm_version" == "5.5.0" ] ||
-       [ "$npm_version" == "5.4.2" ] ||
-       [ "$npm_version" == "5.4.1" ] ||
-       [ "$npm_version" == "5.2.0" ] ||
-       [ "$npm_version" == "5.1.0" ]; then
-    echo "Skipping because npm $npm_version sometimes fails when running 'npm prune' due to a known issue"
-    echo "https://github.com/npm/npm/issues/19356"
-    echo ""
-    echo "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
-    echo "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  else
-    cd "$build_dir" || return
-    monitor "prune_dev_dependencies" npm prune --userconfig "$build_dir/.npmrc" 2>&1
-    build_data::set_raw "skipped_prune" "false"
-  fi
-}
-
 pnpm_prune_devdependencies() {
   local build_dir=${1:-}
 

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -390,6 +390,56 @@ function package_managers::npm::_install_binary() {
 	fi
 }
 
+function package_managers::npm::prune_devdependencies() {
+	local npm_version
+	local build_dir=${1:-}
+
+	npm_version=$(npm --version)
+
+	# NODE_ENV and NPM_CONFIG_PRODUCTION are globals exported by the caller (bin/compile via
+	# lib/environment.sh).
+	# shellcheck disable=SC2154 # set by the caller (bin/compile)
+	if [[ "${NODE_ENV}" == "test" ]]; then
+		echo "Skipping because NODE_ENV is 'test'"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	elif [[ "${NODE_ENV}" != "production" ]]; then
+		echo "Skipping because NODE_ENV is not 'production'"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	elif [[ -n "${NPM_CONFIG_PRODUCTION}" ]]; then
+		echo "Skipping because NPM_CONFIG_PRODUCTION is '${NPM_CONFIG_PRODUCTION}'"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	elif [[ "${npm_version}" == "5.3.0" ]]; then
+		echo "Skipping because npm 5.3.0 fails when running 'npm prune' due to a known issue"
+		echo "https://github.com/npm/npm/issues/17781"
+		echo ""
+		echo "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
+		echo "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	elif [[ "${npm_version}" == "5.6.0" ]] \
+		|| [[ "${npm_version}" == "5.5.1" ]] \
+		|| [[ "${npm_version}" == "5.5.0" ]] \
+		|| [[ "${npm_version}" == "5.4.2" ]] \
+		|| [[ "${npm_version}" == "5.4.1" ]] \
+		|| [[ "${npm_version}" == "5.2.0" ]] \
+		|| [[ "${npm_version}" == "5.1.0" ]]; then
+		echo "Skipping because npm ${npm_version} sometimes fails when running 'npm prune' due to a known issue"
+		echo "https://github.com/npm/npm/issues/19356"
+		echo ""
+		echo "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
+		echo "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	else
+		cd "${build_dir}" || return
+		monitor "prune_dev_dependencies" npm prune --userconfig "${build_dir}/.npmrc" 2>&1
+		build_data::set_raw "skipped_prune" "false"
+	fi
+}
+
 # Restore the sourcing shell's original options (see preamble). errexit/nounset come from the
 # saved `$-`; pipefail from its own saved `set +o` line.
 case "${__npm_saved_flags}" in *e*) set -e ;; *) set +e ;; esac


### PR DESCRIPTION
Our buildpack's error handling is being migrated off the legacy global `ERR` trap onto per-command, call-site classification, one command at a time. Each migration first relocates a command into its owning `lib/package_managers/*.sh` file (opted into `shfmt` + `shellcheck enable=all`) as a behavior-neutral move, so a later change can migrate its failure handling onto the `failure::emit` framework without also shuffling code around.

This PR does the relocate step for npm devDependency pruning: it lifts `npm_prune_devdependencies` out of `lib/dependencies.sh` and into `lib/package_managers/npm.sh` as `package_managers::npm::prune_devdependencies`, alongside the already-migrated npm install/binary functions. The build errors and their user-facing messages are unchanged — this is a pure move plus formatting to satisfy the stricter lint on the migrated file. `lib/package_managers/npm.sh` is already registered in `MIGRATED_FILES`, so no makefile/editorconfig change is needed.

W-23401663