### PR TITLE
Relocate the yarn devDependency pruning into lib/package_managers/yarn.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -557,7 +557,7 @@ cache_build() {
 
 prune_devdependencies() {
   if $YARN || $YARN_2; then
-    yarn_prune_devdependencies "$BUILD_DIR" "$YARN_CACHE_FOLDER" "$BP_DIR"
+    package_managers::yarn::prune_devdependencies "$BUILD_DIR" "$BP_DIR"
   elif $PNPM; then
     pnpm_prune_devdependencies "$BUILD_DIR"
   else

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -125,45 +125,6 @@ run_cleanup_script() {
   fi
 }
 
-yarn_prune_devdependencies() {
-  local build_dir=${1:-}
-  local cache_dir=${2:-}
-  local buildpack_dir=${3:-}
-
-  if [ "$NODE_ENV" == "test" ]; then
-    echo "Skipping because NODE_ENV is 'test'"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  elif [ "$NODE_ENV" != "production" ]; then
-    echo "Skipping because NODE_ENV is not 'production'"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  elif [ -n "$YARN_PRODUCTION" ]; then
-    echo "Skipping because YARN_PRODUCTION is '$YARN_PRODUCTION'"
-    build_data::set_raw "skipped_prune" "true"
-    return 0
-  elif $YARN_2; then
-    if [ "$YARN2_SKIP_PRUNING" == "true" ]; then
-      echo "Skipping because YARN2_SKIP_PRUNING is '$YARN2_SKIP_PRUNING'"
-      build_data::set_raw "skipped_prune" "true"
-      return 0
-    fi
-    cd "$build_dir" || return
-    echo "Running 'yarn heroku prune'"
-    export YARN_PLUGINS="${buildpack_dir}/yarn2-plugins/prune-dev-dependencies/bundles/@yarnpkg/plugin-prune-dev-dependencies.js"
-    monitor "prune_dev_dependencies" yarn heroku prune
-    if node_modules_enabled "$build_dir"; then
-      echo "Removing local yarn cache to reduce slug size"
-      rm -rf "$build_dir/.yarn/cache"
-    fi
-    build_data::set_raw "skipped_prune" "false"
-  else
-    cd "$build_dir" || return
-    monitor "prune_dev_dependencies" yarn install --frozen-lockfile --ignore-engines --ignore-scripts --prefer-offline 2>&1
-    build_data::set_raw "skipped_prune" "false"
-  fi
-}
-
 has_npm_lock() {
   local build_dir=${1:-}
 

--- a/lib/package_managers/yarn.sh
+++ b/lib/package_managers/yarn.sh
@@ -109,6 +109,48 @@ function package_managers::yarn::yarn2_install_dependencies() {
 	monitor "install_dependencies" yarn install --immutable 2>&1
 }
 
+function package_managers::yarn::prune_devdependencies() {
+	local build_dir=${1:-}
+	local buildpack_dir=${2:-}
+
+	# NODE_ENV, YARN_PRODUCTION, YARN_2, and YARN2_SKIP_PRUNING are globals exported by the
+	# caller (bin/compile via lib/environment.sh / the app's config vars).
+	# shellcheck disable=SC2154 # set by the caller (bin/compile)
+	if [[ "${NODE_ENV}" == "test" ]]; then
+		echo "Skipping because NODE_ENV is 'test'"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	elif [[ "${NODE_ENV}" != "production" ]]; then
+		echo "Skipping because NODE_ENV is not 'production'"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	elif [[ -n "${YARN_PRODUCTION}" ]]; then
+		echo "Skipping because YARN_PRODUCTION is '${YARN_PRODUCTION}'"
+		build_data::set_raw "skipped_prune" "true"
+		return 0
+	elif ${YARN_2}; then
+		if [[ "${YARN2_SKIP_PRUNING}" == "true" ]]; then
+			echo "Skipping because YARN2_SKIP_PRUNING is '${YARN2_SKIP_PRUNING}'"
+			build_data::set_raw "skipped_prune" "true"
+			return 0
+		fi
+		cd "${build_dir}" || return
+		echo "Running 'yarn heroku prune'"
+		export YARN_PLUGINS="${buildpack_dir}/yarn2-plugins/prune-dev-dependencies/bundles/@yarnpkg/plugin-prune-dev-dependencies.js"
+		monitor "prune_dev_dependencies" yarn heroku prune
+		# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside; a false result just skips the cache cleanup
+		if node_modules_enabled "${build_dir}"; then
+			echo "Removing local yarn cache to reduce slug size"
+			rm -rf "${build_dir}/.yarn/cache"
+		fi
+		build_data::set_raw "skipped_prune" "false"
+	else
+		cd "${build_dir}" || return
+		monitor "prune_dev_dependencies" yarn install --frozen-lockfile --ignore-engines --ignore-scripts --prefer-offline 2>&1
+		build_data::set_raw "skipped_prune" "false"
+	fi
+}
+
 # Restore the sourcing shell's original options (see preamble). errexit/nounset come from the
 # saved `$-`; pipefail from its own saved `set +o` line.
 case "${__yarn_saved_flags}" in *e*) set -e ;; *) set +e ;; esac


### PR DESCRIPTION
The classic Node.js buildpack is incrementally migrating its shell code off the legacy global `ERR` trap and onto call-site error classification, opting each touched file into `shfmt` + `shellcheck enable=all` as it goes. Before a command's failure handling can be migrated, the command itself has to live in a strict-mode-clean library file.

This is a behavior-neutral step for the yarn devDependency pruning command: it relocates `yarn_prune_devdependencies` out of `lib/dependencies.sh` into `lib/package_managers/yarn.sh` under the `package_managers::yarn::` namespace, matching how `npm` (already migrated) and `pnpm` (a parallel follow-up in #1714) are organized. The `cache_dir` positional argument is dropped from the new function's signature — it was declared but never referenced in the legacy version — so the file passes `shellcheck enable=all` without an SC2034 disable. No error-handling behavior changes here — the build output and user-facing messages are identical; this only positions the command for a later handler migration.

W-23546372