### PR TITLE
Migrate bad-version-for-dependency error to call-site classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Migrated the bad-version-for-dependency build error for npm and Yarn classic onto the call-site failure-classification framework. ([#1763](https://github.com/heroku/heroku-buildpack-nodejs/pull/1763))
 
 ## [v362] - 2026-08-07
 

--- a/lib/_failures.sh
+++ b/lib/_failures.sh
@@ -368,13 +368,6 @@ log_other_failures() {
     return 0
   fi
 
-  # "notarget No matching version found for" = npm
-  # "error Couldn't find any versions for" = yarn
-  if grep -q -e "notarget No matching version found for" -e "error Couldn't find any versions for" "$log_file"; then
-    build_data::set_string "failure" "bad-version-for-dependency"
-    return 0
-  fi
-
   if grep -qi "You are likely using a version of node-tar or npm that is incompatible with this version of Node.js" "$log_file"; then
     build_data::set_string "failure" "node-9-npm-issue"
     return 0

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -432,8 +432,32 @@ function package_managers::npm::_handle_npm_install_failure() {
 		return 0
 	fi
 
+	# npm ETARGET code — stable npm v3–v11. Thrown by npm-pick-manifest when no published version
+	# satisfies the requested range; error-message.js (case 'ETARGET') surfaces the code on the
+	# `npm error code ETARGET` summary line and renders the message under a `notarget` heading.
+	# Matched on the code (like the npm code matchers above) rather than the `notarget` message
+	# text — the code is the stable discriminator. E403 (policy-forbidden) is thrown from the same
+	# npm-pick-manifest path with a distinct code, so this will not over-match it. The legacy
+	# failure id (`bad-version-for-dependency`) is preserved verbatim so the `failure` build-data
+	# key stays continuous for downstream metrics.
+	if grep -qiE 'npm (ERR!|error) code ETARGET($| )' "${log_file}"; then
+		__failure["id"]="bad-version-for-dependency"
+		__failure["classification"]="user"
+		__failure["detail"]="ETARGET: $(package_managers::npm::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: Unable to install dependencies using npm.
+
+				One of your dependencies requests a package version that does not exist
+				in the npm registry. Check the log output above for the offending package
+				and version range, and update it to a version that has been published.
+			EOF
+		)
+		return 0
+	fi
+
 	# TODO: classify additional npm codes present in error-message.js but not yet handled here,
-	# e.g. ETARGET (no matching version), ENOSPC (disk full).
+	# e.g. ENOSPC (disk full).
 	# Add each as its own matcher above, verified against npm source per the version-spread loop.
 
 	# No known failure mode recognised — signal no match so the caller can fall through.

--- a/lib/package_managers/yarn.sh
+++ b/lib/package_managers/yarn.sh
@@ -207,6 +207,26 @@ function package_managers::yarn::_handle_yarn_classic_install_failure() {
 		return 0
 	fi
 
+	# Yarn 1.x emits this literal line from its package resolver (src/package-request.js) when no
+	# published version satisfies the requested range. Keyed on the message text because yarn 1 has
+	# no numeric error codes. The legacy failure id (`bad-version-for-dependency`) is preserved
+	# verbatim so the `failure` build-data key stays continuous for downstream metrics.
+	if grep -qi "error Couldn't find any versions for" "${log_file}"; then
+		__failure["id"]="bad-version-for-dependency"
+		__failure["classification"]="user"
+		__failure["detail"]="$(package_managers::yarn::_extract_error_detail "${log_file}")"
+		__failure["message"]=$(
+			cat <<-EOF
+				Error: Unable to install dependencies using Yarn.
+
+				One of your dependencies requests a package version that does not exist
+				in the npm registry. Check the log output above for the offending package
+				and version range, and update it to a version that has been published.
+			EOF
+		)
+		return 0
+	fi
+
 	# TODO: classify additional yarn 1.x failures currently handled by the legacy trap
 	# (fail_yarn_outdated) in a follow-up migration.
 

--- a/test/unit
+++ b/test/unit
@@ -600,6 +600,18 @@ testHandleNpmInstallLockfileOutOfSync() {
   assertContains "${result[message]}" "npm install"
 }
 
+testHandleNpmInstallBadVersion() {
+  local -A result
+  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/notarget.log" result
+  assertEquals "classifier should return 0 on a match" "0" "$?"
+  # Preserve the legacy failure slug so downstream metrics stay continuous.
+  assertEquals "bad-version-for-dependency" "${result[id]}"
+  assertEquals "user" "${result[classification]}"
+  assertContains "${result[detail]}" "ETARGET:"
+  assertContains "${result[detail]}" "No matching version found"
+  assertContains "${result[message]}" "does not exist"
+}
+
 testHandleInstallPipefail() {
   # The npm-specific pipefail wrapper owns the failure id and the user-facing message;
   # verify both plus the buildpack classification and PIPESTATUS detail inherited from
@@ -660,6 +672,17 @@ testHandleYarnInstallLockfileNeedsUpdate() {
   assertContains "${result[detail]}" "Your lockfile needs to be updated"
   assertContains "${result[message]}" "Outdated Yarn lockfile"
   assertContains "${result[message]}" "yarn install"
+}
+
+testHandleYarnInstallBadVersion() {
+  local -A result
+  package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/no-matching-version.log" result
+  assertEquals "classifier should return 0 on a match" "0" "$?"
+  # Preserve the legacy failure slug so downstream metrics stay continuous.
+  assertEquals "bad-version-for-dependency" "${result[id]}"
+  assertEquals "user" "${result[classification]}"
+  assertContains "${result[detail]}" "Couldn't find any versions for"
+  assertContains "${result[message]}" "does not exist"
 }
 
 testHandleYarnInstallNoMatchReturnsNonZero() {

--- a/test/unit-fixtures/npm-failures/notarget.log
+++ b/test/unit-fixtures/npm-failures/notarget.log
@@ -1,0 +1,5 @@
+npm error code ETARGET
+npm error notarget No matching version found for left-pad@^99.0.0.
+npm error notarget In most cases you or one of your dependencies are requesting
+npm error notarget a package version that doesn't exist.
+npm error A complete log of this run can be found in: /root/.npm/_logs/2026-06-16T00_00_00_000Z-debug-0.log

--- a/test/unit-fixtures/yarn-failures/no-matching-version.log
+++ b/test/unit-fixtures/yarn-failures/no-matching-version.log
@@ -1,0 +1,4 @@
+yarn install v1.22.22
+[1/4] Resolving packages...
+error Couldn't find any versions for "left-pad" that matches "^99.0.0"
+info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.


### PR DESCRIPTION
This continues the classic Node.js buildpack's migration off the global ERR trap onto call-site failure classification.

The legacy `bad-version-for-dependency` matcher in `log_other_failures` covered a single failure meaning — an app-requested dependency version/range that doesn't exist in the registry — but did so in one shared grep block spanning two package managers. npm and Yarn classic are therefore migrated together here: npm's `ETARGET` and Yarn 1.x's `error Couldn't find any versions for` each become their own branch in the existing `_handle_npm_install_failure` / `_handle_yarn_classic_install_failure` classifiers. Both preserve the legacy `bad-version-for-dependency` id so downstream build-data metrics stay continuous, and both classify as `user` since the app controls the offending spec. With both sides covered, the shared legacy matcher is removed.

W-23802234