### PR TITLE
Migrate pnpm dev-dependency pruning onto call-site failure classification

### DIFF
--- a/lib/package_managers/pnpm.sh
+++ b/lib/package_managers/pnpm.sh
@@ -118,6 +118,70 @@ function package_managers::pnpm::_handle_install_pipefail() {
 	failure::handle_pipefail "pnpm-install-pipefail" "${pipe_status_str}" "${message}"
 }
 
+# Emits the pnpm-prune pipefail failure. Both prune paths (`pnpm install --prod` for workspaces
+# and `pnpm prune --prod` otherwise) run `pnpm 2>&1 | tee log`, and a tee-side failure (typically
+# the build ran out of disk space) classifies as buildpack-side rather than blaming the app's
+# dependencies. Callers pass only the joined PIPESTATUS string.
+function package_managers::pnpm::_handle_prune_pipefail() {
+	local pipe_status_str="${1}"
+	local message
+	message=$(
+		cat <<-EOF
+			Error: Unable to capture the pnpm prune log output.
+
+			The dependency prune ran, but writing its log to disk failed (for example,
+			the build ran out of disk space). This is not a problem with your
+			dependencies. Please try again.
+		EOF
+	)
+	failure::handle_pipefail "pnpm-prune-pipefail" "${pipe_status_str}" "${message}"
+}
+
+# Runs a pnpm dev-dependency prune command with call-site failure classification. Shared by both
+# prune strategies: the workspace path (`pnpm install --prod --frozen-lockfile`, a production
+# reinstall) and the non-workspace path (`pnpm prune --prod [--ignore-scripts]`). Both record the
+# same `prune_dev_dependencies_time` metric and have the same failure surface — a tee-side pipe
+# failure is buildpack-side; any pnpm tool failure bubbles to the legacy trap — so the two paths
+# differ only in the command, which the caller passes as arguments.
+function package_managers::pnpm::_run_prune() {
+	local prune_command=("$@")
+
+	local log_file
+	log_file=$(mktemp)
+
+	local start
+	start=$(build_data::current_unix_realtime)
+
+	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
+	# pnpm writes progress and errors across stdout+stderr; merge them with `2>&1` and pass the
+	# merged stream through `tee` for classification. Indentation is applied by the enclosing
+	# `prune_devdependencies | output "$LOG_FILE"` pipe in bin/compile — do not re-indent here or
+	# every pnpm line would be indented twice.
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
+	if ! { "${prune_command[@]}" 2>&1 | tee "${log_file}"; }; then
+		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
+		# The pipeline is `pnpm 2>&1 | tee`, so [0] is pnpm's exit code and [1] is tee's.
+		local pipe_status=("${PIPESTATUS[@]}")
+		local pnpm_exit="${pipe_status[0]}"
+		build_data::set_duration "prune_dev_dependencies_time" "${start}"
+
+		if [[ "${pnpm_exit}" -eq 0 ]]; then
+			# pnpm succeeded but the pipeline failed (tee couldn't write the log — e.g. out of
+			# disk). Buildpack-side, so don't blame the app.
+			package_managers::pnpm::_handle_prune_pipefail "${pipe_status[*]}"
+		fi
+
+		# No known failure mode recognised. Bubble up by returning pnpm's exit code: the pipeline
+		# that runs this prune (`prune_devdependencies | output "$LOG_FILE"`) then fails under
+		# errexit/pipefail, the legacy ERR trap fires, and `log_other_failures` classifies the
+		# failure — there is no migrated pnpm-prune tool-error classifier to add here yet.
+		return "${pnpm_exit}"
+	fi
+
+	build_data::set_duration "prune_dev_dependencies_time" "${start}"
+	build_data::set_raw "skipped_prune" "false"
+}
+
 # Pure classifier for pnpm dependency-install failures.
 #
 # Input:
@@ -223,8 +287,7 @@ function package_managers::pnpm::prune_devdependencies() {
 			rm -rf "${project_path}/node_modules"
 		done
 		# Reinstall with production-only dependencies
-		monitor "prune_dev_dependencies" pnpm install --prod --frozen-lockfile 2>&1
-		build_data::set_raw "skipped_prune" "false"
+		package_managers::pnpm::_run_prune pnpm install --prod --frozen-lockfile
 		return 0
 	fi
 
@@ -253,9 +316,7 @@ function package_managers::pnpm::prune_devdependencies() {
 		pnpm_prune_args+=("--ignore-scripts")
 	fi
 
-	monitor "prune_dev_dependencies" pnpm "${pnpm_prune_args[@]}" 2>&1
-
-	build_data::set_raw "skipped_prune" "false"
+	package_managers::pnpm::_run_prune pnpm "${pnpm_prune_args[@]}"
 }
 
 function package_managers::pnpm::_workspace_configured() {

--- a/test/run-pnpm
+++ b/test/run-pnpm
@@ -24,7 +24,6 @@ testPnpmBuildMetaData() {
     select(.package_manager_request == "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589")
     select(.package_manager_version == "8.15.5")
     select(.pnpm_version == "8.15.5")
-    select(.prune_dev_dependencies_memory | type == "number")
     select(.prune_dev_dependencies_time | type == "number")
     select(.restore_cache_time | type == "number")
     select(.save_cache_time | type == "number")

--- a/test/unit
+++ b/test/unit
@@ -496,6 +496,31 @@ testYarnLibDoesNotLeakErrexit() {
   assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
 }
 
+testPnpmLibDoesNotLeakShellOptions() {
+  # Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated pnpm lib: sourcing
+  # it must restore the caller's nounset rather than leaving `set -u` on.
+  local nounset_after
+  nounset_after=$(
+    set +u
+    # shellcheck source=/dev/null
+    source "$(pwd)/lib/package_managers/pnpm.sh"
+    set -o | awk '$1 == "nounset" { print $2 }'
+  )
+  assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
+}
+
+testPnpmLibDoesNotLeakErrexit() {
+  # Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the pnpm lib.
+  local errexit_after
+  errexit_after=$(
+    set -e
+    # shellcheck source=/dev/null
+    source "$(pwd)/lib/package_managers/pnpm.sh"
+    case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
+  )
+  assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
+}
+
 testHandleNpmInstallEbadplatform() {
   local -A result
   package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log" result
@@ -736,6 +761,26 @@ testHandlePnpmInstallPipefail() {
   assertContains "$out" "Unable to capture the pnpm install log output"
   assertContains "$out" "ran out of disk space"
   assertContains "$(cat "$capture")" "failure=pnpm-install-pipefail"
+  assertContains "$(cat "$capture")" "failure_classification=buildpack"
+  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
+  rm -f "$capture"
+}
+
+testHandlePnpmPrunePipefail() {
+  # The pnpm-prune pipefail wrapper owns the failure id and the user-facing message; verify
+  # both plus the buildpack classification and PIPESTATUS detail inherited from
+  # failure::handle_pipefail. Both prune paths share this wrapper.
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >> "$capture"; }
+    package_managers::pnpm::_handle_prune_pipefail "0 1" 2>&1 || true
+  )
+
+  assertContains "$out" "Unable to capture the pnpm prune log output"
+  assertContains "$out" "ran out of disk space"
+  assertContains "$(cat "$capture")" "failure=pnpm-prune-pipefail"
   assertContains "$(cat "$capture")" "failure_classification=buildpack"
   assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
   rm -f "$capture"


### PR DESCRIPTION
The pnpm dev-dependency pruning step was the last pnpm path still routing failures through the legacy `monitor` wrapper and the global `ERR` trap. This moves it onto the call-site failure-classification model the rest of the pnpm module now uses, so a prune failure is inspected where it happens and a buildpack-side failure (e.g. `tee` hitting a full disk while capturing the log) is no longer misattributed to the app's dependencies.

Pruning runs one of two commands depending on whether the app is a pnpm workspace — a production reinstall (`pnpm install --prod --frozen-lockfile`) or `pnpm prune --prod`. Both share the same duration metric and the same failure surface, so rather than duplicate the ~20-line capture/classify idiom at each call site, the shared logic lives in one `_run_prune` helper that both paths call with their respective command.

This is behavior-neutral for end users: the same messages, the same exit behavior. Dropping the `monitor` wrapper drops the `prune_dev_dependencies_memory` metric (the duration metric is preserved), so this carries no changelog entry.

Builds on the pnpm-install error-handling migration (#1735, now merged).

W-23662286
