### PR TITLE
Migrate npm ERESOLVE build error to call-site failure-classification framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Removed the unused `lib/features.sh` A/B rollout module. ([#1719](https://github.com/heroku/heroku-buildpack-nodejs/pull/1719))
+- Migrated the npm peer-dependency-conflict (`ERESOLVE`) build error onto the call-site failure-classification framework. ([#1720](https://github.com/heroku/heroku-buildpack-nodejs/pull/1720))
 
 ## [v358] - 2026-07-09
 

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -618,25 +618,6 @@ log_other_failures() {
     fi
   fi
 
-  # For now, only capture this error if it doesn't happen during the pruning step. This error shouldn't make
-  # it past the initial `npm install` (but it can) and it would be nice to see when this type of error slips through.
-  if grep -q "npm error code ERESOLVE" "$log_file" && [[ "$(build_data::get_current "build_step")" != "prune-dependencies" ]]; then
-    build_data::set_string "failure" "npm-peer-dependency-conflict"
-    warn "Conflict detected in requested npm dependencies
-
-       An \`ERESOLVE\` error during installation of npm dependencies means your app contains two or more conflicting
-       versions of the same dependency. This is typically caused by peer dependency requirements of requested dependencies.
-       The error above should contain more detail about which dependencies are in conflict. Use tools like \`npm info <package-name>\`
-       to get details about a package, including it's peer dependencies.
-
-       The best way to address this issue is to regularly update your dependency versions to prevent conflicts from happening.
-
-       If that is not possible, a temporary solution is to set a config var with \`heroku set config npm_config_legacy_peer_deps=true\`.
-       This should be used with caution as ignoring peer dependency conflicts can lead to unexpected runtime errors.
-    "
-    fail
-  fi
-
   if grep -q "ERR_OSSL_EVP_UNSUPPORTED" "$log_file"; then
     local solution
     local help_url

--- a/lib/failures.sh
+++ b/lib/failures.sh
@@ -55,6 +55,24 @@ function failure::emit() {
 	fail
 }
 
+# Emits a buildpack-classified failure for the case where the tool inside a `tool | tee log`
+# pipeline exited 0 but a downstream stage (typically `tee` writing to the log) failed — for
+# example the build ran out of disk space. Callers pass a stable failure id, the PIPESTATUS
+# array joined as a string (typically "${pipe_status[*]}") for observability, and the
+# user-facing message. Records classification=buildpack and detail=PIPESTATUS=[...].
+function failure::handle_pipefail() {
+	local id="${1}"
+	local pipe_status="${2}"
+	local message="${3}"
+	local -A failure=(
+		[id]="${id}"
+		[classification]="buildpack"
+		[detail]="PIPESTATUS=[${pipe_status}]"
+		[message]="${message}"
+	)
+	failure::emit failure
+}
+
 # Restore the sourcing shell's original options (see preamble) so strict mode doesn't leak
 # into un-migrated callers. errexit/nounset come from the saved `$-`; pipefail from its own
 # saved `set +o` line.

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -68,25 +68,9 @@ function package_managers::npm::install_dependencies() {
 		local -A failure
 		# shellcheck disable=SC2310 # the elif calls a function in a condition, so set -e is disabled inside
 		if [[ "${npm_exit}" -eq 0 ]]; then
-			# npm itself succeeded; the pipeline failed because `tee` (which captures the install
-			# log) failed — e.g. the build ran out of disk space. That is a failure on the
-			# buildpack's side, not a problem with the app's dependencies, so don't run it through
-			# the npm classifier (it would match nothing and blame the user). `tee` returns a bare
-			# non-zero on any write error without encoding the cause, so we record the raw pipe
-			# status as detail for observability rather than guessing why it failed.
-			failure["id"]="npm-install-pipefail"
-			failure["classification"]="buildpack"
-			failure["detail"]="PIPESTATUS=[${pipe_status[*]}]"
-			failure["message"]=$(
-				cat <<-EOF
-					Error: Unable to capture the npm install log output.
-
-					The dependency install ran, but writing its log to disk failed (for example,
-					the build ran out of disk space). This is not a problem with your
-					dependencies. Please try again.
-				EOF
-			)
-			failure::emit failure
+			# npm succeeded but the pipeline failed (tee couldn't write the log — e.g. out of
+			# disk). Buildpack-side, so don't run it through the npm classifier.
+			package_managers::npm::_handle_install_pipefail "${pipe_status[*]}"
 		elif package_managers::npm::_handle_npm_install_failure "${log_file}" failure; then
 			# The classifier fills `failure` by nameref and returns 0 on a match. It is invoked
 			# directly in the `elif` condition (not wrapped in `$(...)`) so its writes survive — a
@@ -112,6 +96,24 @@ function package_managers::npm::rebuild_dependencies() {
 	local build_dir="${1:-}"
 	local production="${NPM_CONFIG_PRODUCTION:-false}"
 
+	if [[ ! -e "${build_dir}/package.json" ]]; then
+		echo "Skipping (no package.json)"
+		return 0
+	fi
+
+	cd "${build_dir}"
+	echo "Rebuilding any native modules"
+	# `npm rebuild` runs unwrapped: its failure surface is native-module compile errors, not
+	# resolution/registry failures, so the npm-install classifier below does not apply. If it
+	# fails, errexit fires and the legacy trap classifies from the shared log.
+	npm rebuild 2>&1
+
+	if [[ -e "${build_dir}/npm-shrinkwrap.json" ]]; then
+		echo "Installing any new modules (package.json + shrinkwrap)"
+	else
+		echo "Installing any new modules (package.json)"
+	fi
+
 	# npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
 	# to the currently-active npm when that npm still accepts it.
 	local unsafe_perm=()
@@ -120,21 +122,39 @@ function package_managers::npm::rebuild_dependencies() {
 		unsafe_perm=(--unsafe-perm)
 	fi
 
-	# shellcheck disable=SC2292 # single-bracket preserved during relocation; converted alongside the Type B error-handling migration
-	if [ -e "${build_dir}/package.json" ]; then
-		cd "${build_dir}" || return
-		echo "Rebuilding any native modules"
-		npm rebuild 2>&1
-		# shellcheck disable=SC2292 # single-bracket preserved during relocation; converted alongside the Type B error-handling migration
-		if [ -e "${build_dir}/npm-shrinkwrap.json" ]; then
-			echo "Installing any new modules (package.json + shrinkwrap)"
-		else
-			echo "Installing any new modules (package.json)"
+	local npm_command=(
+		npm install --production="${production}" "${unsafe_perm[@]}"
+		--userconfig "${build_dir}/.npmrc"
+	)
+
+	local log_file
+	log_file=$(mktemp)
+
+	local start
+	start=$(build_data::current_unix_realtime)
+
+	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
+	# Shares the classifier with the fresh-install path (`install_dependencies`) — same
+	# command, same failure surface. The metric name (`npm_rebuild_time`) is kept distinct
+	# from `install_dependencies_time` so the two paths remain separable in observability.
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
+	if ! { "${npm_command[@]}" 2>&1 | tee "${log_file}"; }; then
+		local pipe_status=("${PIPESTATUS[@]}")
+		local npm_exit="${pipe_status[0]}"
+		build_data::set_duration "npm_rebuild_time" "${start}"
+
+		local -A failure
+		# shellcheck disable=SC2310 # the elif calls a function in a condition, so set -e is disabled inside
+		if [[ "${npm_exit}" -eq 0 ]]; then
+			package_managers::npm::_handle_install_pipefail "${pipe_status[*]}"
+		elif package_managers::npm::_handle_npm_install_failure "${log_file}" failure; then
+			failure::emit failure
 		fi
-		monitor "npm_rebuild" npm install --production="${production}" "${unsafe_perm[@]}" --userconfig "${build_dir}/.npmrc" 2>&1
-	else
-		echo "Skipping (no package.json)"
+
+		return "${npm_exit}"
 	fi
+
+	build_data::set_duration "npm_rebuild_time" "${start}"
 }
 
 function package_managers::npm::version_major() {
@@ -173,6 +193,24 @@ function package_managers::npm::_has_npm_lock() {
 	else
 		echo "false"
 	fi
+}
+
+# Emits the npm-install pipefail failure. Shared by both `install_dependencies` and
+# `rebuild_dependencies`: both run `npm install 2>&1 | tee log`, and a tee-side failure
+# (typically the build ran out of disk space) classifies identically at either call site.
+function package_managers::npm::_handle_install_pipefail() {
+	local pipe_status_str="${1}"
+	local message
+	message=$(
+		cat <<-EOF
+			Error: Unable to capture the npm install log output.
+
+			The dependency install ran, but writing its log to disk failed (for example,
+			the build ran out of disk space). This is not a problem with your
+			dependencies. Please try again.
+		EOF
+	)
+	failure::handle_pipefail "npm-install-pipefail" "${pipe_status_str}" "${message}"
 }
 
 # Pure classifier for npm dependency-install failures.
@@ -332,8 +370,41 @@ function package_managers::npm::_handle_npm_install_failure() {
 		return 0
 	fi
 
+	# npm ERESOLVE code — stable npm v7–v12. Introduced in npm 7.0.0 by arborist v2 (see
+	# workspaces/arborist/lib/place-dep.js#failPeerConflict and
+	# workspaces/arborist/lib/arborist/build-ideal-tree.js#failPeerConflict) and handled first-class
+	# in lib/utils/error-message.js. Indicates the requested dependency tree contains conflicting
+	# peer-dependency requirements. Shared by both npm install call sites
+	# (`install_dependencies` and `rebuild_dependencies`).
+	if grep -qiE 'npm (ERR!|error) code ERESOLVE($| )' "${log_file}"; then
+		__failure["id"]="npm-peer-dependency-conflict"
+		__failure["classification"]="user"
+		__failure["detail"]="ERESOLVE: $(package_managers::npm::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: Conflict detected in requested npm dependencies.
+
+				An \`ERESOLVE\` error during installation of npm dependencies means your app
+				contains two or more conflicting versions of the same dependency. This is
+				typically caused by peer dependency requirements of requested dependencies.
+				The error above should contain more detail about which dependencies are in
+				conflict. Use tools like \`npm info <package-name>\` to get details about a
+				package, including its peer dependencies.
+
+				The best way to address this issue is to regularly update your dependency
+				versions to prevent conflicts from happening.
+
+				If that is not possible, a temporary solution is to set a config var with
+				\`heroku config:set npm_config_legacy_peer_deps=true\`. This should be used
+				with caution as ignoring peer dependency conflicts can lead to unexpected
+				runtime errors.
+			EOF
+		)
+		return 0
+	fi
+
 	# TODO: classify additional npm codes present in error-message.js but not yet handled here,
-	# e.g. ETARGET (no matching version), ERESOLVE (dependency conflict), ENOSPC (disk full).
+	# e.g. ETARGET (no matching version), ENOSPC (disk full).
 	# Add each as its own matcher above, verified against npm source per the version-spread loop.
 
 	# No known failure mode recognised — signal no match so the caller can fall through.

--- a/test/run-npm
+++ b/test/run-npm
@@ -435,7 +435,7 @@ testErrorNpmGitDependency() {
 testErrorPeerDependencyConflict() {
   cache_dir=$(mktmpdir)
   compile "error-npm-peer-dependency-conflict" "${cache_dir}"
-  assertCaptured "Conflict detected in requested npm dependencies"
+  assertCapturedStderr "Conflict detected in requested npm dependencies"
   assertCapturedError
   assertMetricEqualsString "${cache_dir}" "failure" "npm-peer-dependency-conflict"
 }

--- a/test/unit
+++ b/test/unit
@@ -541,6 +541,20 @@ testHandleNpmInstallAllowRemoteBlocked() {
   assertContains "${result[message]}" "remote URL"
 }
 
+testHandleNpmInstallEresolve() {
+  local -A result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eresolve.log" result
+  assertEquals "classifier should return 0 on a match" "0" "$?"
+  # The legacy failure id is preserved verbatim so the `failure` build-data key stays continuous
+  # for downstream metrics.
+  assertEquals "npm-peer-dependency-conflict" "${result[id]}"
+  assertEquals "user" "${result[classification]}"
+  assertContains "${result[detail]}" "ERESOLVE:"
+  assertContains "${result[detail]}" "could not resolve"
+  # The migrated message still surfaces the legacy_peer_deps workaround verbatim.
+  assertContains "${result[message]}" "npm_config_legacy_peer_deps=true"
+}
+
 testHandleNpmInstallNoMatchReturnsNonZero() {
   local -A result
   # `clean.log` is a successful install; the classifier should not match and should leave the

--- a/test/unit
+++ b/test/unit
@@ -425,6 +425,24 @@ testFailureEmitWritesMarkerWhenSet() {
   rm -f "$marker"
 }
 
+testFailureHandlePipefail() {
+  # The generic pipefail helper hard-codes classification=buildpack and encodes the
+  # PIPESTATUS array into failure_detail for observability. Callers pass the id and message.
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >> "$capture"; }
+    failure::handle_pipefail "some-tool-pipefail" "0 1" "Error: log capture failed." 2>&1 || true
+  )
+
+  assertContains "$out" "Error: log capture failed."
+  assertContains "$(cat "$capture")" "failure=some-tool-pipefail"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
+  rm -f "$capture"
+}
+
 testFailuresLibDoesNotLeakShellOptions() {
   # Source the lib in a fresh subshell that does NOT have nounset enabled, and confirm
   # nounset is still off afterwards (i.e. the lib restored our options instead of leaving
@@ -553,6 +571,26 @@ testHandleNpmInstallEresolve() {
   assertContains "${result[detail]}" "could not resolve"
   # The migrated message still surfaces the legacy_peer_deps workaround verbatim.
   assertContains "${result[message]}" "npm_config_legacy_peer_deps=true"
+}
+
+testHandleInstallPipefail() {
+  # The npm-specific pipefail wrapper owns the failure id and the user-facing message;
+  # verify both plus the buildpack classification and PIPESTATUS detail inherited from
+  # failure::handle_pipefail. Shared by install_dependencies and rebuild_dependencies.
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >> "$capture"; }
+    package_managers::npm::_handle_install_pipefail "0 1" 2>&1 || true
+  )
+
+  assertContains "$out" "Unable to capture the npm install log output"
+  assertContains "$out" "ran out of disk space"
+  assertContains "$(cat "$capture")" "failure=npm-install-pipefail"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
+  rm -f "$capture"
 }
 
 testHandleNpmInstallNoMatchReturnsNonZero() {

--- a/test/unit-fixtures/npm-failures/eresolve.log
+++ b/test/unit-fixtures/npm-failures/eresolve.log
@@ -1,0 +1,17 @@
+npm error code ERESOLVE
+npm error ERESOLVE could not resolve
+npm error
+npm error While resolving: my-app@1.0.0
+npm error Found: react@17.0.2
+npm error node_modules/react
+npm error   react@"17.0.2" from the root project
+npm error
+npm error Could not resolve dependency:
+npm error peer react@"^18.0.0" from some-lib@2.0.0
+npm error node_modules/some-lib
+npm error   some-lib@"2.0.0" from the root project
+npm error
+npm error Fix the upstream dependency conflict, or retry
+npm error this command with --force or --legacy-peer-deps
+npm error to accept an incorrect (and potentially broken) dependency resolution.
+npm error A complete log of this run can be found in: /root/.npm/_logs/2026-06-16T00_00_00_000Z-debug-0.log


### PR DESCRIPTION
The classic buildpack's ERESOLVE (peer-dependency conflict) matcher lived in the legacy `log_other_failures` global trap. That trap runs after the fact — it re-reads `$LOG_FILE`, guesses at what went wrong, and cannot record structured details. This moves ERESOLVE into the call-site classifier pattern (`package_managers::npm::_handle_npm_install_failure`), which fires directly from the `npm install` invocation and records `failure_classification=user` plus the failing dep line in `failure_detail`.

Both npm install call sites — the fresh-install path and the prebuild rebuild path — share the classifier, so removing the legacy matcher is safe (there is no longer an un-migrated path that could hit ERESOLVE and slip past the trap). The rebuild-path call site was previously running through the legacy `monitor` wrapper and depending on the ERR trap for classification; it now uses the same `if ! { ... | tee }` capture idiom as the fresh-install path.

The pipefail-handling boilerplate ("tool succeeded but the downstream pipe stage failed") that both npm install sites had inline is factored into a new generic `failure::handle_pipefail` helper in `lib/failures.sh` (reusable by yarn/pnpm as those migrate), with a thin npm-specific wrapper that owns the npm-flavored id and message.

The user-facing ERESOLVE message is unchanged.

W-23572424