### PR TITLE
Migrate pnpm install error handling to call-site classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Migrated the pnpm lockfile-out-of-sync (`ERR_PNPM_OUTDATED_LOCKFILE`) build error onto the call-site failure-classification framework. ([#1735](https://github.com/heroku/heroku-buildpack-nodejs/pull/1735))
+
 
 ## [v360] - 2026-07-29
 

--- a/lib/package_managers/pnpm.sh
+++ b/lib/package_managers/pnpm.sh
@@ -32,7 +32,47 @@ package_managers::pnpm::install_dependencies() {
 		esac
 	fi
 
-	monitor "install_dependencies" pnpm "${pnpm_install_args[@]}" 2>&1
+	local log_file
+	log_file=$(mktemp)
+
+	local start
+	start=$(build_data::current_unix_realtime)
+
+	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
+	# pnpm writes progress and errors across stdout+stderr; merge them with `2>&1` and pass the
+	# merged stream through `tee` for classification. Indentation is applied by the enclosing
+	# `build_dependencies | output "$LOG_FILE"` pipe in bin/compile — do not re-indent here or
+	# every pnpm line would be indented twice.
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
+	if ! { pnpm "${pnpm_install_args[@]}" 2>&1 | tee "${log_file}"; }; then
+		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
+		# The pipeline is `pnpm 2>&1 | tee`, so [0] is pnpm's exit code and [1] is tee's.
+		local pipe_status=("${PIPESTATUS[@]}")
+		local pnpm_exit="${pipe_status[0]}"
+		build_data::set_duration "install_dependencies_time" "${start}"
+
+		local -A failure
+		# shellcheck disable=SC2310 # the elif calls a function in a condition, so set -e is disabled inside
+		if [[ "${pnpm_exit}" -eq 0 ]]; then
+			# pnpm succeeded but the pipeline failed (tee couldn't write the log — e.g. out of
+			# disk). Buildpack-side, so don't run it through the pnpm classifier.
+			package_managers::pnpm::_handle_install_pipefail "${pipe_status[*]}"
+		elif package_managers::pnpm::_handle_install_failure "${log_file}" failure; then
+			# The classifier fills `failure` by nameref and returns 0 on a match. It is invoked
+			# directly in the `elif` condition (not wrapped in `$(...)`) so its writes survive — a
+			# command substitution runs in a subshell where the nameref updates would be lost.
+			failure::emit failure
+		fi
+
+		# No known failure mode recognised. Bubble up by returning pnpm's exit code: the pipeline
+		# that runs this install (`build_dependencies | output "$LOG_FILE"`) then fails under
+		# errexit/pipefail, the legacy ERR trap fires, and `log_other_failures` classifies the
+		# failure from $LOG_FILE — covering the pnpm codes not yet migrated here, instead of
+		# masking them with a generic message.
+		return "${pnpm_exit}"
+	fi
+
+	build_data::set_duration "install_dependencies_time" "${start}"
 
 	# prune the store when the counter reaches zero to clean up errant package versions which may have been upgraded/removed
 	counter=$(load_pnpm_prune_store_counter "${cache_dir}")
@@ -57,6 +97,85 @@ package_managers::pnpm::install_dependencies() {
 		fi
 	fi
 	save_pnpm_prune_store_counter "${cache_dir}" "$((counter - 1))"
+}
+
+# Emits the pnpm-install pipefail failure for the case where pnpm exited 0 but a downstream
+# pipe stage (typically `tee` writing to the log) failed — for example the build ran out of
+# disk space. Wraps `failure::handle_pipefail` with the pnpm-specific id and message so callers
+# pass only the joined PIPESTATUS string.
+function package_managers::pnpm::_handle_install_pipefail() {
+	local pipe_status_str="${1}"
+	local message
+	message=$(
+		cat <<-EOF
+			Error: Unable to capture the pnpm install log output.
+
+			The dependency install ran, but writing its log to disk failed (for example,
+			the build ran out of disk space). This is not a problem with your
+			dependencies. Please try again.
+		EOF
+	)
+	failure::handle_pipefail "pnpm-install-pipefail" "${pipe_status_str}" "${message}"
+}
+
+# Pure classifier for pnpm dependency-install failures.
+#
+# Input:
+#   $1  path to a log file containing the captured output of the failed pnpm command
+#   $2  name of an associative array to fill (see failure::emit for its fields)
+# Returns 0 and fills the array when a known failure mode is recognised; returns 1 and leaves
+# the array untouched otherwise. Has no side effects: it does not write build data, print to
+# the build log, or exit. Detail is set to the pnpm error code plus the first descriptive error
+# line, giving observability a precise discriminator within each failure bucket.
+function package_managers::pnpm::_handle_install_failure() {
+	local log_file="${1}"
+	# shellcheck disable=SC2178 # nameref alias to the caller's associative array, not a string
+	local -n __failure="${2}"
+
+	# ERR_PNPM_OUTDATED_LOCKFILE — pnpm refuses to install under `--frozen-lockfile` when
+	# pnpm-lock.yaml has drifted from package.json (thrown from pnpm's install index.ts). Gate on
+	# the stable error code rather than the message, which has drifted across pnpm versions. The
+	# ERR_PNPM_ prefix is stamped by the PnpmError constructor and survives in non-TTY dynos even
+	# when chalk wraps it in ANSI color.
+	if grep -qi 'ERR_PNPM_OUTDATED_LOCKFILE' "${log_file}"; then
+		__failure["id"]="pnpm-lockfile-out-of-sync"
+		__failure["classification"]="user"
+		__failure["detail"]="ERR_PNPM_OUTDATED_LOCKFILE: $(package_managers::pnpm::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: pnpm lockfile is not in sync.
+
+				This error occurs when the contents of \`package.json\` contains a different
+				set of dependencies than the contents of \`pnpm-lock.yaml\`. This can happen
+				when a package is added, modified, or removed but the lockfile was not updated.
+
+				To fix this, run \`pnpm install\` locally in your app directory to regenerate the
+				lockfile, commit the changes to \`pnpm-lock.yaml\`, and redeploy.
+			EOF
+		)
+		return 0
+	fi
+
+	# TODO: classify additional pnpm codes surfaced by pnpm's default reporter but not yet handled
+	# here, e.g. ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE (lockfile format-version mismatch),
+	# ERR_PNPM_NO_MATCHING_VERSION, ERR_PNPM_FETCH_401/403/404, ERR_PNPM_PEER_DEP_ISSUES, ELIFECYCLE.
+	# Add each as its own matcher above, verified against pnpm source.
+
+	# No known failure mode recognised — signal no match so the caller can fall through.
+	return 1
+}
+
+# Returns the first descriptive pnpm error line for use as failure detail: pnpm's default
+# reporter renders the summary as `[ERR_PNPM_<CODE>] <message>`, so grab that first line and
+# strip the leading `[CODE] ` bracket prefix. `|| true` so a no-match never trips errexit.
+# Internal helper to package_managers::pnpm::_handle_install_failure; not meant to be called
+# directly.
+function package_managers::pnpm::_extract_error_detail() {
+	local log_file="${1}"
+	grep -aE '^\[ERR_PNPM_[A-Z_]+\]' "${log_file}" \
+		| head -n 1 \
+		| sed -E 's/^\[[A-Z_]+\][[:space:]]*//' \
+		|| true
 }
 
 function package_managers::pnpm::prune_devdependencies() {

--- a/test/run-pnpm
+++ b/test/run-pnpm
@@ -13,7 +13,6 @@ testPnpmBuildMetaData() {
     select(.has_cached_bower_components == false)
     select(.has_custom_cache_dirs == false)
     select(.has_procfile == false)
-    select(.install_dependencies_memory | type == "number")
     select(.install_dependencies_time | type == "number")
     select(.install_node_binary_time | type == "number")
     select(.install_pnpm_binary_time | type == "number")

--- a/test/unit
+++ b/test/unit
@@ -678,6 +678,63 @@ testHandleYarnInstallPipefail() {
   rm -f "$capture"
 }
 
+testHandlePnpmInstallLockfileOutOfSync() {
+  local -A result
+  package_managers::pnpm::_handle_install_failure "$(pwd)/test/unit-fixtures/pnpm-failures/outdated-lockfile.log" result
+  assertEquals "classifier should return 0 on a match" "0" "$?"
+  assertEquals "pnpm-lockfile-out-of-sync" "${result[id]}"
+  assertEquals "user" "${result[classification]}"
+  # Detail carries the pnpm code plus the first descriptive error line.
+  assertContains "${result[detail]}" "ERR_PNPM_OUTDATED_LOCKFILE:"
+  assertContains "${result[detail]}" "is not up to date"
+  assertContains "${result[message]}" "pnpm lockfile is not in sync"
+  assertContains "${result[message]}" "pnpm install"
+}
+
+testHandlePnpmInstallNoMatchReturnsNonZero() {
+  local -A result
+  # `clean.log` is a successful install; the classifier should not match and should leave the
+  # array empty. Guard the call so set -e (if active) doesn't abort on the expected non-zero.
+  if package_managers::pnpm::_handle_install_failure "$(pwd)/test/unit-fixtures/pnpm-failures/clean.log" result; then
+    fail "expected classifier to return non-zero for an unrecognised log"
+  fi
+  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+}
+
+testHandlePnpmInstallPipefail() {
+  # The pnpm-specific pipefail wrapper owns the failure id and the user-facing message;
+  # verify both plus the buildpack classification and PIPESTATUS detail inherited from
+  # failure::handle_pipefail.
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >> "$capture"; }
+    package_managers::pnpm::_handle_install_pipefail "0 1" 2>&1 || true
+  )
+
+  assertContains "$out" "Unable to capture the pnpm install log output"
+  assertContains "$out" "ran out of disk space"
+  assertContains "$(cat "$capture")" "failure=pnpm-install-pipefail"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
+  rm -f "$capture"
+}
+
+testPnpmExtractErrorDetailReturnsFirstDescriptiveLine() {
+  # Strips the leading `[ERR_PNPM_<CODE>] ` bracket prefix from the rendered summary line.
+  local detail
+  detail=$(package_managers::pnpm::_extract_error_detail "$(pwd)/test/unit-fixtures/pnpm-failures/outdated-lockfile.log")
+  assertEquals "Cannot install with \"frozen-lockfile\" because pnpm-lock.yaml is not up to date with <ROOT>/package.json" "$detail"
+}
+
+testPnpmExtractErrorDetailEmptyWhenNoDescriptiveLine() {
+  # A log with no `[ERR_PNPM_...]` summary line yields empty detail without erroring.
+  local detail
+  detail=$(package_managers::pnpm::_extract_error_detail "$(pwd)/test/unit-fixtures/pnpm-failures/clean.log")
+  assertEquals "" "$detail"
+}
+
 # npm 12 removed --unsafe-perm; the gate helper decides whether callers may pass it. Stub `npm`
 # in a subshell so `version_major` reads a controlled version without a real npm install.
 testSupportsUnsafePermForNpm11() {

--- a/test/unit-fixtures/pnpm-failures/clean.log
+++ b/test/unit-fixtures/pnpm-failures/clean.log
@@ -1,0 +1,10 @@
+Scope: all 3 workspace projects
+Lockfile is up to date, resolution step is skipped
+Packages: +142
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Progress: resolved 142, reused 142, downloaded 0, added 142, done
+
+dependencies:
++ lodash 4.17.21
+
+Done in 3.2s

--- a/test/unit-fixtures/pnpm-failures/outdated-lockfile.log
+++ b/test/unit-fixtures/pnpm-failures/outdated-lockfile.log
@@ -1,0 +1,8 @@
+Scope: all 3 workspace projects
+ WARN  Ignoring not compatible lockfile at /tmp/build/pnpm-lock.yaml
+[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/package.json
+
+Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
+
+  Failure reason:
+  specifiers in the lockfile ({"lodash":"^4.17.20"}) don't match specs in package.json ({"lodash":"^4.17.21"})


### PR DESCRIPTION
Continues the error-handling migration by moving the pnpm lockfile-out-of-sync failure (`ERR_PNPM_OUTDATED_LOCKFILE`) off the legacy global `ERR` trap onto the call-site classification framework in `lib/package_managers/pnpm.sh`.

Handling this failure at the call site keeps the matcher next to the command that produces it (`pnpm install --frozen-lockfile`), lets us attach a stable `id`/`classification` for build-data reporting, and establishes the pnpm install-path scaffolding for future error-code migrations. The classifier gates on pnpm's stable `ERR_PNPM_OUTDATED_LOCKFILE` error code (stamped by pnpm's PnpmError constructor) rather than the message text, which has drifted across pnpm versions.

Because pnpm install failures were previously unclassified (no legacy matcher in `lib/_failures.sh`), the user-facing message is new. It explains that `--frozen-lockfile` refused to install when `pnpm-lock.yaml` has drifted from `package.json`, and covers the fix inline (`pnpm install` locally, commit, redeploy).

W-23651645
