### PR TITLE
Migrate the checked-in .heroku file build error onto call-site failure classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Migrated the checked-in `.heroku` / `.heroku/node` file build error onto the call-site failure-classification framework. ([#1761](https://github.com/heroku/heroku-buildpack-nodejs/pull/1761))
 
 ## [v362] - 2026-08-07
 

--- a/bin/compile
+++ b/bin/compile
@@ -113,8 +113,7 @@ YARN_2=$(package_managers::yarn::detect_berry "$YARN" "$BUILD_DIR")
 
 ### Failures that should be caught immediately
 
-fail_dot_heroku "$BUILD_DIR"
-fail_dot_heroku_node "$BUILD_DIR"
+runtimes::nodejs::fail_dot_heroku "$BUILD_DIR"
 fail_invalid_package_json "$BUILD_DIR"
 fail_multiple_lockfiles "$BUILD_DIR"
 fail_conflicting_package_manager_metadata "$BUILD_DIR"

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -47,36 +47,6 @@ fail_invalid_package_json() {
   fi
 }
 
-fail_dot_heroku() {
-  if [ -f "${1:-}/.heroku" ]; then
-    build_data::set_string "failure" "dot-heroku"
-    header "Build failed"
-    warn "The directory .heroku could not be created
-
-       It looks like a .heroku file is checked into this project.
-       The Node.js buildpack uses the hidden directory .heroku to store
-       binaries like the node runtime and npm. You should remove the
-       .heroku file or ignore it by adding it to .slugignore
-       "
-    fail
-  fi
-}
-
-fail_dot_heroku_node() {
-  if [ -f "${1:-}/.heroku/node" ]; then
-    build_data::set_string "failure" "dot-heroku-node"
-    header "Build failed"
-    warn "The directory .heroku/node could not be created
-
-       It looks like a .heroku file is checked into this project.
-       The Node.js buildpack uses the hidden directory .heroku to store
-       binaries like the node runtime and npm. You should remove the
-       .heroku file or ignore it by adding it to .slugignore
-       "
-    fail
-  fi
-}
-
 fail_iojs_unsupported() {
   local build_dir="$1"
   local iojs_engine

--- a/lib/runtimes/nodejs.sh
+++ b/lib/runtimes/nodejs.sh
@@ -365,6 +365,44 @@ function runtimes::nodejs::_fail_resolve() {
 	failure::emit failure
 }
 
+# Preflight guard: fails the build when a `.heroku` or `.heroku/node` file is checked into the
+# app. The buildpack creates the hidden `.heroku` (and `.heroku/node`) directory to install
+# binaries into, so a checked-in file at either path blocks the build. The two conditions are
+# mutually exclusive — a regular `.heroku` file precludes a `.heroku/node` path and vice versa —
+# so a single check routes to the matching failure id. The guard checks the condition; the paired
+# _fail_* helper emits (see the emit-at-site rationale on runtimes::nodejs::_fail_node_download).
+function runtimes::nodejs::fail_dot_heroku() {
+	local build_dir="${1:?}"
+	if [[ -f "${build_dir}/.heroku" ]]; then
+		runtimes::nodejs::_fail_dot_heroku ".heroku" "dot-heroku"
+	elif [[ -f "${build_dir}/.heroku/node" ]]; then
+		runtimes::nodejs::_fail_dot_heroku ".heroku/node" "dot-heroku-node"
+	fi
+}
+
+# Emits the classified failure for a checked-in `.heroku`-family file and exits. Classified
+# `user` because the app checked the file into source control. Takes the offending path and the
+# historical failure id (`dot-heroku` or `dot-heroku-node`), which is preserved for metric
+# continuity.
+function runtimes::nodejs::_fail_dot_heroku() {
+	local path="${1:?}"
+	local id="${2:?}"
+	local -A failure
+	failure["id"]="${id}"
+	failure["classification"]="user"
+	failure["message"]=$(
+		cat <<-EOF
+			Error: The directory ${path} could not be created.
+
+			It looks like a .heroku file is checked into this project. The Node.js
+			buildpack uses the hidden directory .heroku to store binaries like the
+			node runtime and npm. You should remove the .heroku file or ignore it
+			by adding it to .slugignore.
+		EOF
+	)
+	failure::emit failure
+}
+
 function runtimes::nodejs::install_metrics_plugin() {
 	local major minor
 	local bp_dir="$1"

--- a/test/run-general
+++ b/test/run-general
@@ -262,21 +262,21 @@ testWarningsOnFailure() {
 
 testDotHerokuCollision() {
   compile "dot-heroku-collision"
-  assertCaptured "The directory .heroku could not be created"
-  assertCaptured ".heroku file is checked into this project"
+  assertCapturedStderr "The directory .heroku could not be created"
+  assertCapturedStderr ".heroku file is checked into this project"
   assertNotCaptured "please submit a ticket"
   assertCapturedError
 
   compile "dot-heroku-collision-2"
-  assertNotCaptured ".heroku file is checked into this project"
+  assertNotCapturedStderr ".heroku file is checked into this project"
   assertCapturedSuccessWithWarnings
 }
 
 
 testDotHerokuNodeCollision() {
   compile "dot-heroku-node-collision"
-  assertCaptured "The directory .heroku/node could not be created"
-  assertCaptured ".heroku file is checked into this project"
+  assertCapturedStderr "The directory .heroku/node could not be created"
+  assertCapturedStderr ".heroku file is checked into this project"
   assertNotCaptured "please submit a ticket"
   assertCapturedError
 }

--- a/test/unit
+++ b/test/unit
@@ -1052,6 +1052,78 @@ testFailUnsupportedChecksumEmitsDetailedMessage() {
   rm -f "$capture"
 }
 
+testFailDotHerokuEmitsDetailedMessage() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::_fail_dot_heroku ".heroku" "dot-heroku"
+
+  assertContains "$out" "Error: The directory .heroku could not be created."
+  assertContains "$out" "a .heroku file is checked into this project"
+  # The historical failure id is preserved for metric continuity.
+  assertContains "$(cat "$capture")" "failure=dot-heroku"
+  assertContains "$(cat "$capture")" "failure_classification=user"
+  rm -f "$capture"
+}
+
+testFailDotHerokuNodeEmitsDetailedMessage() {
+  local out capture
+  capture=$(mktemp)
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::_fail_dot_heroku ".heroku/node" "dot-heroku-node"
+
+  assertContains "$out" "Error: The directory .heroku/node could not be created."
+  assertContains "$out" "a .heroku file is checked into this project"
+  assertContains "$(cat "$capture")" "failure=dot-heroku-node"
+  assertContains "$(cat "$capture")" "failure_classification=user"
+  rm -f "$capture"
+}
+
+testGuardDotHerokuEmitsWhenFilePresent() {
+  local out capture build_dir
+  capture=$(mktemp)
+  build_dir=$(mktemp -d)
+  touch "$build_dir/.heroku"
+
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::fail_dot_heroku "$build_dir"
+
+  assertContains "$out" "Error: The directory .heroku could not be created."
+  assertContains "$(cat "$capture")" "failure=dot-heroku"
+  rm -rf "$build_dir"
+  rm -f "$capture"
+}
+
+testGuardDotHerokuNoopWhenFileAbsent() {
+  local out capture build_dir
+  capture=$(mktemp)
+  build_dir=$(mktemp -d)
+
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::fail_dot_heroku "$build_dir"
+
+  assertEquals "no message should be emitted when .heroku is absent" "" "$out"
+  assertEquals "no classified failure should be recorded" "" "$(cat "$capture")"
+  rm -rf "$build_dir"
+  rm -f "$capture"
+}
+
+testGuardDotHerokuNodeEmitsWhenFilePresent() {
+  local out capture build_dir
+  capture=$(mktemp)
+  build_dir=$(mktemp -d)
+  mkdir -p "$build_dir/.heroku"
+  touch "$build_dir/.heroku/node"
+
+  _capture_node_fail out "$capture" \
+    runtimes::nodejs::fail_dot_heroku "$build_dir"
+
+  assertContains "$out" "Error: The directory .heroku/node could not be created."
+  assertContains "$(cat "$capture")" "failure=dot-heroku-node"
+  rm -rf "$build_dir"
+  rm -f "$capture"
+}
+
 testExtractErrorDetailReturnsFirstDescriptiveLine() {
   # Skips the bare `code <CODE>` line and the "complete log" noise, strips the
   # `npm error `/`npm ERR! ` prefix (but keeps any keyword like `notsup` that follows).


### PR DESCRIPTION
Continues the migration of the classic buildpack off its global `ERR` trap and onto call-site failure classification, so build errors are handled and classified where they occur rather than by a distant trap matching on log output.

This moves the two checked-in-`.heroku`-file preflight guards out of the legacy `lib/_failures.sh` and onto the framework in `lib/runtimes/nodejs.sh`, where the runtime install directory (`.heroku/node`) is owned. The `.heroku` and `.heroku/node` conditions are mutually exclusive on the filesystem, so they collapse into a single guard that emits the correct classification per case. The historical `dot-heroku` / `dot-heroku-node` failure ids are preserved for metric continuity, and the user-facing messages are unchanged in meaning.

Tested with unit tests covering the guard and the emit helper for both paths.

W-23799359