### PR TITLE
Relocate the npm dependency-rebuild path into lib/package_managers/npm.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -517,7 +517,7 @@ build_dependencies() {
     package_managers::pnpm::install_dependencies "$BUILD_DIR" "$CACHE_DIR"
   elif $PREBUILD; then
     echo "Prebuild detected (node_modules already exists)"
-    npm_rebuild "$BUILD_DIR"
+    package_managers::npm::rebuild_dependencies "$BUILD_DIR"
   else
     package_managers::npm::install_dependencies "$BUILD_DIR"
   fi

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -191,28 +191,3 @@ should_use_npm_ci() {
   fi
 }
 
-npm_rebuild() {
-  local build_dir=${1:-}
-  local production=${NPM_CONFIG_PRODUCTION:-false}
-
-  # npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
-  # to the currently-active npm when that npm still accepts it.
-  local unsafe_perm=()
-  if package_managers::npm::supports_unsafe_perm; then
-    unsafe_perm=(--unsafe-perm)
-  fi
-
-  if [ -e "$build_dir/package.json" ]; then
-    cd "$build_dir" || return
-    echo "Rebuilding any native modules"
-    npm rebuild 2>&1
-    if [ -e "$build_dir/npm-shrinkwrap.json" ]; then
-      echo "Installing any new modules (package.json + shrinkwrap)"
-    else
-      echo "Installing any new modules (package.json)"
-    fi
-    monitor "npm_rebuild" npm install --production="$production" "${unsafe_perm[@]}" --userconfig "$build_dir/.npmrc" 2>&1
-  else
-    echo "Skipping (no package.json)"
-  fi
-}

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -11,8 +11,7 @@ __npm_saved_flags="$-"
 __npm_saved_pipefail="$(set +o | grep pipefail)"
 set -euo pipefail
 
-# Installs app dependencies with npm (fresh install path; the prebuild/rebuild path is
-# still handled by lib/dependencies.sh until it is migrated).
+# Installs app dependencies with npm (fresh install path).
 #
 # On failure, the captured output is run through package_managers::npm::_handle_npm_install_failure and, if a
 # known failure mode is recognised, failure::emit renders the message, records the
@@ -104,6 +103,38 @@ function package_managers::npm::install_dependencies() {
 	fi
 
 	build_data::set_duration "install_dependencies_time" "${start}"
+}
+
+# Rebuilds app dependencies with npm (prebuild/rebuild path used when node_modules is
+# checked into source control): runs `npm rebuild` to rebuild any native modules, then
+# `npm install` to install anything missing from package.json.
+function package_managers::npm::rebuild_dependencies() {
+	local build_dir="${1:-}"
+	local production="${NPM_CONFIG_PRODUCTION:-false}"
+
+	# npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
+	# to the currently-active npm when that npm still accepts it.
+	local unsafe_perm=()
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside; a non-match just omits the flag
+	if package_managers::npm::supports_unsafe_perm; then
+		unsafe_perm=(--unsafe-perm)
+	fi
+
+	# shellcheck disable=SC2292 # single-bracket preserved during relocation; converted alongside the Type B error-handling migration
+	if [ -e "${build_dir}/package.json" ]; then
+		cd "${build_dir}" || return
+		echo "Rebuilding any native modules"
+		npm rebuild 2>&1
+		# shellcheck disable=SC2292 # single-bracket preserved during relocation; converted alongside the Type B error-handling migration
+		if [ -e "${build_dir}/npm-shrinkwrap.json" ]; then
+			echo "Installing any new modules (package.json + shrinkwrap)"
+		else
+			echo "Installing any new modules (package.json)"
+		fi
+		monitor "npm_rebuild" npm install --production="${production}" "${unsafe_perm[@]}" --userconfig "${build_dir}/.npmrc" 2>&1
+	else
+		echo "Skipping (no package.json)"
+	fi
 }
 
 function package_managers::npm::version_major() {


### PR DESCRIPTION
The classic Node.js buildpack is incrementally migrating its shell code off the legacy global `ERR` trap and onto call-site error classification, opting each touched file into `shfmt` + `shellcheck enable=all` as it goes. Before a command's failure handling can be migrated, the command itself has to live in a strict-mode-clean library file.

This is a behavior-neutral step for the npm prebuild/rebuild path (`npm rebuild` followed by `npm install`, used when `node_modules` is checked into source control): it relocates `npm_rebuild` out of `lib/dependencies.sh` into `lib/package_managers/npm.sh` as `package_managers::npm::rebuild_dependencies`, joining the already-migrated `install_dependencies` handler. No error-handling behavior changes here — the commands, flags, output, and messages are identical; this only positions the command for a later handler migration.

W-23547385