### PR TITLE
Migrate npm prune dev-dependency step to call-site failure classification

### DIFF
--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -592,9 +592,56 @@ function package_managers::npm::prune_devdependencies() {
 		return 0
 	else
 		cd "${build_dir}" || return
-		monitor "prune_dev_dependencies" npm prune --userconfig "${build_dir}/.npmrc" 2>&1
+
+		local log_file
+		log_file=$(mktemp)
+
+		local start
+		start=$(build_data::current_unix_realtime)
+
+		# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
+		# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
+		if ! { npm prune --userconfig "${build_dir}/.npmrc" 2>&1 | tee "${log_file}"; }; then
+			# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
+			# The pipeline is `npm 2>&1 | tee`, so [0] is npm's exit code and [1] is tee's.
+			local pipe_status=("${PIPESTATUS[@]}")
+			local npm_exit="${pipe_status[0]}"
+			build_data::set_duration "prune_dev_dependencies_time" "${start}"
+
+			if [[ "${npm_exit}" -eq 0 ]]; then
+				# npm succeeded but the pipeline failed (tee couldn't write the log — e.g. out of
+				# disk). Buildpack-side, so don't blame the app.
+				package_managers::npm::_handle_prune_pipefail "${pipe_status[*]}"
+			fi
+
+			# No known failure mode recognised. Bubble up by returning npm's exit code: the pipeline
+			# that runs this prune (`prune_devdependencies | output "$LOG_FILE"`) then fails under
+			# errexit/pipefail, the legacy ERR trap fires, and `log_other_failures` classifies the
+			# failure — there is no migrated npm-prune tool-error classifier to add here yet.
+			return "${npm_exit}"
+		fi
+
+		build_data::set_duration "prune_dev_dependencies_time" "${start}"
 		build_data::set_raw "skipped_prune" "false"
 	fi
+}
+
+# Emits the npm-prune pipefail failure. `prune_devdependencies` runs
+# `npm prune 2>&1 | tee log`, and a tee-side failure (typically the build ran out of disk
+# space) classifies as buildpack-side rather than blaming the app's dependencies.
+function package_managers::npm::_handle_prune_pipefail() {
+	local pipe_status_str="${1}"
+	local message
+	message=$(
+		cat <<-EOF
+			Error: Unable to capture the npm prune log output.
+
+			The dependency prune ran, but writing its log to disk failed (for example,
+			the build ran out of disk space). This is not a problem with your
+			dependencies. Please try again.
+		EOF
+	)
+	failure::handle_pipefail "npm-prune-pipefail" "${pipe_status_str}" "${message}"
 }
 
 # Runs a named lifecycle script with npm. Spells the npm-specific command (`npm run <script>

--- a/test/run-npm
+++ b/test/run-npm
@@ -327,7 +327,6 @@ testNpmBuildMetaData() {
     select(.npm_version == "6.14.12")
     select(.package_manager == "npm")
     select(.package_manager_version == "6.14.12")
-    select(.prune_dev_dependencies_memory | type == "number")
     select(.prune_dev_dependencies_time | type == "number")
     select(.restore_cache_time | type == "number")
     select(.save_cache_time | type == "number")

--- a/test/unit
+++ b/test/unit
@@ -603,6 +603,26 @@ testHandleInstallPipefail() {
   rm -f "$capture"
 }
 
+testHandlePrunePipefail() {
+  # The npm-specific prune pipefail wrapper owns the failure id and the user-facing message;
+  # verify both plus the buildpack classification and PIPESTATUS detail inherited from
+  # failure::handle_pipefail.
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >> "$capture"; }
+    package_managers::npm::_handle_prune_pipefail "0 1" 2>&1 || true
+  )
+
+  assertContains "$out" "Unable to capture the npm prune log output"
+  assertContains "$out" "ran out of disk space"
+  assertContains "$(cat "$capture")" "failure=npm-prune-pipefail"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
+  rm -f "$capture"
+}
+
 testHandleNpmInstallNoMatchReturnsNonZero() {
   local -A result
   # `clean.log` is a successful install; the classifier should not match and should leave the


### PR DESCRIPTION
Continues the migration of the buildpack's error handling off the global ERR trap and onto call-site classification. This moves the `npm prune` dev-dependency step: it was the last npm command still running through the legacy `monitor` wrapper, which coupled it to trap-based failure handling and to memory sampling we no longer carry forward.

`npm prune` now runs inside `if ! { npm prune … | tee log; }`, capturing PIPESTATUS so a downstream pipe failure (e.g. `tee` unable to write the log when the build is out of disk) is classified as buildpack-side (`npm-prune-pipefail`) rather than blamed on the app. A real `npm prune` failure bubbles to the legacy trap exactly as before — there is no user-facing npm-prune error matcher to migrate yet, so no messages change.

The `prune_dev_dependencies_time` metric is preserved; the `prune_dev_dependencies_memory` metric is dropped, matching the earlier npm install migration.

W-23651723