### PR TITLE
Relocate should_use_npm_ci into lib/package_managers/npm.sh

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -443,7 +443,7 @@ if $PNPM; then
 fi
 
 if [[ -z "$USE_NPM_INSTALL" ]]; then
-  if [[ "$(should_use_npm_ci "$BUILD_DIR")" == "true" ]]; then
+  if [[ "$(package_managers::npm::should_use_npm_ci "$BUILD_DIR")" == "true" ]]; then
     USE_NPM_INSTALL=false
   else
     USE_NPM_INSTALL=true

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -124,31 +124,3 @@ run_cleanup_script() {
     run_if_present "$build_dir" 'heroku-cleanup'
   fi
 }
-
-has_npm_lock() {
-  local build_dir=${1:-}
-
-  if [[ -f "$build_dir/package-lock.json" ]] || [[ -f "$build_dir/npm-shrinkwrap.json" ]]; then
-    echo "true"
-  else
-    echo "false"
-  fi
-}
-
-should_use_npm_ci() {
-  local build_dir=${1:-}
-  local npm_version
-  local major
-
-  npm_version=$(npm --version)
-  major=$(package_managers::npm::version_major)
-
-  # We should only run `npm ci` if all of the manifest files are there, and we are running at least npm 6.x
-  # `npm ci` was introduced in the 5.x line in 5.7.0, but this sees very little usage, < 5% of builds
-  if [[ -f "$build_dir/package.json" ]] && [[ "$(has_npm_lock "$build_dir")" == "true" ]] && (( major >= 6 )); then
-    echo "true"
-  else
-    echo "false"
-  fi
-}
-

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -149,6 +149,32 @@ function package_managers::npm::supports_unsafe_perm() {
 	[[ "${major}" -lt 12 ]]
 }
 
+# Prints "true" when the build should install via `npm ci` (lockfile-strict) instead of
+# `npm install`. `npm ci` was introduced in the 5.x line in 5.7.0, but that sees very
+# little usage (< 5% of builds), so this gates on npm >= 6.
+function package_managers::npm::should_use_npm_ci() {
+	local build_dir="${1:-}"
+	local major has_lock
+	major="$(package_managers::npm::version_major)"
+	has_lock="$(package_managers::npm::_has_npm_lock "${build_dir}")"
+
+	if [[ -f "${build_dir}/package.json" ]] && [[ "${has_lock}" == "true" ]] && ((major >= 6)); then
+		echo "true"
+	else
+		echo "false"
+	fi
+}
+
+function package_managers::npm::_has_npm_lock() {
+	local build_dir="${1:-}"
+
+	if [[ -f "${build_dir}/package-lock.json" ]] || [[ -f "${build_dir}/npm-shrinkwrap.json" ]]; then
+		echo "true"
+	else
+		echo "false"
+	fi
+}
+
 # Pure classifier for npm dependency-install failures.
 #
 # Input:


### PR DESCRIPTION
Continues co-locating npm-specific decisions under lib/package_managers/npm.sh so the package-manager surface stays in one file rather than being split across lib/dependencies.sh. The dependency list on npm inside dependencies.sh shrinks, which lets that file follow its own migration path independently.

W-23549021