### PR TITLE
Migrate npm-lockfile-out-of-sync (EUSAGE) build error to call-site failure classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Migrated the Yarn 2+ (Berry) lockfile-out-of-sync (`YN0028`) build error onto the call-site failure-classification framework. ([#1726](https://github.com/heroku/heroku-buildpack-nodejs/pull/1726))
+- Migrated the npm lockfile-out-of-sync (`EUSAGE`) build error onto the call-site failure-classification framework. ([#1727](https://github.com/heroku/heroku-buildpack-nodejs/pull/1727))
 
 ## [v359] - 2026-07-27
 

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -579,22 +579,6 @@ log_other_failures() {
     fail
   fi
 
-  if grep -q "npm error code EUSAGE" "$log_file"; then
-    if grep -q "Please update your lock file" "$log_file"; then
-      build_data::set_string "failure" "npm-lockfile-out-of-sync"
-      warn "npm lockfile is not in sync
-
-       This error occurs when the contents of \`package.json\` contains a different
-       set of dependencies that the contents of \`package-lock.json\`. This can happen
-       when a package is added, modified, or removed but the lockfile was not updated.
-
-       To fix this, run \`npm install\` locally in your app directory to regenerate the
-       lockfile, commit the changes to \`package-lock.json\`, and redeploy.
-      " "https://devcenter.heroku.com/articles/troubleshooting-node-deploys#make-sure-that-the-lockfile-is-up-to-date"
-      fail
-    fi
-  fi
-
   if grep -q "ERR_OSSL_EVP_UNSUPPORTED" "$log_file"; then
     local solution
     local help_url

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -403,6 +403,35 @@ function package_managers::npm::_handle_npm_install_failure() {
 		return 0
 	fi
 
+	# npm EUSAGE code — set broadly by npm's `usageError()` (lib/base-cmd.js, stable since v7.6.2),
+	# so gate on the specific "Please update your lock file" message emitted only from
+	# `npm ci` when `validateLockfile()` fails (lib/commands/ci.js, stable since v8.4.1). The
+	# outer EUSAGE match with the discriminator line is what isolates the lockfile-out-of-sync
+	# case from every other EUSAGE sub-case (arg-validation, audit/diff/sbom/etc.), which the
+	# legacy matcher (`_failures.sh:582-596`) also handled this way. Only `install_dependencies`
+	# runs `npm ci`, but this classifier is shared with `rebuild_dependencies` — the latter
+	# only ever runs `npm install`, so it cannot emit this mode; the matcher simply won't fire
+	# there.
+	if grep -qiE 'npm (ERR!|error) code EUSAGE($| )' "${log_file}" \
+		&& grep -qi 'Please update your lock file' "${log_file}"; then
+		__failure["id"]="npm-lockfile-out-of-sync"
+		__failure["classification"]="user"
+		__failure["detail"]="EUSAGE: $(package_managers::npm::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: npm lockfile is not in sync.
+
+				This error occurs when the contents of \`package.json\` contains a different
+				set of dependencies than the contents of \`package-lock.json\`. This can happen
+				when a package is added, modified, or removed but the lockfile was not updated.
+
+				To fix this, run \`npm install\` locally in your app directory to regenerate the
+				lockfile, commit the changes to \`package-lock.json\`, and redeploy.
+			EOF
+		)
+		return 0
+	fi
+
 	# TODO: classify additional npm codes present in error-message.js but not yet handled here,
 	# e.g. ETARGET (no matching version), ENOSPC (disk full).
 	# Add each as its own matcher above, verified against npm source per the version-spread loop.

--- a/test/run-npm
+++ b/test/run-npm
@@ -416,8 +416,7 @@ testUseNpm10() {
 testErrorNpmLockfileOutOfSync() {
   cache_dir=$(mktmpdir)
   compile "error-npm-lockfile-out-of-sync" "${cache_dir}"
-  assertCaptured "npm lockfile is not in sync"
-  assertCaptured "https://devcenter.heroku.com/articles/troubleshooting-node-deploys#make-sure-that-the-lockfile-is-up-to-date"
+  assertCapturedStderr "npm lockfile is not in sync"
   assertCapturedError
   assertMetricEqualsString "${cache_dir}" "failure" "npm-lockfile-out-of-sync"
 }

--- a/test/unit
+++ b/test/unit
@@ -573,6 +573,20 @@ testHandleNpmInstallEresolve() {
   assertContains "${result[message]}" "npm_config_legacy_peer_deps=true"
 }
 
+testHandleNpmInstallLockfileOutOfSync() {
+  local -A result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eusage.log" result
+  assertEquals "classifier should return 0 on a match" "0" "$?"
+  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
+  assertEquals "npm-lockfile-out-of-sync" "${result[id]}"
+  assertEquals "user" "${result[classification]}"
+  assertContains "${result[detail]}" "EUSAGE:"
+  assertContains "${result[detail]}" "package.json and package-lock.json are in sync"
+  assertContains "${result[message]}" "npm lockfile is not in sync"
+  assertContains "${result[message]}" "npm install"
+  assertContains "${result[message]}" "troubleshooting-node-deploys#make-sure-that-the-lockfile-is-up-to-date"
+}
+
 testHandleInstallPipefail() {
   # The npm-specific pipefail wrapper owns the failure id and the user-facing message;
   # verify both plus the buildpack classification and PIPESTATUS detail inherited from

--- a/test/unit
+++ b/test/unit
@@ -584,7 +584,6 @@ testHandleNpmInstallLockfileOutOfSync() {
   assertContains "${result[detail]}" "package.json and package-lock.json are in sync"
   assertContains "${result[message]}" "npm lockfile is not in sync"
   assertContains "${result[message]}" "npm install"
-  assertContains "${result[message]}" "troubleshooting-node-deploys#make-sure-that-the-lockfile-is-up-to-date"
 }
 
 testHandleInstallPipefail() {

--- a/test/unit-fixtures/npm-failures/eusage.log
+++ b/test/unit-fixtures/npm-failures/eusage.log
@@ -1,0 +1,12 @@
+npm error code EUSAGE
+npm error
+npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync. Please update your lock file with `npm install` before continuing.
+npm error
+npm error Invalid: lock file's abbrev@1.0.4 does not satisfy abbrev@1.1.1
+npm error
+npm error Clean install a project
+npm error
+npm error Usage:
+npm error npm ci
+npm error
+npm error A complete log of this run can be found in: /root/.npm/_logs/2026-06-16T00_00_00_000Z-debug-0.log


### PR DESCRIPTION
Continues the migration of npm build-error classification off the global `ERR` trap in `lib/_failures.sh` and onto the call-site classification framework in `lib/package_managers/npm.sh`.

Handling this failure at the call site keeps the matcher next to the command that produces it (`npm ci`), lets us attach a stable `id`/`classification` for build-data reporting, and removes another dependency on scanning the aggregate log after the fact. The matcher continues to gate on the same `EUSAGE` code plus the "Please update your lock file" discriminator, so it isolates the lockfile-out-of-sync sub-case from other `EUSAGE` variants — matching the legacy behavior. The outer grep is tightened to the classifier's house-style `-qiE 'npm (ERR!|error) code EUSAGE'`, which also closes a partial-coverage gap on pre-npm-10.6 output that emitted the older `npm ERR!` prefix. User-facing guidance and the devcenter link are preserved.

Covered by a new case in the npm-install unit-test suite with a fixture log under `test/unit-fixtures/npm-failures/`.

W-23612008