### PR TITLE
Migrate iojs-unsupported error onto call-site failure classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Migrated the io.js unsupported (`iojs-unsupported`) build error onto the call-site failure-classification framework. ([#1757](https://github.com/heroku/heroku-buildpack-nodejs/pull/1757))
 
 ## [v362] - 2026-08-07
 

--- a/bin/compile
+++ b/bin/compile
@@ -121,7 +121,7 @@ fail_dot_heroku_node "$BUILD_DIR"
 fail_invalid_package_json "$BUILD_DIR"
 fail_multiple_lockfiles "$BUILD_DIR"
 fail_conflicting_package_manager_metadata "$BUILD_DIR"
-fail_iojs_unsupported "$BUILD_DIR"
+runtimes::nodejs::fail_iojs_unsupported "$BUILD_DIR"
 warn_prebuilt_modules "$BUILD_DIR"
 warn_missing_package_json "$BUILD_DIR"
 

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -77,34 +77,6 @@ fail_dot_heroku_node() {
   fi
 }
 
-fail_iojs_unsupported() {
-  local build_dir="$1"
-  local iojs_engine
-  iojs_engine=$(utils::json::read "$build_dir/package.json" ".engines.iojs")
-
-  if [ -n "$iojs_engine" ]; then
-    build_data::set_string "failure" "iojs-unsupported"
-    warn "io.js no longer supported
-
-       You are specifying an io.js version in your package.json:
-
-       \"engines\": {
-         ...
-         \"iojs\": \"${iojs_engine}\"
-       }
-
-       io.js merged back into Nodejs.org in 2015 and has been unsupported
-       for many years. It is likely to contain several large security
-       vulnerabilities that have been patched in Node.
-
-       You can update your app to use the official Node.js release by
-       removing the version specfication under \"engines\" in your
-       package.json.
-       "
-    fail
-  fi
-}
-
 # Builds the "keep one, remove the rest" fix instructions for a multiple-lockfiles error.
 # Given the detected package manager names as arguments (e.g. "npm" "pnpm" "Yarn"), it prints
 # one block per package manager listing the exact `git rm` command needed to remove the other

--- a/lib/runtimes/nodejs.sh
+++ b/lib/runtimes/nodejs.sh
@@ -58,6 +58,20 @@ function runtimes::nodejs::install() {
 	build_data::set_string "bundled_npm_version" "${bundled_npm_version}"
 }
 
+# Pre-flight guard: fails the build when the app requests an io.js version via
+# `engines.iojs` in package.json. io.js merged back into Node.js in 2015 and is long
+# unsupported. Reads the requested version and, if present, hands off to the emit-at-site
+# helper (which prints the message, records build data, and exits).
+function runtimes::nodejs::fail_iojs_unsupported() {
+	local build_dir="${1}"
+	local iojs_engine
+	iojs_engine=$(utils::json::read "${build_dir}/package.json" ".engines.iojs")
+
+	if [[ -n "${iojs_engine}" ]]; then
+		runtimes::nodejs::_fail_iojs_unsupported "${iojs_engine}"
+	fi
+}
+
 function runtimes::nodejs::_install() {
 	local requested_version="${1:-}"
 	local dir="${2:?}"
@@ -360,6 +374,35 @@ function runtimes::nodejs::_fail_resolve() {
 			This is usually a temporary problem on our side. Please try building again.
 			If the problem persists, open a support ticket:
 			https://help.heroku.com/
+		EOF
+	)
+	failure::emit failure
+}
+
+# Emits the classified failure for an app that requests an io.js version via `engines.iojs`
+# in package.json. Keeps the historical `iojs-unsupported` failure id for metric continuity.
+# Classified `user` — the app controls this entry. See runtimes::nodejs::_fail_node_download
+# for why this emits directly at the call site.
+function runtimes::nodejs::_fail_iojs_unsupported() {
+	local iojs_engine="${1}"
+	local -A failure
+	failure["id"]="iojs-unsupported"
+	failure["classification"]="user"
+	failure["detail"]="${iojs_engine}"
+	failure["message"]=$(
+		cat <<-EOF
+			Error: io.js is no longer supported.
+
+			Your package.json requests an io.js version:
+
+			"engines": {
+			  "iojs": "${iojs_engine}"
+			}
+
+			io.js merged back into Node.js in 2015 and has been unsupported for many years.
+			It likely contains security vulnerabilities that have since been patched in Node.js.
+
+			To fix this, remove the "iojs" entry under "engines" in your package.json.
 		EOF
 	)
 	failure::emit failure

--- a/test/run-general
+++ b/test/run-general
@@ -459,8 +459,7 @@ testDetectWithoutPackageJson() {
 
 testIoJs() {
   compile "iojs"
-  assertCaptured "io.js no longer supported"
-  assertCapturedError
+  assertCapturedError 1 "io.js is no longer supported"
 }
 
 ###

--- a/test/unit
+++ b/test/unit
@@ -1075,6 +1075,23 @@ testFailUnsupportedChecksumEmitsDetailedMessage() {
   rm -f "$capture"
 }
 
+testFailIojsUnsupportedEmitsDetailedMessage() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::_fail_iojs_unsupported "3.3.1"
+
+  # The message names io.js, echoes the requested version, and gives the fix instruction.
+  assertContains "$out" "Error: io.js is no longer supported."
+  assertContains "$out" '"iojs": "3.3.1"'
+  assertContains "$out" 'remove the "iojs" entry under "engines" in your package.json'
+  # The historical failure id is preserved for metric continuity; app-controlled input.
+  assertContains "$(cat "$capture")" "failure=iojs-unsupported"
+  assertContains "$(cat "$capture")" "failure_classification=user"
+  assertContains "$(cat "$capture")" "failure_detail=3.3.1"
+  rm -f "$capture"
+}
+
 testExtractErrorDetailReturnsFirstDescriptiveLine() {
   # Skips the bare `code <CODE>` line and the "complete log" noise, strips the
   # `npm error `/`npm ERR! ` prefix (but keeps any keyword like `notsup` that follows).


### PR DESCRIPTION
Continues the migration off the global `handle_failure` ERR trap and onto call-site failure classification (see `lib/failures.sh` for the target model). The io.js pre-flight guard was one of the last holdouts still living in `lib/_failures.sh` as a standalone function with an inline `warn`/`fail` pair, giving it no `classification` or structured `detail` for build-data/metrics purposes.

This moves the guard into `lib/runtimes/nodejs.sh` (alongside the other Node.js runtime failure helpers) as an emit-at-site helper, following the same public/private split as `runtimes::nodejs::_fail_node_download` and `runtimes::nodejs::_fail_no_version_resolved`. It keeps the historical `iojs-unsupported` failure id for metric continuity and classifies it `user`, since the app controls its own `engines.iojs` entry.

W-23796439