### PR TITLE
Restructure README into a focused, user-facing document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,42 +2,77 @@
 
 Thanks for making a contribution to the Heroku Node.js Buildpack!
 
-*Note: If you are looking to open an issue or make a contribution to the Heroku Node.js Cloud Native Buildpacks (this includes builds made with `pack`), go here: https://github.com/heroku/nodejs-engine-buildpack*
+*Note: If you are looking to open an issue or make a contribution to the Heroku Node.js Cloud Native Buildpacks (this includes builds made with `pack`), go here: https://github.com/heroku/buildpacks-nodejs*
 
-## Setup
+## Prerequisites
 
-### Install Docker (optional)
+For local development, you may need the following tools:
 
-Before you get started, you may want to [install Docker](https://docs.docker.com/engine/install/). Docker will be needed to run the test suite.
+- [Docker](https://docs.docker.com/engine/install/) (required to run the test suite)
+- [Rust](https://www.rust-lang.org/tools/install) (for building the version resolver in `resolve-version/`)
+- The `x86_64-unknown-linux-musl` cross-compilation target and linker (used by `make build-resolvers`)
 
-If you don't install Docker, you have the option of waiting until your pull request open to run tests. [The Travis tests can be found here.](https://travis-ci.com/github/heroku/heroku-buildpack-nodejs/pull_requests)
+## Clone the repo
 
-### Clone Repo
-
-First, you will want to fork and clone the repository.
+Fork and clone the repository:
 
 ```sh
 git clone git@github.com:your-username/heroku-buildpack-nodejs.git
 ```
 
-Once you have this on your local machine, you're ready to start making changes.
+## Deploying an app with a fork or branch
+
+Push your changes to your fork, then create a new Heroku app to test it, or configure an existing app to use your buildpack:
+
+```sh
+# Create a new Heroku app that uses your buildpack
+heroku create --buildpack <your-github-url>
+
+# Configure an existing Heroku app to use your buildpack
+heroku buildpacks:set <your-github-url>
+
+# You can also use a git branch!
+heroku buildpacks:set <your-github-url>#your-branch
+```
 
 ## Testing
 
-### Writing Tests
+The tests use [Docker](https://www.docker.com/) to simulate Heroku's stacks, and run via the vendored [shunit2](https://github.com/kward/shunit2) test framework.
 
-There are unit tests that are run with `shunit`. For any change you make, write a unit test in `test/run` that would break if you removed the code that you've just worked on. Add a fixture (`test/fixtures/*`) if you need an additional sample app to test with. [More info about testing here.](https://github.com/heroku/heroku-buildpack-nodejs#tests)
+For any change you make, write a unit test in `test/run` that would break if you removed the code you've just worked on. Add a fixture (`test/fixtures/*`) if you need an additional sample app to test with.
 
-### Running Tests
+Run the full test suite:
 
-To run the tests, run `make test`. You will need Docker installed. This will start a test run of all Heroku stack images that will run serially. If you want to test one stack image (which is usually adequate), run `make heroku-24-build` (or whatever stack image you'd like to test).
+```sh
+make test
+```
+
+Test a single stack (usually adequate):
+
+```sh
+make heroku-22-build
+make heroku-24-build
+make heroku-26-build
+```
+
+Run just the unit tests:
+
+```sh
+make unit
+```
+
+Lint and check formatting of the shell scripts:
+
+```sh
+make lint
+```
 
 ## Opening a Pull Request
 
-After the work is completed, please open a pull request. If it links to an Issue, please make sure to include in the Description:
+After the work is completed, please open a pull request. If it links to an Issue, include it in the description:
 
 ```md
 Fixes: https://github.com/heroku/heroku-buildpack-nodejs/issues/xxx
 ```
 
-In the Description, also add an explanation of the work that's done and the tests that are included.
+Also add an explanation of the work done and the tests included.

--- a/README.md
+++ b/README.md
@@ -2,108 +2,45 @@
 
 ![nodejs](https://raw.githubusercontent.com/heroku/buildpacks/refs/heads/main/assets/images/buildpack-banner-node-js.png)
 
-This is the official [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for Node.js apps.
-
 [![CI](https://github.com/heroku/heroku-buildpack-nodejs/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/heroku-buildpack-nodejs/actions/workflows/ci.yml)
+
+This is the official [Heroku buildpack](https://devcenter.heroku.com/articles/buildpacks) for Node.js apps.
+
+## Getting Started
+
+See the [Getting Started with Node.js on Heroku](https://devcenter.heroku.com/articles/getting-started-with-nodejs) tutorial.
+
+## Application Requirements
+
+A `package.json` file must be present in the root (top-level) directory of your app's source code.
+
+The buildpack supports the npm, Yarn, and pnpm package managers, selected by the lockfile present in your app:
+- `package-lock.json` (npm)
+- `yarn.lock` (Yarn)
+- `pnpm-lock.yaml` (pnpm)
+
+If no lockfile is found, npm is used. A lockfile is strongly recommended for reproducible builds.
+
+## Configuration
+
+### Node.js Version
+
+Specify the Node.js version for your app with the `engines.node` field in `package.json`:
+
+```json
+{
+  "engines": {
+    "node": "24.x"
+  }
+}
+```
+
+We recommend using a major version range (like `24.x`) rather than pinning an exact version, so your app automatically receives Node.js security and bug-fix updates.
+
+If you don't specify a version, the buildpack uses the current recommended LTS release.
+
+For the list of supported Node.js versions, see [Heroku Node.js Support](https://devcenter.heroku.com/articles/nodejs-support).
 
 ## Documentation
 
-For more information about using this Node.js buildpack on Heroku, see these Dev Center articles:
-
-- [Heroku Node.js Support](https://devcenter.heroku.com/articles/nodejs-support)
-- [Getting Started with Node.js on Heroku](https://devcenter.heroku.com/articles/nodejs)
-- [Troubleshooting Node.js Deploys](https://devcenter.heroku.com/articles/troubleshooting-node-deploys)
-
-For more general information about buildpacks on Heroku:
-
-- [Buildpacks](https://devcenter.heroku.com/articles/buildpacks)
-- [Buildpack API](https://devcenter.heroku.com/articles/buildpack-api)
-
-## Using the Heroku Node.js buildpack
-
-It's suggested that you use the latest version of the release buildpack. You can set it using the `heroku-cli`.
-
-```sh
-heroku buildpacks:set heroku/nodejs
-```
-
-Your builds will always use the latest published release of the buildpack.
-
-> **Note:** `buildpacks:set` replaces the buildpack at position 1. If your app
-> already uses other buildpacks, use `buildpacks:add --index 1 heroku/nodejs`
-> instead so this one isn't overwritten. See
-> [Managing Buildpacks](https://devcenter.heroku.com/articles/managing-buildpacks).
-
-## Chain Node with multiple buildpacks
-
-This buildpack automatically exports node, npm, and any node_modules binaries
-into the `$PATH` for easy use in subsequent buildpacks.
-
-## Feedback
-
-Having trouble? Dig it? Feature request?
-
-- [help.heroku.com](https://help.heroku.com/)
-- [GitHub issues](https://github.com/heroku/heroku-buildpack-nodejs/issues)
-
-## Development
-
-### Prerequisites
-
-For local development, you may need the following tools:
-
-- [Docker](https://hub.docker.com/search?type=edition&offering=community)
-- [Rust](https://www.rust-lang.org/tools/install) (for building the version resolver in `resolve-version/`)
-- The `x86_64-unknown-linux-musl` cross-compilation target and linker (used by `make build-resolvers`)
-
-### Deploying an app with a fork or branch
-
-To make changes to this buildpack, fork it on GitHub.
-Push up changes to your fork, then create a new Heroku app to test it,
-or configure an existing app to use your buildpack:
-
-```
-# Create a new Heroku app that uses your buildpack
-heroku create --buildpack <your-github-url>
-
-# Configure an existing Heroku app to use your buildpack
-heroku buildpacks:set <your-github-url>
-
-# You can also use a git branch!
-heroku buildpacks:set <your-github-url>#your-branch
-```
-
-## Tests
-
-The buildpack tests use [Docker](https://www.docker.com/) to simulate
-Heroku's stacks.
-
-To run the test suite:
-
-```
-make test
-```
-
-Or to just test a specific stack:
-
-```
-make heroku-22-build
-make heroku-24-build
-make heroku-26-build
-```
-
-The tests are run via the vendored
-[shunit2](https://github.com/kward/shunit2)
-test framework.
-
-To run just the unit tests (in Docker):
-
-```
-make unit
-```
-
-To lint and check formatting of the shell scripts:
-
-```
-make lint
-```
+For more information about using Node.js on Heroku, see [Dev Center](https://devcenter.heroku.com/categories/nodejs-support).

--- a/README.md
+++ b/README.md
@@ -29,23 +29,10 @@ heroku buildpacks:set heroku/nodejs
 
 Your builds will always use the latest published release of the buildpack.
 
-If you need to use the git url, you can use the `latest` tag to make sure you always have the latest release. **The `main` branch will always have the latest buildpack updates, but it does not correspond with a numbered release.**
-
-```sh
-heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#latest -a my-app
-```
-
-> **Note:** `buildpacks:set` replaces the buildpack at position 1 in your app's
-> buildpack list. If your app already uses other buildpacks, use
-> `buildpacks:add --index 1` instead so this buildpack runs first without
-> overwriting an existing one:
->
-> ```sh
-> heroku buildpacks:add --index 1 heroku/nodejs -a my-app
-> ```
-
-For more on managing an app's buildpacks, see
-[Managing Buildpacks](https://devcenter.heroku.com/articles/managing-buildpacks).
+> **Note:** `buildpacks:set` replaces the buildpack at position 1. If your app
+> already uses other buildpacks, use `buildpacks:add --index 1 heroku/nodejs`
+> instead so this one isn't overwritten. See
+> [Managing Buildpacks](https://devcenter.heroku.com/articles/managing-buildpacks).
 
 ## Chain Node with multiple buildpacks
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,22 @@ It's suggested that you use the latest version of the release buildpack. You can
 heroku buildpacks:set heroku/nodejs
 ```
 
-Your builds will always used the latest published release of the buildpack.
+Your builds will always use the latest published release of the buildpack.
 
 If you need to use the git url, you can use the `latest` tag to make sure you always have the latest release. **The `main` branch will always have the latest buildpack updates, but it does not correspond with a numbered release.**
 
 ```sh
 heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#latest -a my-app
 ```
+
+> **Note:** `buildpacks:set` replaces the buildpack at position 1 in your app's
+> buildpack list. If your app already uses other buildpacks, use
+> `buildpacks:add --index 1` instead so this buildpack runs first without
+> overwriting an existing one:
+>
+> ```sh
+> heroku buildpacks:add --index 1 heroku/nodejs -a my-app
+> ```
 
 ## Locking to a buildpack version
 
@@ -44,8 +53,13 @@ First, find the version you want from
 Then, specify that version with `buildpacks:set`:
 
 ```
-heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#v176 -a my-app
+heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#v358 -a my-app
 ```
+
+If your app already has a Node.js buildpack entry (for example `heroku/nodejs`),
+target its position with `--index` so the pinned URL replaces it rather than
+being added alongside it. Use `heroku buildpacks` to see the current list and
+its positions.
 
 ### Chain Node with multiple buildpacks
 
@@ -66,8 +80,8 @@ Having trouble? Dig it? Feature request?
 For local development, you may need the following tools:
 
 - [Docker](https://hub.docker.com/search?type=edition&offering=community)
-- [Go 1.14](https://golang.org/doc/install#install)
-- [upx](https://upx.github.io/)
+- [Rust](https://www.rust-lang.org/tools/install) (for building the version resolver in `resolve-version/`)
+- The `x86_64-unknown-linux-musl` cross-compilation target and linker (used by `make build-resolvers`)
 
 ### Deploying an app with a fork or branch
 
@@ -85,16 +99,6 @@ heroku buildpacks:set <your-github-url>
 # You can also use a git branch!
 heroku buildpacks:set <your-github-url>#your-branch
 ```
-
-### Downloading Plugins
-
-In order to download the latest plugins that have been released, run the following:
-
-```
-plugin/download.sh v$VERSION
-```
-
-Make sure the version is in the format `v#`, ie. `v7`.
 
 ## Tests
 
@@ -118,6 +122,18 @@ make heroku-26-build
 The tests are run via the vendored
 [shunit2](https://github.com/kward/shunit2)
 test framework.
+
+To run just the unit tests (in Docker):
+
+```
+make unit
+```
+
+To lint and check formatting of the shell scripts:
+
+```
+make lint
+```
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -44,24 +44,10 @@ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#latest -
 > heroku buildpacks:add --index 1 heroku/nodejs -a my-app
 > ```
 
-## Locking to a buildpack version
+For more on managing an app's buildpacks, see
+[Managing Buildpacks](https://devcenter.heroku.com/articles/managing-buildpacks).
 
-Even though it's suggested to use the latest release, you may want to lock dependencies - including buildpacks - to a specific version.
-
-First, find the version you want from
-[the list of buildpack versions](https://github.com/heroku/heroku-buildpack-nodejs/tags).
-Then, specify that version with `buildpacks:set`:
-
-```
-heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#v358 -a my-app
-```
-
-If your app already has a Node.js buildpack entry (for example `heroku/nodejs`),
-target its position with `--index` so the pinned URL replaces it rather than
-being added alongside it. Use `heroku buildpacks` to see the current list and
-its positions.
-
-### Chain Node with multiple buildpacks
+## Chain Node with multiple buildpacks
 
 This buildpack automatically exports node, npm, and any node_modules binaries
 into the `$PATH` for easy use in subsequent buildpacks.

--- a/README.md
+++ b/README.md
@@ -107,36 +107,3 @@ To lint and check formatting of the shell scripts:
 ```
 make lint
 ```
-
-### Debugging
-
-To display the logged build outputs to assist with debugging, use the "echo" and "cat" commands. For example:
-
-```sh
-test() {
-  local log_file var
-
-  var="testtest"
-  log_file=$(mktemp)
-  echo "this is the log file" > "$log_file"
-  echo "test log file" >> "$log_file"
-
-  # use `echo` and `cat` for printing variables and reading files respectively
-  echo $var
-  cat $log_file
-
-  # some cases when debugging is necessary
-  assertEquals "$var" "testtest"
-  assertFileContains "test log file" "$log_file"
-}
-```
-
-Running the test above would produce:
-
-```log
-testtest
-this is the log file
-test log file
-```
-
-The test output writes to `$STD_OUT`, so you can use `cat $STD_OUT` to read output.


### PR DESCRIPTION
Issue #1642 reported that the README's `buildpacks:set` examples silently overwrite whatever buildpack sits at position 1, which caused a production regression for the reporter. Rather than patch the misleading instructions, this reshapes the README to match the focused, user-facing structure of the Python buildpack: what your app needs, how to select a Node.js version, and links out to Dev Center for buildpack management instead of duplicating it. Contributor and development docs move into CONTRIBUTING.md.

Fixes #1642, W-23575617