### PR TITLE
Remove unreachable fail_yarn_install failure matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Migrated the pnpm lockfile-out-of-sync (`ERR_PNPM_OUTDATED_LOCKFILE`) build error onto the call-site failure-classification framework. ([#1735](https://github.com/heroku/heroku-buildpack-nodejs/pull/1735))
 - Added pnpm to verbose build-summary dependency listing. ([#1737](https://github.com/heroku/heroku-buildpack-nodejs/pull/1737))
+- Removed the unreachable `fail_yarn_install` build-error matcher, which only matched output from the inventory-based Yarn resolver removed in [#1420](https://github.com/heroku/heroku-buildpack-nodejs/pull/1420). ([#1742](https://github.com/heroku/heroku-buildpack-nodejs/pull/1742))
 
 ## [v360] - 2026-07-29
 

--- a/bin/compile
+++ b/bin/compile
@@ -92,7 +92,6 @@ handle_failure() {
     header "Build failed"
     fail_using_yarn2_with_yarn_production_environment_variable_set "$LOG_FILE"
     fail_yarn_outdated "$LOG_FILE"
-    fail_yarn_install "$LOG_FILE" "$BUILD_DIR"
     log_other_failures "$LOG_FILE"
     warn_untracked_dependencies "$LOG_FILE"
     warn_angular_resolution "$LOG_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -96,7 +96,6 @@ handle_failure() {
     header "Build failed"
     fail_using_yarn2_with_yarn_production_environment_variable_set "$LOG_FILE"
     fail_yarn_outdated "$LOG_FILE"
-    fail_yarn_install "$LOG_FILE" "$BUILD_DIR"
     log_other_failures "$LOG_FILE"
     warn_untracked_dependencies "$LOG_FILE"
     warn_angular_resolution "$LOG_FILE"

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -227,41 +227,6 @@ fail_yarn_outdated() {
   fi
 }
 
-fail_yarn_install() {
-  local yarn_engine
-  local log_file="$1"
-  local build_dir="$2"
-
-  if grep -qi 'Could not find Yarn version corresponding to version requirement' "$log_file"; then
-    yarn_engine=$(utils::json::read "$build_dir/package.json" ".engines.yarn")
-    build_data::set_string "failure" "invalid-yarn-version"
-    echo ""
-    warn "No matching version found for Yarn: $yarn_engine
-
-       Heroku supports most versions of Yarn published on npm, however you have
-       specified a version in package.json ($yarn_engine) that does not correspond
-       to any published version of Yarn. You can see a list of all published
-       versions of Yarn with the following command:
-
-       $ yarn info yarn versions
-
-       You should always specify a Yarn version that matches the version
-       you’re developing and testing with. To find your version locally:
-
-       $ yarn --version
-       1.12.3
-
-       Use the engines section of your package.json to specify the version of
-       Yarn to use on Heroku.
-
-       \"engines\": {
-         \"yarn\": \"1.x\"
-       }
-    " https://help.heroku.com/8MEL050H
-    fail
-  fi
-}
-
 # Yarn 2 failures
 
 fail_using_yarn2_with_yarn_production_environment_variable_set() {

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -231,41 +231,6 @@ fail_yarn_outdated() {
   fi
 }
 
-fail_yarn_install() {
-  local yarn_engine
-  local log_file="$1"
-  local build_dir="$2"
-
-  if grep -qi 'Could not find Yarn version corresponding to version requirement' "$log_file"; then
-    yarn_engine=$(read_json "$build_dir/package.json" ".engines.yarn")
-    build_data::set_string "failure" "invalid-yarn-version"
-    echo ""
-    warn "No matching version found for Yarn: $yarn_engine
-
-       Heroku supports most versions of Yarn published on npm, however you have
-       specified a version in package.json ($yarn_engine) that does not correspond
-       to any published version of Yarn. You can see a list of all published
-       versions of Yarn with the following command:
-
-       $ yarn info yarn versions
-
-       You should always specify a Yarn version that matches the version
-       you’re developing and testing with. To find your version locally:
-
-       $ yarn --version
-       1.12.3
-
-       Use the engines section of your package.json to specify the version of
-       Yarn to use on Heroku.
-
-       \"engines\": {
-         \"yarn\": \"1.x\"
-       }
-    " https://help.heroku.com/8MEL050H
-    fail
-  fi
-}
-
 # Yarn 2 failures
 
 fail_using_yarn2_with_yarn_production_environment_variable_set() {

--- a/lib/package_managers/yarn.sh
+++ b/lib/package_managers/yarn.sh
@@ -133,8 +133,8 @@ function package_managers::yarn::install_dependencies() {
 		# No known failure mode recognised. Bubble up by returning yarn's exit code: the pipeline
 		# that runs this install (`build_dependencies | output "$LOG_FILE"`) then fails under
 		# errexit/pipefail, the legacy ERR trap fires, and `log_other_failures` classifies the
-		# failure from $LOG_FILE — covering the yarn 1.x cases (fail_yarn_outdated, fail_yarn_install)
-		# not yet migrated here, instead of masking them with a generic message.
+		# failure from $LOG_FILE — covering the yarn 1.x cases (fail_yarn_outdated) not yet
+		# migrated here, instead of masking them with a generic message.
 		return "${yarn_exit}"
 	fi
 
@@ -208,7 +208,7 @@ function package_managers::yarn::_handle_yarn_classic_install_failure() {
 	fi
 
 	# TODO: classify additional yarn 1.x failures currently handled by the legacy trap
-	# (fail_yarn_outdated, fail_yarn_install) in a follow-up migration.
+	# (fail_yarn_outdated) in a follow-up migration.
 
 	# No known failure mode recognised — signal no match so the caller can fall through.
 	return 1


### PR DESCRIPTION
The `fail_yarn_install` matcher fires only when a build log contains `Could not find Yarn version corresponding to version requirement`. That string was produced exclusively by the old inventory-based Yarn resolver, which was removed in #1420 when Yarn switched to installing directly via `npm install yarn@<version>`. Since then nothing in the buildpack can emit it, so the matcher is dead code.

Removing it loses no live coverage. A requested Yarn version that doesn't exist is already handled at the source inside `package_managers::yarn::install_binary` (`yarn-install-failed` / `yarn-resolve-failed`), and a bad `npm install yarn@<version>` is caught by the `notarget` matcher in `log_other_failures`. The `invalid-yarn-version` failure slug this matcher recorded was already unreachable.

W-23664997