### PR TITLE
Migrate output.sh and build_data.sh into the linting + namespaced-functions model

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 # Migrated shell files (kept in sync with the makefile's MIGRATED_FILES list). Tabs are used
 # so here-documents can be indented:
 # https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Documents
-[{lib/failures.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
+[{lib/build_data.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
 binary_next_line = true
 indent_style = tab
 shell_variant = bash

--- a/bin/compile
+++ b/bin/compile
@@ -20,6 +20,8 @@ BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
 # shellcheck source=lib/output.sh
 source "$BP_DIR/lib/output.sh"
+# shellcheck source=lib/_output.sh
+source "$BP_DIR/lib/_output.sh"
 # shellcheck source=lib/monitor.sh
 source "$BP_DIR/lib/monitor.sh"
 # shellcheck source=lib/environment.sh
@@ -46,8 +48,8 @@ source "$BP_DIR/lib/yaml.sh"
 source "$BP_DIR/lib/cache.sh"
 # shellcheck source=lib/package_manager.sh
 source "$BP_DIR/lib/package_manager.sh"
-# shellcheck source=lib/builddata.sh
-source "$BP_DIR/lib/builddata.sh"
+# shellcheck source=lib/build_data.sh
+source "$BP_DIR/lib/build_data.sh"
 
 export PATH="$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin":$PATH
 

--- a/bin/report
+++ b/bin/report
@@ -24,6 +24,6 @@ CACHE_DIR="${2}"
 # The absolute path to the root of the buildpack.
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
 
-source "${BUILDPACK_DIR}/lib/builddata.sh"
+source "${BUILDPACK_DIR}/lib/build_data.sh"
 
 build_data::print_bin_report_json

--- a/lib/_output.sh
+++ b/lib/_output.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Legacy, non-namespaced output helpers awaiting migration/elimination. These are still called
+# by un-migrated scripts (`bin/compile`, `lib/_failures.sh`). New code should use the namespaced
+# `output::*` functions in `lib/output.sh` instead. Once every caller has moved off `output` and
+# `header`, this file can be deleted.
+
+info() {
+  echo "       $*" || true
+}
+
+# format output and send a copy to the log
+output() {
+  local logfile="$1"
+
+  while IFS= read -r LINE;
+  do
+    # do not indent headers that are being piped through the output
+    if [[ "$LINE" =~ ^-----\>.* ]]; then
+      echo "$LINE" || true
+    else
+      echo "       $LINE" || true
+    fi
+    echo "$LINE" >> "$logfile" || true
+  done
+}
+
+header() {
+  echo "" || true
+  echo "-----> $*" || true
+}
+
+error() {
+  echo " !     $*" >&2 || true
+  echo "" || true
+}

--- a/lib/build_data.sh
+++ b/lib/build_data.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# Enable strict mode for ShellCheck's benefit, but restore the caller's options at the end of
+# the file (see epilogue) so these don't bleed into the un-migrated scripts that source this
+# lib. The caller's flags are read from `$-`, which reflects the *current* shell — a
+# `$(set +o)` capture runs in a command-substitution subshell where bash always forces errexit
+# off, so it would record (and later restore) errexit as disabled even when the caller had it
+# enabled. `$-` has no letter for pipefail, so that one option is captured separately (it is
+# reported correctly inside command substitution).
+# shellcheck disable=SC2034 # both are consumed by the epilogue
+__build_data_saved_flags="$-"
+__build_data_saved_pipefail="$(set +o | grep pipefail)"
+set -euo pipefail
+
 BUILD_DATA_FILE="${CACHE_DIR:?}/build-data/nodejs.json"
 PREVIOUS_BUILD_DATA_FILE="${CACHE_DIR:?}/build-data/nodejs-prev.json"
 
@@ -172,3 +184,11 @@ function build_data::current_unix_realtime() {
 function build_data::print_bin_report_json() {
 	jq --sort-keys '.' "${BUILD_DATA_FILE}"
 }
+
+# Restore the sourcing shell's original options (see preamble) so strict mode doesn't leak
+# into un-migrated callers. errexit/nounset come from the saved `$-`; pipefail from its own
+# saved `set +o` line.
+case "${__build_data_saved_flags}" in *e*) set -e ;; *) set +e ;; esac
+case "${__build_data_saved_flags}" in *u*) set -u ;; *) set +u ;; esac
+eval "${__build_data_saved_pipefail}"
+unset __build_data_saved_flags __build_data_saved_pipefail

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -1,40 +1,20 @@
 #!/usr/bin/env bash
 
+# Enable strict mode for ShellCheck's benefit, but restore the caller's options at the end of
+# the file (see epilogue) so these don't bleed into the un-migrated scripts that source this
+# lib. The caller's flags are read from `$-`, which reflects the *current* shell — a
+# `$(set +o)` capture runs in a command-substitution subshell where bash always forces errexit
+# off, so it would record (and later restore) errexit as disabled even when the caller had it
+# enabled. `$-` has no letter for pipefail, so that one option is captured separately (it is
+# reported correctly inside command substitution).
+# shellcheck disable=SC2034 # both are consumed by the epilogue
+__output_saved_flags="$-"
+__output_saved_pipefail="$(set +o | grep pipefail)"
+set -euo pipefail
+
 ANSI_RED=$'\e[1;31m'
 ANSI_YELLOW=$'\e[1;33m'
 ANSI_RESET=$'\e[0m'
-
-# TODO: deprecated these in favor of https://github.com/heroku/heroku-buildpack-python/blob/main/lib/output.sh
-
-info() {
-  echo "       $*" || true
-}
-
-# format output and send a copy to the log
-output() {
-  local logfile="$1"
-
-  while IFS= read -r LINE;
-  do
-    # do not indent headers that are being piped through the output
-    if [[ "$LINE" =~ ^-----\>.* ]]; then
-      echo "$LINE" || true
-    else
-      echo "       $LINE" || true
-    fi
-    echo "$LINE" >> "$logfile" || true
-  done
-}
-
-header() {
-  echo "" || true
-  echo "-----> $*" || true
-}
-
-error() {
-  echo " !     $*" >&2 || true
-  echo "" || true
-}
 
 # Output a styled multi-line error message to stderr.
 #
@@ -47,22 +27,30 @@ error() {
 # EOF
 # ```
 output::error() {
-  echo >&2
-  sed --unbuffered "s/^/${ANSI_RED} !     /" | sed --unbuffered "s/$/${ANSI_RESET}/" >&2
-  echo >&2
+	echo >&2
+	sed --unbuffered "s/^/${ANSI_RED} !     /" | sed --unbuffered "s/$/${ANSI_RESET}/" >&2
+	echo >&2
 }
 
 output::step() {
-  echo ""
-  echo "-----> $*"
+	echo ""
+	echo "-----> $*"
 }
 
 output::indent() {
-  sed --unbuffered 's/^/       /'
+	sed --unbuffered 's/^/       /'
 }
 
 output::warning() {
-  echo >&2
-  sed --unbuffered "s/^/${ANSI_YELLOW} !     /" | sed --unbuffered "s/$/${ANSI_RESET}/" >&2
-  echo >&2
+	echo >&2
+	sed --unbuffered "s/^/${ANSI_YELLOW} !     /" | sed --unbuffered "s/$/${ANSI_RESET}/" >&2
+	echo >&2
 }
+
+# Restore the sourcing shell's original options (see preamble) so strict mode doesn't leak
+# into un-migrated callers. errexit/nounset come from the saved `$-`; pipefail from its own
+# saved `set +o` line.
+case "${__output_saved_flags}" in *e*) set -e ;; *) set +e ;; esac
+case "${__output_saved_flags}" in *u*) set -u ;; *) set +u ;; esac
+eval "${__output_saved_pipefail}"
+unset __output_saved_flags __output_saved_pipefail

--- a/makefile
+++ b/makefile
@@ -3,7 +3,9 @@
 # source of truth for what gets linted/formatted (CI invokes these targets, it does
 # not maintain its own list).
 MIGRATED_FILES = \
+	lib/build_data.sh \
 	lib/failures.sh \
+	lib/output.sh \
 	lib/package_manager.sh \
 	lib/package_managers/npm.sh \
 	lib/package_managers/pnpm.sh \

--- a/test/unit
+++ b/test/unit
@@ -1111,6 +1111,7 @@ source "$(pwd)"/lib/package_managers/yarn.sh
 source "$(pwd)"/lib/runtimes/nodejs.sh
 source "$(pwd)"/lib/monitor.sh
 source "$(pwd)"/lib/output.sh
+source "$(pwd)"/lib/_output.sh
 source "$(pwd)"/lib/_failures.sh
 source "$(pwd)"/profile/WEB_CONCURRENCY.sh
 


### PR DESCRIPTION
The classic buildpack's lint + namespaced-functions migration is tracked file-by-file via `MIGRATED_FILES`. This brings two more `lib/` files into that model so they're covered by `make lint` in CI.

`build_data.sh` (renamed from `builddata.sh` to match its `build_data::` namespace) was already tab-indented and namespaced; it only needed the strict-mode preamble/epilogue shield so its `set -euo pipefail` doesn't leak into the un-migrated scripts that source it.

`output.sh` was a hybrid — the namespaced `output::*` functions we want to keep, sitting alongside the deprecated non-namespaced `info`/`output`/`header`/`error` functions that both migrated and un-migrated code still call. Rather than block the migration on a cross-cutting rename of every call site, this splits the legacy functions into `lib/_output.sh` (following the existing `failures.sh` / `_failures.sh` precedent), which makes explicit what still needs cleanup. Retiring `_output.sh` once all callers move off `output`/`header` is left as follow-up.

W-23664744