### PR TITLE
Relocate the yarn install command into lib/package_managers/yarn.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -510,9 +510,9 @@ build_dependencies() {
   cache_status="$(get_cache_status "$CACHE_DIR")"
   start=$(build_data::current_unix_realtime)
   if [[ "$YARN_2" == "true" ]]; then
-    yarn_2_install "$BUILD_DIR"
+    package_managers::yarn::yarn2_install_dependencies "$BUILD_DIR"
   elif $YARN; then
-    yarn_node_modules "$BUILD_DIR"
+    package_managers::yarn::install_dependencies "$BUILD_DIR"
   elif $PNPM; then
     package_managers::pnpm::install_dependencies "$BUILD_DIR" "$CACHE_DIR"
   elif $PREBUILD; then

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -125,24 +125,6 @@ run_cleanup_script() {
   fi
 }
 
-yarn_node_modules() {
-  local build_dir=${1:-}
-  local production=${YARN_PRODUCTION:-false}
-
-  echo "Installing node modules (yarn.lock)"
-  cd "$build_dir" || return
-  monitor "install_dependencies" yarn install --production="$production" --frozen-lockfile --ignore-engines --prefer-offline 2>&1
-}
-
-yarn_2_install() {
-  local build_dir=${1:-}
-
-  echo "Running 'yarn install' with yarn.lock"
-  cd "$build_dir" || return
-
-  monitor "install_dependencies" yarn install --immutable 2>&1
-}
-
 yarn_prune_devdependencies() {
   local build_dir=${1:-}
   local cache_dir=${2:-}

--- a/lib/package_managers/yarn.sh
+++ b/lib/package_managers/yarn.sh
@@ -91,6 +91,24 @@ function package_managers::yarn::_determine_package_name() {
 	return "${exit_code}"
 }
 
+function package_managers::yarn::install_dependencies() {
+	local build_dir="${1:-}"
+	local production="${YARN_PRODUCTION:-false}"
+
+	echo "Installing node modules (yarn.lock)"
+	cd "${build_dir}" || return
+	monitor "install_dependencies" yarn install --production="${production}" --frozen-lockfile --ignore-engines --prefer-offline 2>&1
+}
+
+function package_managers::yarn::yarn2_install_dependencies() {
+	local build_dir="${1:-}"
+
+	echo "Running 'yarn install' with yarn.lock"
+	cd "${build_dir}" || return
+
+	monitor "install_dependencies" yarn install --immutable 2>&1
+}
+
 # Restore the sourcing shell's original options (see preamble). errexit/nounset come from the
 # saved `$-`; pipefail from its own saved `set +o` line.
 case "${__yarn_saved_flags}" in *e*) set -e ;; *) set +e ;; esac


### PR DESCRIPTION
The classic Node.js buildpack is incrementally migrating its shell code off the legacy global `ERR` trap and onto call-site error classification, opting each touched file into `shfmt` + `shellcheck enable=all` as it goes. Before a command's failure handling can be migrated, the command itself has to live in a strict-mode-clean library file.

This is a behavior-neutral step for the `yarn install` command (both the Yarn 1 and Yarn 2+ variants): it relocates `yarn_node_modules` and `yarn_2_install` out of `lib/dependencies.sh` into `lib/package_managers/yarn.sh` under the `package_managers::yarn::` namespace, matching how `npm` and `pnpm` are already organized. No error-handling behavior changes here — the build output and user-facing messages are identical; this only positions the command for a later handler migration.

W-23544168