### PR TITLE
Migrate the Yarn 2+ (Berry) YARN_PRODUCTION build error to call-site failure classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Migrated the Yarn 2+ (Berry) `YARN_PRODUCTION` build error onto the call-site failure-classification framework. The buildpack now detects the unsupported configuration before running any Yarn command and fails with a clearer message. ([#1756](https://github.com/heroku/heroku-buildpack-nodejs/pull/1756))
 
 ## [v362] - 2026-08-07
 

--- a/bin/compile
+++ b/bin/compile
@@ -94,7 +94,6 @@ handle_failure() {
   # specific message emit already printed. Migrated failures are self-contained by design.
   if [[ ! -e "${FAILURE_EMITTED_MARKER:-}" ]]; then
     header "Build failed"
-    fail_using_yarn2_with_yarn_production_environment_variable_set "$LOG_FILE"
     fail_yarn_outdated "$LOG_FILE"
     fail_yarn_install "$LOG_FILE" "$BUILD_DIR"
     log_other_failures "$LOG_FILE"
@@ -147,6 +146,11 @@ create_build_env
 export VENDOR_PATH
 
 if [[ "$YARN_2" == "true" ]]; then
+  # Fail fast before any yarn command runs: YARN_PRODUCTION aborts Berry's config load, so
+  # whichever yarn invocation runs first (install, prune, or a `yarn run` script hook) would
+  # otherwise blow up mid-build with an opaque clipanion error.
+  package_managers::yarn::fail_if_yarn_production_env_set_on_berry "${YARN_PRODUCTION:-}"
+
   if [[ -f "$BUILD_DIR/.npmrc" ]]; then
     warn "There is an existing .npmrc file that will not be used. All configurations are read from the .yarnrc.yml file." "https://devcenter.heroku.com/articles/migrating-to-yarn-2"
   fi

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -264,32 +264,6 @@ fail_yarn_install() {
 
 # Yarn 2 failures
 
-fail_using_yarn2_with_yarn_production_environment_variable_set() {
-  local yarn_engine
-  local skip_pruning
-  local log_file="$1"
-
-  if grep -qi 'Unrecognized or legacy configuration settings found: production' "$log_file"; then
-    yarn_engine=$(yarn --version)
-    if [[ "$YARN_PRODUCTION" == "true" ]]; then
-      skip_pruning=false
-    else
-      skip_pruning=true
-    fi
-
-    build_data::set_string "failure" "yarn2-with-yarn-production-env-set"
-    echo ""
-    warn "Legacy Yarn 1.x configuration present:
-
-       Your application uses Yarn v$yarn_engine which does not support the YARN_PRODUCTION environment variable. Please
-       update your heroku config vars to remove YARN_PRODUCTION and set YARN2_SKIP_PRUNING instead.
-
-         $ heroku config:unset YARN_PRODUCTION && heroku config:set YARN2_SKIP_PRUNING=$skip_pruning
-    " https://devcenter.heroku.com/articles/nodejs-support#skip-pruning
-    fail
-  fi
-}
-
 fail_missing_yarnrc_yml() {
   local build_dir="$1"
 

--- a/lib/package_managers/yarn.sh
+++ b/lib/package_managers/yarn.sh
@@ -59,6 +59,52 @@ function package_managers::yarn::install_binary() {
 	fi
 }
 
+# Fails fast when a Yarn 2+ (Berry) build has the legacy yarn 1.x `YARN_PRODUCTION` variable set.
+# Berry maps it to the unregistered `production` setting and aborts config load — with a strict
+# clipanion UsageError — on EVERY yarn invocation (install, prune, and `yarn run <script>` for the
+# prebuild/build/cleanup hooks). Detecting the condition here, before any yarn command runs, fails
+# once with actionable guidance instead of letting whichever yarn command happens to run first
+# blow up partway through the build. Emits directly (the cause is known locally, so there is no log
+# to classify); a no-op when the variable is unset, so the caller can invoke it unconditionally.
+function package_managers::yarn::fail_if_yarn_production_env_set_on_berry() {
+	local yarn_production="${1:-}"
+
+	if [[ -z "${yarn_production}" ]]; then
+		return 0
+	fi
+
+	# Preserve the legacy matcher's value-sensitive guidance: YARN_PRODUCTION=true meant the app
+	# wanted production-only installs (prune devDependencies), so the equivalent Berry setting keeps
+	# pruning (YARN2_SKIP_PRUNING=false); any other value meant keep devDependencies, so it skips
+	# pruning (YARN2_SKIP_PRUNING=true). Hardcoding one value would invert intent for the common
+	# YARN_PRODUCTION=true case, leaving devDependencies in the slug.
+	local skip_pruning
+	if [[ "${yarn_production}" == "true" ]]; then
+		skip_pruning="false"
+	else
+		skip_pruning="true"
+	fi
+
+	local -A failure
+	failure["id"]="yarn2-with-yarn-production-env-set"
+	failure["classification"]="user"
+	failure["message"]=$(
+		cat <<-EOF
+			Unsupported Yarn configuration: YARN_PRODUCTION
+
+			Yarn 2+ (Berry) does not support the YARN_PRODUCTION environment
+			variable and stops the build while loading its configuration.
+
+			To fix, remove YARN_PRODUCTION and use YARN2_SKIP_PRUNING to control
+			whether devDependencies are pruned after the build:
+
+			\$ heroku config:unset YARN_PRODUCTION
+			\$ heroku config:set YARN2_SKIP_PRUNING=${skip_pruning}
+		EOF
+	)
+	failure::emit failure
+}
+
 # Yarn 2+ (aka: "berry") is hosted under a different npm package so we need to do some
 # extra checking to determine the correct package name.
 function package_managers::yarn::_determine_package_name() {
@@ -451,12 +497,9 @@ function package_managers::yarn::_handle_prune_pipefail() {
 
 # Pure classifier for yarn 1.x (classic) devDependency-prune failures. Yarn 2+ (Berry) has a
 # separate prune path (`_prune_berry_devdependencies`) with its own classifier. No prune-specific
-# failure mode is recognised today: the only yarn-prune-associated legacy matcher
-# (yarn2-with-yarn-production-env-set) actually fires at the Berry *install* step, not here — the
-# prune step returns early when YARN_PRODUCTION is set — so it stays on the legacy trap (see
-# lib/_failures.sh). This stub always returns 1 so the caller bubbles the raw exit code to the
-# legacy trap; it is kept for symmetry with the classic install classifier and as the home for any
-# future yarn 1.x prune matcher.
+# failure mode is recognised today. This stub always returns 1 so the caller bubbles the raw exit
+# code to the legacy trap; it is kept for symmetry with the classic install classifier and as the
+# home for any future yarn 1.x prune matcher.
 #
 # Input:
 #   $1  path to a log file containing the captured output of the failed yarn prune command
@@ -550,10 +593,9 @@ function package_managers::yarn::_prune_berry_devdependencies() {
 
 # Pure classifier for yarn 2+ (Berry) devDependency-prune failures. Yarn 1.x (classic) has a
 # separate prune path (`_prune_classic_devdependencies`) with its own classifier. No prune-specific
-# failure mode is recognised today (see the classic prune classifier's note on
-# yarn2-with-yarn-production-env-set, which belongs to the Berry install step, not prune). This
-# stub always returns 1 so the caller bubbles the raw exit code to the legacy trap; it is kept for
-# symmetry with the Berry install classifier and as the home for any future Berry prune matcher.
+# failure mode is recognised today. This stub always returns 1 so the caller bubbles the raw exit
+# code to the legacy trap; it is kept for symmetry with the Berry install classifier and as the
+# home for any future Berry prune matcher.
 #
 # Input:
 #   $1  path to a log file containing the captured output of the failed yarn prune command

--- a/test/run-yarn
+++ b/test/run-yarn
@@ -324,8 +324,8 @@ testYarn2WithYarnProductionSetCapturesAndReportsError() {
    env_dir=$(mktmpdir)
    echo "false" > $env_dir/YARN_PRODUCTION
    compile "yarn-2" "$(mktmpdir)" $env_dir
-   assertCaptured "Legacy Yarn 1.x configuration present"
-   assertCapturedError
+   assertCapturedError "Unsupported Yarn configuration: YARN_PRODUCTION"
+   assertCapturedStderr "YARN2_SKIP_PRUNING=true"
  }
 
 

--- a/test/unit
+++ b/test/unit
@@ -738,6 +738,59 @@ testHandleYarnInstallPipefail() {
   rm -f "$capture"
 }
 
+testFailProductionEnvSetPrunesWhenProductionTrue() {
+  # YARN_PRODUCTION=true meant "production install" under yarn 1.x, so the migration guidance keeps
+  # pruning by recommending YARN2_SKIP_PRUNING=false.
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >>"$capture"; }
+    package_managers::yarn::fail_if_yarn_production_env_set_on_berry "true" 2>&1 || true
+  )
+
+  assertContains "$out" "Unsupported Yarn configuration: YARN_PRODUCTION"
+  assertContains "$out" "heroku config:unset YARN_PRODUCTION"
+  assertContains "$out" "heroku config:set YARN2_SKIP_PRUNING=false"
+  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
+  assertContains "$(cat "$capture")" "failure=yarn2-with-yarn-production-env-set"
+  assertContains "$(cat "$capture")" "failure_classification=user"
+  rm -f "$capture"
+}
+
+testFailProductionEnvSetSkipsPruneForOtherValues() {
+  # Any non-"true" value meant "keep devDependencies", so the guidance skips pruning
+  # (YARN2_SKIP_PRUNING=true).
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >>"$capture"; }
+    package_managers::yarn::fail_if_yarn_production_env_set_on_berry "false" 2>&1 || true
+  )
+
+  assertContains "$out" "heroku config:set YARN2_SKIP_PRUNING=true"
+  assertContains "$(cat "$capture")" "failure=yarn2-with-yarn-production-env-set"
+  rm -f "$capture"
+}
+
+testFailProductionEnvSetIsNoOpWhenUnset() {
+  # The guard is invoked unconditionally from bin/compile, so an unset YARN_PRODUCTION must not
+  # emit or fail — it returns 0 with no output and no build-data writes.
+  local out capture rc
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >>"$capture"; }
+    package_managers::yarn::fail_if_yarn_production_env_set_on_berry "" 2>&1
+  ) && rc=0 || rc=$?
+
+  assertEquals "guard should return 0 when YARN_PRODUCTION is unset" "0" "${rc}"
+  assertEquals "guard should emit nothing when YARN_PRODUCTION is unset" "" "$out"
+  assertEquals "guard should not write build data when YARN_PRODUCTION is unset" "" "$(cat "$capture")"
+  rm -f "$capture"
+}
+
 testHandlePnpmInstallLockfileOutOfSync() {
   local -A result
   package_managers::pnpm::_handle_install_failure "$(pwd)/test/unit-fixtures/pnpm-failures/outdated-lockfile.log" result


### PR DESCRIPTION
Yarn 2+ (Berry) doesn't support the `YARN_PRODUCTION` environment variable — it aborts while loading its configuration, so a build with `YARN_PRODUCTION` set fails with an opaque clipanion error on whichever yarn command happens to run first (install, prune, or a `yarn run` script hook such as `heroku-prebuild`).

This detects the unsupported configuration up front, before any yarn command runs, and fails fast with a clear, actionable message that tells the user to unset `YARN_PRODUCTION` and set `YARN2_SKIP_PRUNING` instead — preserving the value-sensitive pruning guidance the previous error gave. Because the check runs before every yarn invocation by construction, it fully replaces the old log-scraping trap matcher, which is removed.

Fixes W-23796452