### PR TITLE
Migrate invalid-package-json error onto call-site failure classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Migrated the invalid package.json (`invalid-package-json`) build error onto the call-site failure-classification framework. ([#1758](https://github.com/heroku/heroku-buildpack-nodejs/pull/1758))
 
 ## [v362] - 2026-08-07
 

--- a/bin/compile
+++ b/bin/compile
@@ -115,7 +115,7 @@ YARN_2=$(package_managers::yarn::detect_berry "$YARN" "$BUILD_DIR")
 
 fail_dot_heroku "$BUILD_DIR"
 fail_dot_heroku_node "$BUILD_DIR"
-fail_invalid_package_json "$BUILD_DIR"
+utils::package_json::fail_invalid "$BUILD_DIR"
 fail_multiple_lockfiles "$BUILD_DIR"
 fail_conflicting_package_manager_metadata "$BUILD_DIR"
 fail_iojs_unsupported "$BUILD_DIR"

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -37,16 +37,6 @@ failure_message() {
   echo ""
 }
 
-fail_invalid_package_json() {
-  if ! utils::json::is_valid "${1:-}/package.json"; then
-    error "Unable to parse package.json"
-    build_data::set_string "failure" "invalid-package-json"
-    header "Build failed"
-    failure_message
-    fail
-  fi
-}
-
 fail_dot_heroku() {
   if [ -f "${1:-}/.heroku" ]; then
     build_data::set_string "failure" "dot-heroku"

--- a/lib/utils/package_json.sh
+++ b/lib/utils/package_json.sh
@@ -22,6 +22,40 @@ function utils::package_json::has_script() {
 	fi
 }
 
+# Pre-flight guard: fails the build when the app's package.json is not parseable JSON. Checks
+# the file and, if it is invalid, hands off to the emit-at-site helper (which prints the
+# message, records build data, and exits).
+function utils::package_json::fail_invalid() {
+	local build_dir="${1}"
+
+	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
+	if ! utils::json::is_valid "${build_dir}/package.json"; then
+		utils::package_json::_fail_invalid
+	fi
+}
+
+# Emits the classified failure for an app whose package.json cannot be parsed as JSON. Keeps
+# the historical `invalid-package-json` failure id for metric continuity. Classified `user` —
+# the app controls this file. See runtimes::nodejs::_fail_iojs_unsupported for why this emits
+# directly at the call site.
+function utils::package_json::_fail_invalid() {
+	local -A failure
+	failure["id"]="invalid-package-json"
+	failure["classification"]="user"
+	failure["message"]=$(
+		cat <<-EOF
+			Error: Unable to parse your package.json.
+
+			Your package.json contains invalid JSON and could not be read.
+
+			Check the file for syntax errors such as trailing commas, missing commas,
+			or unquoted keys, then commit and redeploy. You can validate it locally by
+			running \`jq . package.json\` or using an online JSON linter.
+		EOF
+	)
+	failure::emit failure
+}
+
 # Restore the sourcing shell's original options (see preamble). errexit/nounset come from the
 # saved `$-`; pipefail from its own saved `set +o` line.
 case "${__package_json_saved_flags}" in *e*) set -e ;; *) set +e ;; esac

--- a/test/run-general
+++ b/test/run-general
@@ -304,8 +304,9 @@ testUntrackedDependencies() {
 testBadJson() {
   compile "bad-json"
   assertCaptured "Build failed"
-  assertCaptured "We're sorry this build is failing"
   assertNotCaptured "Installing binaries"
+  # The migrated invalid-package-json path renders the failure via failure::emit, which writes
+  # the message to stderr and suppresses the legacy handle_failure footer.
   assertCapturedError 1 "Unable to parse"
 }
 

--- a/test/unit
+++ b/test/unit
@@ -97,6 +97,45 @@ testJsonValid() {
     "utils::json::is_valid '$(pwd)/test/fixtures/bad-json/package.json'"
 }
 
+testFailInvalidPackageJsonEmitsDetailedMessage() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    utils::package_json::_fail_invalid
+
+  # The message names package.json and gives concrete syntax-error fix guidance.
+  assertContains "$out" "Error: Unable to parse your package.json."
+  assertContains "$out" "invalid JSON"
+  assertContains "$out" "jq . package.json"
+  # The historical failure id is preserved for metric continuity; app-controlled input.
+  assertContains "$(cat "$capture")" "failure=invalid-package-json"
+  assertContains "$(cat "$capture")" "failure_classification=user"
+  rm -f "$capture"
+}
+
+testFailInvalidPackageJsonGuardEmitsOnMalformedJson() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    utils::package_json::fail_invalid "$(pwd)/test/fixtures/bad-json"
+
+  assertContains "$out" "Error: Unable to parse your package.json."
+  assertContains "$(cat "$capture")" "failure=invalid-package-json"
+  rm -f "$capture"
+}
+
+testFailInvalidPackageJsonGuardDoesNotEmitOnValidJson() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    utils::package_json::fail_invalid "$(pwd)/test/fixtures/has-script-fixtures"
+
+  # Valid JSON: the guard never reaches the emit helper, so nothing is printed or recorded.
+  assertNull "valid package.json should not emit a failure message" "$out"
+  assertEquals "valid package.json should not record a failure" "" "$(cat "$capture")"
+  rm -f "$capture"
+}
+
 testAssertMetricsBasicQueries() {
   local cache_dir=$(mktemp -d)
   local metrics_dir="${cache_dir}/build-data"


### PR DESCRIPTION
Continues the migration off the global `handle_failure` ERR trap and onto call-site failure classification (see `lib/failures.sh` for the target model). The invalid package.json check was a pre-flight guard still living in `lib/_failures.sh` as a standalone function with an inline `error`/`fail` pair, giving it no `classification` for build-data/metrics purposes.

This moves the guard into `lib/utils/package_json.sh` as an emit-at-site helper, following the same public/private split as `runtimes::nodejs::fail_iojs_unsupported`. It keeps the historical `invalid-package-json` failure id for metric continuity and classifies it `user`, since the app controls its own `package.json`. The user-facing message was reworded to the newer emit-at-site house style.

Tested with new unit tests covering the emit helper and the public guard against both malformed and valid `package.json` fixtures; the existing `bad-json` integration test was updated to match the new emit-at-site output.

W-23798005