### PR TITLE
Run build steps bare and move output indentation into each step

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -368,9 +368,6 @@ install_bins() {
 		EOF
   fi
 
-  if [[ $YARN_2 == true ]]; then
-    YARN=false
-  fi
 }
 
 output::step "Installing binaries"

--- a/bin/compile
+++ b/bin/compile
@@ -114,12 +114,12 @@ create_env() {
   write_export "$BP_DIR" "$BUILD_DIR"
 }
 
-header "Creating runtime environment" | output "$LOG_FILE"
+output::step "Creating runtime environment"
 
 mkdir -p "$BUILD_DIR/.heroku/node/"
 cd "$BUILD_DIR"
 create_env # can't pipe the whole thing because piping causes subshells, preventing exports
-list_node_config | output "$LOG_FILE"
+list_node_config
 create_build_env
 
 
@@ -214,19 +214,19 @@ install_bins() {
   [ -n "$pnpm_engine" ] && build_data::set_string "pnpm_version_request" "$pnpm_engine"
   [ -n "$package_manager" ] && build_data::set_string "package_manager_request" "$package_manager"
 
-  echo "engines.node (package.json):   ${node_engine:-unspecified}"
-  echo "engines.npm (package.json):    ${npm_engine:-unspecified (use default)}"
+  output::info "engines.node (package.json):   ${node_engine:-unspecified}"
+  output::info "engines.npm (package.json):    ${npm_engine:-unspecified (use default)}"
 
   if $YARN || [ -n "$yarn_engine" ]; then
-    echo "engines.yarn (package.json):   ${yarn_engine:-unspecified (use default)}"
+    output::info "engines.yarn (package.json):   ${yarn_engine:-unspecified (use default)}"
   fi
 
   if $PNPM || [ -n "$pnpm_engine" ]; then
-    echo "engines.pnpm (package.json):   ${pnpm_engine:-unspecified (use default)}"
+    output::info "engines.pnpm (package.json):   ${pnpm_engine:-unspecified (use default)}"
   fi
 
   if [ -n "$package_manager" ]; then
-    echo "packageManager (package.json): $(echo "$package_manager" | cut -d "+" -f 1)"
+    output::info "packageManager (package.json): $(echo "$package_manager" | cut -d "+" -f 1)"
   fi
 
   local showed_warning=false
@@ -374,7 +374,7 @@ install_bins() {
 }
 
 output::step "Installing binaries"
-install_bins | output::indent | tee -a "$LOG_FILE"
+install_bins
 
 if $PNPM; then
   # pnpm 11+ reads config from pnpm_config_* env vars (https://pnpm.io/blog/releases/11.0#highlights),
@@ -441,7 +441,7 @@ restore_cache() {
 
   if $YARN; then
     if $PREBUILD && [[ "$SKIP_NODE_MODULES_CHECK" == "true" ]]; then
-      echo "Keeping existing node_modules because SKIP_NODE_MODULES_CHECK=${SKIP_NODE_MODULES_CHECK}"
+      output::info "Keeping existing node_modules because SKIP_NODE_MODULES_CHECK=${SKIP_NODE_MODULES_CHECK}"
     elif $PREBUILD; then
       output::warning <<-EOF
 			node_modules checked into source control
@@ -453,26 +453,26 @@ restore_cache() {
   fi
 
   if [[ "$cache_status" == "disabled" ]]; then
-    header "Restoring cache"
-    echo "Caching has been disabled because NODE_MODULES_CACHE=${NODE_MODULES_CACHE}"
+    output::step "Restoring cache"
+    output::info "Caching has been disabled because NODE_MODULES_CACHE=${NODE_MODULES_CACHE}"
   elif [[ "$cache_status" == "valid" ]]; then
-    header "Restoring cache"
+    output::step "Restoring cache"
     if [[ "$cache_directories" == "" ]]; then
       restore_default_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$YARN_CACHE_FOLDER" "$NPM_CONFIG_CACHE" "$PNPM_CONFIG_CACHE"
     else
       restore_custom_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$PNPM_CONFIG_CACHE" "$cache_directories"
     fi
   elif [[ "$cache_status" == "new-signature" ]]; then
-    header "Restoring cache"
+    output::step "Restoring cache"
     if [[ "$cache_directories" == "" ]]; then
-      echo "Cached directories were not restored due to a change in version of node, npm, yarn or stack"
-      echo "Module installation may take longer for this build"
+      output::info "Cached directories were not restored due to a change in version of node, npm, yarn or stack"
+      output::info "Module installation may take longer for this build"
     else
       # If the user has specified custom cache directories, be more explicit
-      echo "Invalidating cache due to a change in version of node, npm, yarn or stack"
-      echo "Will not restore the following directories for this build:"
+      output::info "Invalidating cache due to a change in version of node, npm, yarn or stack"
+      output::info "Will not restore the following directories for this build:"
       for directory in $cache_directories; do
-        echo "  $directory"
+        output::info "  $directory"
       done
     fi
   else
@@ -488,7 +488,7 @@ restore_cache() {
 }
 
 build_data::set_string "build_step" "restore-cache"
-restore_cache | output "$LOG_FILE"
+restore_cache
 
 build_dependencies() {
   local cache_status start
@@ -502,23 +502,23 @@ build_dependencies() {
   elif $PNPM; then
     package_managers::pnpm::install_dependencies "$BUILD_DIR" "$CACHE_DIR"
   elif $PREBUILD; then
-    echo "Prebuild detected (node_modules already exists)"
+    output::info "Prebuild detected (node_modules already exists)"
     package_managers::npm::rebuild_dependencies "$BUILD_DIR"
   else
     package_managers::npm::install_dependencies "$BUILD_DIR"
   fi
 
   build_data::set_string "build_step" "build-script"
-  header "Build"
+  output::step "Build"
   package_manager::run_build_script "$BUILD_DIR"
 }
 
 build_data::set_string "build_step" "prebuild-script"
-package_manager::run_prebuild_script "$BUILD_DIR" | output "$LOG_FILE"
+package_manager::run_prebuild_script "$BUILD_DIR"
 
-header "Installing dependencies" | output "$LOG_FILE"
+output::step "Installing dependencies"
 build_data::set_string "build_step" "install-dependencies"
-build_dependencies | output "$LOG_FILE"
+build_dependencies
 
 cache_build() {
   local cache_directories cache_build_start_time
@@ -531,10 +531,10 @@ cache_build() {
     # so be silent here
     :
   elif [[ "$cache_directories" == "" ]]; then
-    header "Caching build"
+    output::step "Caching build"
     save_default_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$YARN_CACHE_FOLDER" "$NPM_CONFIG_CACHE" "$PNPM_CONFIG_CACHE"
   else
-    header "Caching build"
+    output::step "Caching build"
     save_custom_cache_directories "$BUILD_DIR" "$CACHE_DIR" "$PNPM_CONFIG_CACHE" "$cache_directories"
   fi
   save_signature "$CACHE_DIR"
@@ -553,30 +553,30 @@ prune_devdependencies() {
 
 if $YARN_2; then
   build_data::set_string "build_step" "save-cache"
-  cache_build | output "$LOG_FILE"
+  cache_build
   build_data::set_string "build_step" "prune-dependencies"
-  header "Pruning devDependencies" | output "$LOG_FILE"
-  prune_devdependencies | output "$LOG_FILE"
+  output::step "Pruning devDependencies"
+  prune_devdependencies
 elif "$YARN" && "$USE_YARN_CACHE" && [[ "$(get_cache_directories "$BUILD_DIR")" == "" ]]; then
   build_data::set_string "build_step" "prune-dependencies"
-  header "Pruning devDependencies" | output "$LOG_FILE"
-  prune_devdependencies | output "$LOG_FILE"
+  output::step "Pruning devDependencies"
+  prune_devdependencies
   build_data::set_string "build_step" "save-cache"
-  cache_build | output "$LOG_FILE"
+  cache_build
 else
   build_data::set_string "build_step" "save-cache"
-  cache_build | output "$LOG_FILE"
+  cache_build
   build_data::set_string "build_step" "prune-dependencies"
-  header "Pruning devDependencies" | output "$LOG_FILE"
-  prune_devdependencies | output "$LOG_FILE"
+  output::step "Pruning devDependencies"
+  prune_devdependencies
 fi
 
 build_data::set_string "build_step" "cleanup-script"
-package_manager::run_cleanup_script "$BUILD_DIR" | output "$LOG_FILE"
+package_manager::run_cleanup_script "$BUILD_DIR"
 
 summarize_build() {
   if $NODE_VERBOSE; then
-    package_manager::list_dependencies "$BUILD_DIR"
+    package_manager::list_dependencies "$BUILD_DIR" | output::indent
   fi
 }
 
@@ -584,7 +584,7 @@ build_data::set_string "build_step" "install-metrics-plugin"
 runtimes::nodejs::install_metrics_plugin "$BP_DIR" "$BUILD_DIR"
 
 build_data::set_string "build_step" "summarize"
-summarize_build | output "$LOG_FILE"
+summarize_build
 build_data::set_duration "build_time" "$build_start_time"
 
 if ! [ -e "$BUILD_DIR/Procfile" ]; then

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -53,7 +53,7 @@ restore_default_cache_directories() {
 
   if [[ "$YARN" == "true" ]]; then
     if [[ "$YARN_ZERO_INSTALL" == "true" ]]; then
-      echo "- yarn cache is checked into source control and cannot be cached"
+      output::info "- yarn cache is checked into source control and cannot be cached"
     elif [[ -e "$cache_dir/node/cache/yarn" ]]; then
       rm -rf "$yarn_cache_dir"
       mkdir -p "$(dirname "$yarn_cache_dir")"
@@ -64,44 +64,44 @@ restore_default_cache_directories() {
         # the near future.
         rm -rf "$yarn_cache_dir/yarn"
       fi
-      echo "- yarn cache"
+      output::info "- yarn cache"
     else
-      echo "- yarn cache (not cached - skipping)"
+      output::info "- yarn cache (not cached - skipping)"
     fi
   elif [[ "$PNPM" == "true" ]]; then
     if [[ -d "$cache_dir/node/cache/pnpm" ]]; then
       rm -rf "$pnpm_cache_dir"
       mv "$cache_dir/node/cache/pnpm" "$pnpm_cache_dir"
-      echo "- pnpm cache"
+      output::info "- pnpm cache"
       build_data::set_raw "pnpm_cache" "true"
     else
-      echo "- pnpm cache (not cached - skipping)"
+      output::info "- pnpm cache (not cached - skipping)"
     fi
   elif [[ "$USE_NPM_INSTALL" == "false" ]]; then
     if [[ -d "$cache_dir/node/cache/npm" ]]; then
       rm -rf "$npm_cache"
       mv "$cache_dir/node/cache/npm" "$npm_cache"
-      echo "- npm cache"
+      output::info "- npm cache"
       build_data::set_raw "npm_cache" "true"
     else
-      echo "- npm cache (not cached - skipping)"
+      output::info "- npm cache (not cached - skipping)"
     fi
   else
     # node_modules
     if [[ -e "$build_dir/node_modules" ]]; then
-      echo "- node_modules is checked into source control and cannot be cached"
+      output::info "- node_modules is checked into source control and cannot be cached"
     elif [[ -e "$cache_dir/node/cache/node_modules" ]]; then
-      echo "- node_modules"
+      output::info "- node_modules"
       mkdir -p "$(dirname "$build_dir/node_modules")"
       mv "$cache_dir/node/cache/node_modules" "$build_dir/node_modules"
     else
-      echo "- node_modules (not cached - skipping)"
+      output::info "- node_modules (not cached - skipping)"
     fi
   fi
 
   # bower_components, should be silent if it is not in the cache
   if [[ -e "$cache_dir/node/cache/bower_components" ]]; then
-    echo "- bower_components"
+    output::info "- bower_components"
   fi
 }
 
@@ -113,26 +113,26 @@ restore_custom_cache_directories() {
   # Parse the input string with multiple lines: "a\nb\nc" into an array
   mapfile -t cache_directories <<< "$4"
 
-  echo "Loading from cacheDirectories (package.json):"
+  output::info "Loading from cacheDirectories (package.json):"
 
   for cachepath in "${cache_directories[@]}"; do
     if [[ "$PNPM" == "true" ]] && [[ "$cachepath" =~ ^node_modules(/|$) ]]; then
-      echo "- $cachepath (skipping because pnpm is used)"
+      output::info "- $cachepath (skipping because pnpm is used)"
     elif [ -e "$build_dir/$cachepath" ]; then
-      echo "- $cachepath (exists - skipping)"
+      output::info "- $cachepath (exists - skipping)"
     else
       if [ -e "$cache_dir/node/cache/$cachepath" ]; then
-        echo "- $cachepath"
+        output::info "- $cachepath"
         mkdir -p "$(dirname "$build_dir/$cachepath")"
         mv "$cache_dir/node/cache/$cachepath" "$build_dir/$cachepath"
       else
-        echo "- $cachepath (not cached - skipping)"
+        output::info "- $cachepath (not cached - skipping)"
       fi
     fi
   done
 
   if [[ "$PNPM" == "true" ]] && [ -e "$cache_dir/node/cache/pnpm/store" ]; then
-    echo "- pnpm store (included because pnpm is used)"
+    output::info "- pnpm store (included because pnpm is used)"
     # the $pnpm_cache_dir is created at the start of the build so, now, if we want to
     # rename the cache directory to $pnpm_cache_dir, we have to remove it or we'll
     # end up with a $pnpm_cache_dir/store directory instead of $pnpm_cache_dir.
@@ -158,7 +158,7 @@ save_default_cache_directories() {
   if [[ "$YARN" == "true" ]]; then
     if [[ -d "$yarn_cache_dir" ]]; then
       if [[ "$YARN_ZERO_INSTALL" == "true" ]]; then
-        echo "- yarn cache is checked into source control and cannot be cached"
+        output::info "- yarn cache is checked into source control and cannot be cached"
       elif [[ "$YARN_2" == "true" ]]; then
         # For improved performance, we copy using hard links if possible. This
         # requires that the yarn cache and build cache directories are on the
@@ -172,40 +172,40 @@ save_default_cache_directories() {
         else
           cp -RTf "$yarn_cache_dir" "$cache_dir/node/cache/yarn"
         fi
-        echo "- yarn cache"
+        output::info "- yarn cache"
       else
         mv "$yarn_cache_dir" "$cache_dir/node/cache/yarn"
-        echo "- yarn cache"
+        output::info "- yarn cache"
       fi
     fi
   elif [[ "$PNPM" == "true" ]]; then
     if [[ -d "$pnpm_cache_dir" ]]; then
       mv "$pnpm_cache_dir" "$cache_dir/node/cache/pnpm"
-      echo "- pnpm cache"
+      output::info "- pnpm cache"
     fi
   elif [[ "$USE_NPM_INSTALL" == "false" ]]; then
     if [[ -d "$npm_cache" ]]; then
       mv "$npm_cache" "$cache_dir/node/cache/npm"
-      echo "- npm cache"
+      output::info "- npm cache"
     else
-      echo "- npm cache (nothing to cache)"
+      output::info "- npm cache (nothing to cache)"
     fi
   else
     # node_modules
     if [[ -e "$build_dir/node_modules" ]]; then
-      echo "- node_modules"
+      output::info "- node_modules"
       mkdir -p "$cache_dir/node/cache/node_modules"
       cp -a "$build_dir/node_modules" "$(dirname "$cache_dir/node/cache/node_modules")"
     else
       # this can happen if there are no dependencies
-      echo "- node_modules (nothing to cache)"
+      output::info "- node_modules (nothing to cache)"
     fi
   fi
 
   # bower_components
   if [[ -e "$build_dir/bower_components" ]]; then
     build_data::set_raw "has_cached_bower_components" "true"
-    echo "- bower_components"
+    output::info "- bower_components"
     mkdir -p "$cache_dir/node/cache/bower_components"
     cp -a "$build_dir/bower_components" "$(dirname "$cache_dir/node/cache/bower_components")"
   else
@@ -223,22 +223,22 @@ save_custom_cache_directories() {
   # Parse the input string with multiple lines: "a\nb\nc" into an array
   mapfile -t cache_directories <<< "$4"
 
-  echo "Saving cacheDirectories (package.json):"
+  output::info "Saving cacheDirectories (package.json):"
 
   for cachepath in "${cache_directories[@]}"; do
     if [[ "$PNPM" == "true" ]] && [[ "$cachepath" =~ ^node_modules(/|$) ]]; then
-      echo "- $cachepath (skipping because pnpm is used)"
+      output::info "- $cachepath (skipping because pnpm is used)"
     elif [ -e "$build_dir/$cachepath" ]; then
-      echo "- $cachepath"
+      output::info "- $cachepath"
       mkdir -p "$cache_dir/node/cache/$cachepath"
       cp -a "$build_dir/$cachepath" "$(dirname "$cache_dir/node/cache/$cachepath")"
     else
-      echo "- $cachepath (nothing to cache)"
+      output::info "- $cachepath (nothing to cache)"
     fi
   done
 
   if [[ "$PNPM" == "true" ]] && [ -e "$pnpm_cache_dir" ]; then
-    echo "- pnpm store (included because pnpm is used)"
+    output::info "- pnpm store (included because pnpm is used)"
     mkdir -p "$cache_dir/node/cache/pnpm"
     cp -a "$pnpm_cache_dir" "$cache_dir/node/cache/pnpm/store"
   fi

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -30,18 +30,22 @@ create_build_env() {
 }
 
 list_node_config() {
-  echo ""
-  printenv | grep ^NPM_CONFIG_ || true
-  printenv | grep ^YARN_ || true
-  printenv | grep ^USE_NPM_ || true
-  printenv | grep ^USE_YARN_ || true
-  printenv | grep ^NODE_ || true
-
-  if [ "$NPM_CONFIG_PRODUCTION" = "true" ] && [ "$NODE_ENV" != "production" ]; then
+  # Pure informational output (env dump + notes); indent the whole body under the caller's
+  # `output::step` so the call site can invoke this bare, like the other migrated steps.
+  {
     echo ""
-    echo "npm scripts will see NODE_ENV=production (not '${NODE_ENV}')"
-    echo "https://docs.npmjs.com/misc/config#production"
-  fi
+    printenv | grep ^NPM_CONFIG_ || true
+    printenv | grep ^YARN_ || true
+    printenv | grep ^USE_NPM_ || true
+    printenv | grep ^USE_YARN_ || true
+    printenv | grep ^NODE_ || true
+
+    if [ "$NPM_CONFIG_PRODUCTION" = "true" ] && [ "$NODE_ENV" != "production" ]; then
+      echo ""
+      echo "npm scripts will see NODE_ENV=production (not '${NODE_ENV}')"
+      echo "https://docs.npmjs.com/misc/config#production"
+    fi
+  } | output::indent
 }
 
 export_env_dir() {

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -41,6 +41,13 @@ output::indent() {
 	sed --unbuffered 's/^/       /'
 }
 
+# Prints a single informational line, indented to sit under the current `output::step` header.
+# The counterpart to `output::indent` for one-off lines that aren't part of a piped command's
+# output (replaces the legacy bare-`echo`-through-the-`output`-pipe idiom).
+output::info() {
+	echo "       $*"
+}
+
 output::warning() {
 	echo >&2
 	sed --unbuffered "s/^/${ANSI_YELLOW} !     /" | sed --unbuffered "s/$/${ANSI_RESET}/" >&2

--- a/lib/package_manager.sh
+++ b/lib/package_manager.sh
@@ -64,13 +64,13 @@ function package_manager::run_script_command() {
 	log_file=$(mktemp)
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves. The
-	# script's stdout+stderr are merged with `2>&1` and passed through `tee` (for later
-	# classification) to stdout; indentation is applied by the enclosing `… | output "$LOG_FILE"`
-	# pipe in bin/compile, so do not re-indent here.
+	# script's stdout+stderr are merged with `2>&1`, passed through `tee` (for later
+	# classification) to stdout, and indented with `output::indent`.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { "${command[@]}" 2>&1 | tee "${log_file}"; }; then
+	if ! { "${command[@]}" 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `<tool> 2>&1 | tee`, so [0] is the tool's exit code and [1] is tee's.
+		# The pipeline is `<tool> 2>&1 | tee | output::indent`, so [0] is the tool's exit code
+		# (tee is [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local tool_exit="${pipe_status[0]}"
 
@@ -297,7 +297,7 @@ function package_manager::run_prebuild_script() {
 	has_heroku_prebuild_script=$(utils::package_json::has_script "${build_dir}/package.json" "heroku-prebuild")
 
 	if [[ "${has_heroku_prebuild_script}" == "true" ]]; then
-		header "Prebuild"
+		output::step "Prebuild"
 		package_manager::_run_if_present "${build_dir}" 'heroku-prebuild'
 	fi
 }
@@ -309,7 +309,7 @@ function package_manager::run_build_script() {
 	has_build_script=$(utils::package_json::has_script "${build_dir}/package.json" "build")
 	has_heroku_build_script=$(utils::package_json::has_script "${build_dir}/package.json" "heroku-postbuild")
 	if [[ "${has_heroku_build_script}" == "true" ]] && [[ "${has_build_script}" == "true" ]]; then
-		echo "Detected both \"build\" and \"heroku-postbuild\" scripts"
+		output::info "Detected both \"build\" and \"heroku-postbuild\" scripts"
 		package_manager::_run_if_present "${build_dir}" 'heroku-postbuild'
 	elif [[ "${has_heroku_build_script}" == "true" ]]; then
 		package_manager::_run_if_present "${build_dir}" 'heroku-postbuild'
@@ -325,7 +325,7 @@ function package_manager::run_cleanup_script() {
 	has_heroku_cleanup_script=$(utils::package_json::has_script "${build_dir}/package.json" "heroku-cleanup")
 
 	if [[ "${has_heroku_cleanup_script}" == "true" ]]; then
-		header "Cleanup"
+		output::step "Cleanup"
 		package_manager::_run_if_present "${build_dir}" 'heroku-cleanup'
 	fi
 }

--- a/lib/package_managers/npm.sh
+++ b/lib/package_managers/npm.sh
@@ -22,7 +22,7 @@ function package_managers::npm::install_dependencies() {
 	local production="${NPM_CONFIG_PRODUCTION:-false}"
 
 	if [[ ! -e "${build_dir}/package.json" ]]; then
-		echo "Skipping (no package.json)"
+		output::info "Skipping (no package.json)"
 		return 0
 	fi
 
@@ -31,16 +31,16 @@ function package_managers::npm::install_dependencies() {
 	local npm_command=(npm)
 	if [[ "${USE_NPM_INSTALL:-true}" == "false" ]]; then
 		build_data::set_raw "use_npm_ci" "true"
-		echo "Installing node modules"
+		output::info "Installing node modules"
 		npm_command+=(ci)
 	else
 		build_data::set_raw "use_npm_ci" "false"
 		if [[ -e "${build_dir}/package-lock.json" ]]; then
-			echo "Installing node modules (package.json + package-lock)"
+			output::info "Installing node modules (package.json + package-lock)"
 		elif [[ -e "${build_dir}/npm-shrinkwrap.json" ]]; then
-			echo "Installing node modules (package.json + shrinkwrap)"
+			output::info "Installing node modules (package.json + shrinkwrap)"
 		else
-			echo "Installing node modules (package.json)"
+			output::info "Installing node modules (package.json)"
 		fi
 		npm_command+=(install)
 	fi
@@ -58,9 +58,9 @@ function package_managers::npm::install_dependencies() {
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { "${npm_command[@]}" 2>&1 | tee "${log_file}"; }; then
+	if ! { "${npm_command[@]}" 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `npm 2>&1 | tee`, so [0] is npm's exit code and [1] is tee's.
+		# The pipeline is `npm 2>&1 | tee | output::indent`, so [0] is npm's exit code (tee is [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local npm_exit="${pipe_status[0]}"
 		build_data::set_duration "install_dependencies_time" "${start}"
@@ -94,11 +94,10 @@ function package_managers::npm::install_dependencies() {
 			failure::emit failure
 		fi
 
-		# No known failure mode recognised. Bubble up by returning npm's exit code: the pipeline
-		# that runs this install (`build_dependencies | output "$LOG_FILE"`) then fails under
-		# errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error — covering the codes (ERESOLVE, ETARGET, ENOSPC, …) not yet
-		# migrated here.
+		# No known failure mode recognised. Bubble up by returning npm's exit code: the bare
+		# `build_dependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error — covering the
+		# codes (ERESOLVE, ETARGET, ENOSPC, …) not yet migrated here.
 		return "${npm_exit}"
 	fi
 
@@ -113,12 +112,12 @@ function package_managers::npm::rebuild_dependencies() {
 	local production="${NPM_CONFIG_PRODUCTION:-false}"
 
 	if [[ ! -e "${build_dir}/package.json" ]]; then
-		echo "Skipping (no package.json)"
+		output::info "Skipping (no package.json)"
 		return 0
 	fi
 
 	cd "${build_dir}"
-	echo "Rebuilding any native modules"
+	output::info "Rebuilding any native modules"
 
 	local native_rebuild_log_file
 	native_rebuild_log_file=$(mktemp)
@@ -128,9 +127,9 @@ function package_managers::npm::rebuild_dependencies() {
 	# a native-module compile failure (e.g. via node-gyp) surfaces through the same npm error
 	# codes as an install failure.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { npm rebuild 2>&1 | tee "${native_rebuild_log_file}"; }; then
+	if ! { npm rebuild 2>&1 | tee "${native_rebuild_log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `npm 2>&1 | tee`, so [0] is npm's exit code and [1] is tee's.
+		# The pipeline is `npm 2>&1 | tee | output::indent`, so [0] is npm's exit code (tee is [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local npm_exit="${pipe_status[0]}"
 
@@ -162,17 +161,16 @@ function package_managers::npm::rebuild_dependencies() {
 			failure::emit failure
 		fi
 
-		# No known failure mode recognised. Bubble up by returning npm's exit code: the pipeline
-		# that runs this rebuild (`build_dependencies | output "$LOG_FILE"`) then fails under
-		# errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error.
+		# No known failure mode recognised. Bubble up by returning npm's exit code: the bare
+		# `build_dependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error.
 		return "${npm_exit}"
 	fi
 
 	if [[ -e "${build_dir}/npm-shrinkwrap.json" ]]; then
-		echo "Installing any new modules (package.json + shrinkwrap)"
+		output::info "Installing any new modules (package.json + shrinkwrap)"
 	else
-		echo "Installing any new modules (package.json)"
+		output::info "Installing any new modules (package.json)"
 	fi
 
 	# npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
@@ -199,7 +197,7 @@ function package_managers::npm::rebuild_dependencies() {
 	# command, same failure surface. The metric name (`npm_rebuild_time`) is kept distinct
 	# from `install_dependencies_time` so the two paths remain separable in observability.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { "${npm_command[@]}" 2>&1 | tee "${log_file}"; }; then
+	if ! { "${npm_command[@]}" 2>&1 | tee "${log_file}" | output::indent; }; then
 		local pipe_status=("${PIPESTATUS[@]}")
 		local npm_exit="${pipe_status[0]}"
 		build_data::set_duration "npm_rebuild_time" "${start}"
@@ -646,16 +644,16 @@ function package_managers::npm::install_binary() {
 	local npm_version_major
 	npm_version_major="$(package_managers::npm::version_major)"
 	if ${npm_lock} && [[ "${version}" == "" ]] && [[ "${npm_version_major}" -lt "5" ]]; then
-		echo "Detected package-lock.json: defaulting npm to version 5.x.x"
+		output::info "Detected package-lock.json: defaulting npm to version 5.x.x"
 		version="5.x.x"
 	fi
 
 	if [[ "${version}" == "" ]]; then
-		echo "Using default npm version: ${npm_version}"
+		output::info "Using default npm version: ${npm_version}"
 	elif [[ "${npm_version}" == "${version}" ]]; then
-		echo "npm ${npm_version} already installed with node"
+		output::info "npm ${npm_version} already installed with node"
 	else
-		echo "Bootstrapping npm ${version} (replacing ${npm_version})..."
+		output::info "Bootstrapping npm ${version} (replacing ${npm_version})..."
 		local install_npm_start
 		install_npm_start=$(build_data::current_unix_realtime)
 		package_managers::npm::_install_binary "${version}"
@@ -664,7 +662,7 @@ function package_managers::npm::install_binary() {
 		utils::command::suppress_output npm --version
 		local installed_npm_version
 		installed_npm_version="$(npm --version)"
-		echo "npm ${installed_npm_version} installed"
+		output::info "npm ${installed_npm_version} installed"
 	fi
 }
 
@@ -700,7 +698,7 @@ function package_managers::npm::_install_binary() {
 			return
 		fi
 		if [[ "${major}" == "11" ]] && [[ "${minor}" -ge 11 ]]; then
-			echo "Installing npm@~11.10.0 to workaround Node.js 22.22.2 regression (https://github.com/npm/cli/issues/9151)"
+			output::info "Installing npm@~11.10.0 to workaround Node.js 22.22.2 regression (https://github.com/npm/cli/issues/9151)"
 			if ! utils::command::suppress_output npm install "${unsafe_perm[@]}" --quiet --no-audit --no-progress -g "npm@~11.10.0"; then
 				build_data::set_string "failure" "npm-node-22.22.2-workaround-failed"
 				output::error <<-EOF
@@ -734,23 +732,23 @@ function package_managers::npm::prune_devdependencies() {
 	# lib/environment.sh).
 	# shellcheck disable=SC2154 # set by the caller (bin/compile)
 	if [[ "${NODE_ENV}" == "test" ]]; then
-		echo "Skipping because NODE_ENV is 'test'"
+		output::info "Skipping because NODE_ENV is 'test'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ "${NODE_ENV}" != "production" ]]; then
-		echo "Skipping because NODE_ENV is not 'production'"
+		output::info "Skipping because NODE_ENV is not 'production'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ -n "${NPM_CONFIG_PRODUCTION}" ]]; then
-		echo "Skipping because NPM_CONFIG_PRODUCTION is '${NPM_CONFIG_PRODUCTION}'"
+		output::info "Skipping because NPM_CONFIG_PRODUCTION is '${NPM_CONFIG_PRODUCTION}'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ "${npm_version}" == "5.3.0" ]]; then
-		echo "Skipping because npm 5.3.0 fails when running 'npm prune' due to a known issue"
-		echo "https://github.com/npm/npm/issues/17781"
-		echo ""
-		echo "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
-		echo "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+		output::info "Skipping because npm 5.3.0 fails when running 'npm prune' due to a known issue"
+		output::info "https://github.com/npm/npm/issues/17781"
+		output::info ""
+		output::info "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
+		output::info "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ "${npm_version}" == "5.6.0" ]] \
@@ -760,11 +758,11 @@ function package_managers::npm::prune_devdependencies() {
 		|| [[ "${npm_version}" == "5.4.1" ]] \
 		|| [[ "${npm_version}" == "5.2.0" ]] \
 		|| [[ "${npm_version}" == "5.1.0" ]]; then
-		echo "Skipping because npm ${npm_version} sometimes fails when running 'npm prune' due to a known issue"
-		echo "https://github.com/npm/npm/issues/19356"
-		echo ""
-		echo "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
-		echo "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+		output::info "Skipping because npm ${npm_version} sometimes fails when running 'npm prune' due to a known issue"
+		output::info "https://github.com/npm/npm/issues/19356"
+		output::info ""
+		output::info "You can silence this warning by updating to at least npm 5.7.1 in your package.json"
+		output::info "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	else
@@ -778,9 +776,9 @@ function package_managers::npm::prune_devdependencies() {
 
 		# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
 		# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-		if ! { npm prune --userconfig "${build_dir}/.npmrc" 2>&1 | tee "${log_file}"; }; then
+		if ! { npm prune --userconfig "${build_dir}/.npmrc" 2>&1 | tee "${log_file}" | output::indent; }; then
 			# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-			# The pipeline is `npm 2>&1 | tee`, so [0] is npm's exit code and [1] is tee's.
+			# The pipeline is `npm 2>&1 | tee | output::indent`, so [0] is npm's exit code (tee is [1], output::indent [2]).
 			local pipe_status=("${PIPESTATUS[@]}")
 			local npm_exit="${pipe_status[0]}"
 			build_data::set_duration "prune_dev_dependencies_time" "${start}"
@@ -791,10 +789,10 @@ function package_managers::npm::prune_devdependencies() {
 				package_managers::npm::_handle_prune_pipefail "${pipe_status[*]}"
 			fi
 
-			# No known failure mode recognised. Bubble up by returning npm's exit code: the pipeline
-			# that runs this prune (`prune_devdependencies | output "$LOG_FILE"`) then fails under
-			# errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-			# failure=internal-error — there is no migrated npm-prune tool-error classifier to add here yet.
+			# No known failure mode recognised. Bubble up by returning npm's exit code: the bare
+			# `prune_devdependencies` call in bin/compile then fails under errexit and the generic
+			# failure::handle_uncaught ERR trap records it as failure=internal-error — there is no
+			# migrated npm-prune tool-error classifier to add here yet.
 			return "${npm_exit}"
 		fi
 
@@ -829,11 +827,11 @@ function package_managers::npm::run_script() {
 	local script_name=${1}
 	local build_flags=${2:-}
 
-	echo "Running ${script_name}"
+	output::info "Running ${script_name}"
 
 	local command=(npm run "${script_name}" --if-present)
 	if [[ -n "${build_flags}" ]]; then
-		echo "Running with ${build_flags} flags"
+		output::info "Running with ${build_flags} flags"
 		command+=(-- "${build_flags}")
 	fi
 

--- a/lib/package_managers/pnpm.sh
+++ b/lib/package_managers/pnpm.sh
@@ -15,7 +15,7 @@ package_managers::pnpm::install_dependencies() {
 	local build_dir=${1:-}
 	local cache_dir=${2:-}
 
-	echo "Running 'pnpm install' with pnpm-lock.yaml"
+	output::info "Running 'pnpm install' with pnpm-lock.yaml"
 	cd "${build_dir}" || return
 
 	pnpm_install_args=("install" "--prod=false" "--frozen-lockfile")
@@ -26,8 +26,8 @@ package_managers::pnpm::install_dependencies() {
 				pnpm_install_args+=("--reporter=${PNPM_INSTALL_REPORTER}")
 				;;
 			*)
-				echo "Warning: Invalid PNPM_INSTALL_REPORTER value '${PNPM_INSTALL_REPORTER}'. Valid values: default, ndjson, append-only, silent"
-				echo "Proceeding with default reporter"
+				output::info "Warning: Invalid PNPM_INSTALL_REPORTER value '${PNPM_INSTALL_REPORTER}'. Valid values: default, ndjson, append-only, silent"
+				output::info "Proceeding with default reporter"
 				;;
 		esac
 	fi
@@ -39,14 +39,12 @@ package_managers::pnpm::install_dependencies() {
 	start=$(build_data::current_unix_realtime)
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
-	# pnpm writes progress and errors across stdout+stderr; merge them with `2>&1` and pass the
-	# merged stream through `tee` for classification. Indentation is applied by the enclosing
-	# `build_dependencies | output "$LOG_FILE"` pipe in bin/compile — do not re-indent here or
-	# every pnpm line would be indented twice.
+	# pnpm writes progress and errors across stdout+stderr; merge them with `2>&1`, pass the
+	# merged stream through `tee` for classification, and indent it with `output::indent`.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { pnpm "${pnpm_install_args[@]}" 2>&1 | tee "${log_file}"; }; then
+	if ! { pnpm "${pnpm_install_args[@]}" 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `pnpm 2>&1 | tee`, so [0] is pnpm's exit code and [1] is tee's.
+		# The pipeline is `pnpm 2>&1 | tee | output::indent`, so [0] is pnpm's exit code (tee is [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local pnpm_exit="${pipe_status[0]}"
 		build_data::set_duration "install_dependencies_time" "${start}"
@@ -79,10 +77,10 @@ package_managers::pnpm::install_dependencies() {
 			failure::emit failure
 		fi
 
-		# No known failure mode recognised. Bubble up by returning pnpm's exit code: the pipeline
-		# that runs this install (`build_dependencies | output "$LOG_FILE"`) then fails under
-		# errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error — covering the pnpm codes not yet migrated here.
+		# No known failure mode recognised. Bubble up by returning pnpm's exit code: the bare
+		# `build_dependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error — covering the
+		# pnpm codes not yet migrated here.
 		return "${pnpm_exit}"
 	fi
 
@@ -91,7 +89,7 @@ package_managers::pnpm::install_dependencies() {
 	# prune the store when the counter reaches zero to clean up errant package versions which may have been upgraded/removed
 	counter=$(load_pnpm_prune_store_counter "${cache_dir}")
 	if ((counter == 0)); then
-		echo "Cleaning up pnpm store"
+		output::info "Cleaning up pnpm store"
 		# pnpm <9.12.0 errors with `ENOENT: ... scandir '<store>/v*/files'`
 		# when the store has no fetched package files (e.g. an install with
 		# no external dependencies), because pnpm only creates that
@@ -106,7 +104,7 @@ package_managers::pnpm::install_dependencies() {
 		trap "rm -f '${prune_output}' >/dev/null" RETURN
 		pnpm store prune >"${prune_output}" 2>&1 || prune_exit=$?
 		if ((prune_exit != 0)) && ! grep -qE "ENOENT.*scandir" "${prune_output}"; then
-			cat "${prune_output}"
+			output::indent <"${prune_output}"
 			return "${prune_exit}"
 		fi
 	fi
@@ -168,14 +166,12 @@ function package_managers::pnpm::_run_prune() {
 	start=$(build_data::current_unix_realtime)
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
-	# pnpm writes progress and errors across stdout+stderr; merge them with `2>&1` and pass the
-	# merged stream through `tee` for classification. Indentation is applied by the enclosing
-	# `prune_devdependencies | output "$LOG_FILE"` pipe in bin/compile — do not re-indent here or
-	# every pnpm line would be indented twice.
+	# pnpm writes progress and errors across stdout+stderr; merge them with `2>&1`, pass the
+	# merged stream through `tee` for classification, and indent it with `output::indent`.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { "${prune_command[@]}" 2>&1 | tee "${log_file}"; }; then
+	if ! { "${prune_command[@]}" 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `pnpm 2>&1 | tee`, so [0] is pnpm's exit code and [1] is tee's.
+		# The pipeline is `pnpm 2>&1 | tee | output::indent`, so [0] is pnpm's exit code (tee is [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local pnpm_exit="${pipe_status[0]}"
 		build_data::set_duration "prune_dev_dependencies_time" "${start}"
@@ -204,10 +200,10 @@ function package_managers::pnpm::_run_prune() {
 			failure::emit failure
 		fi
 
-		# No known failure mode recognised. Bubble up by returning pnpm's exit code: the pipeline
-		# that runs this prune (`prune_devdependencies | output "$LOG_FILE"`) then fails under
-		# errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error — there is no migrated pnpm-prune tool-error classifier to add here yet.
+		# No known failure mode recognised. Bubble up by returning pnpm's exit code: the bare
+		# `prune_devdependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error — there is no
+		# migrated pnpm-prune tool-error classifier to add here yet.
 		return "${pnpm_exit}"
 	fi
 
@@ -284,15 +280,15 @@ function package_managers::pnpm::prune_devdependencies() {
 	# lib/environment.sh / the app's config vars).
 	# shellcheck disable=SC2154 # set by the caller (bin/compile)
 	if [[ "${NODE_ENV}" == "test" ]]; then
-		echo "Skipping because NODE_ENV is 'test'"
+		output::info "Skipping because NODE_ENV is 'test'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ "${NODE_ENV}" != "production" ]]; then
-		echo "Skipping because NODE_ENV is not 'production'"
+		output::info "Skipping because NODE_ENV is not 'production'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ "${PNPM_SKIP_PRUNING}" == "true" ]]; then
-		echo "Skipping because PNPM_SKIP_PRUNING is '${PNPM_SKIP_PRUNING}'"
+		output::info "Skipping because PNPM_SKIP_PRUNING is '${PNPM_SKIP_PRUNING}'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	fi
@@ -413,7 +409,7 @@ function package_managers::pnpm::_list_workspace_projects() {
 
 function package_managers::pnpm::install_binary() {
 	local version="$1"
-	echo "Downloading and installing pnpm (${version})"
+	output::info "Downloading and installing pnpm (${version})"
 	# npm 12 removed the --unsafe-perm flag and rejects it with EUNKNOWNCONFIG, so only pass it
 	# to the currently-active npm when that npm still accepts it.
 	local unsafe_perm=()
@@ -434,7 +430,7 @@ function package_managers::pnpm::install_binary() {
 	# Verify pnpm works before capturing and ensure its stderr is inspectable later
 	utils::command::suppress_output pnpm --version
 	# shellcheck disable=SC2312 # the preceding utils::command::suppress_output already verified pnpm works, so masking its exit here is intentional (matches pre-migration behavior)
-	echo "Using pnpm $(pnpm --version)"
+	output::info "Using pnpm $(pnpm --version)"
 }
 
 # Runs a named lifecycle script with pnpm. Spells the pnpm-specific command (`pnpm run
@@ -445,11 +441,11 @@ function package_managers::pnpm::run_script() {
 	local script_name=${1}
 	local build_flags=${2:-}
 
-	echo "Running ${script_name}"
+	output::info "Running ${script_name}"
 
 	local command=(pnpm run --if-present "${script_name}")
 	if [[ -n "${build_flags}" ]]; then
-		echo "Running with ${build_flags} flags"
+		output::info "Running with ${build_flags} flags"
 		command+=(-- "${build_flags}")
 	fi
 

--- a/lib/package_managers/yarn.sh
+++ b/lib/package_managers/yarn.sh
@@ -26,9 +26,9 @@ function package_managers::yarn::install_binary() {
 
 	if [[ -n "${YARN_BINARY_URL}" ]]; then
 		url="${YARN_BINARY_URL}"
-		echo "Downloading and installing yarn from ${url}"
+		output::info "Downloading and installing yarn from ${url}"
 	else
-		echo "Downloading and installing yarn (${version})"
+		output::info "Downloading and installing yarn (${version})"
 		# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
 		if ! package_name=$(package_managers::yarn::_determine_package_name "${version}"); then
 			build_data::set_string "failure" "yarn-resolve-failed"
@@ -53,9 +53,9 @@ function package_managers::yarn::install_binary() {
 	installed_version="$(yarn --version)"
 	# shellcheck disable=SC2154 # YARN_2 is a global set by the caller (bin/compile)
 	if ${YARN_2}; then
-		echo "Using yarn ${installed_version}"
+		output::info "Using yarn ${installed_version}"
 	else
-		echo "Installed yarn ${installed_version}"
+		output::info "Installed yarn ${installed_version}"
 	fi
 }
 
@@ -141,7 +141,7 @@ function package_managers::yarn::install_dependencies() {
 	local build_dir="${1:-}"
 	local production="${YARN_PRODUCTION:-false}"
 
-	echo "Installing node modules (yarn.lock)"
+	output::info "Installing node modules (yarn.lock)"
 	cd "${build_dir}" || return
 
 	local log_file
@@ -151,14 +151,13 @@ function package_managers::yarn::install_dependencies() {
 	start=$(build_data::current_unix_realtime)
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
-	# Yarn 1 writes progress and errors across stdout+stderr; merge them with `2>&1` and pass the
-	# merged stream through `tee` for classification. Indentation is applied by the enclosing
-	# `build_dependencies | output "$LOG_FILE"` pipe in bin/compile — do not re-indent here or
-	# every yarn line would be indented twice.
+	# Yarn 1 writes progress and errors across stdout+stderr; merge them with `2>&1`, pass the
+	# merged stream through `tee` for classification, and indent it with `output::indent`.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { yarn install --production="${production}" --frozen-lockfile --ignore-engines --prefer-offline 2>&1 | tee "${log_file}"; }; then
+	if ! { yarn install --production="${production}" --frozen-lockfile --ignore-engines --prefer-offline 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `yarn 2>&1 | tee`, so [0] is yarn's exit code and [1] is tee's.
+		# The pipeline is `yarn 2>&1 | tee | output::indent`, so [0] is yarn's exit code (tee is
+		# [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local yarn_exit="${pipe_status[0]}"
 		build_data::set_duration "install_dependencies_time" "${start}"
@@ -197,10 +196,10 @@ function package_managers::yarn::install_dependencies() {
 			failure::emit failure
 		fi
 
-		# No known failure mode recognised. Bubble up by returning yarn's exit code: the pipeline
-		# that runs this install (`build_dependencies | output "$LOG_FILE"`) then fails under
-		# errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error — covering the yarn 1.x cases not yet migrated here.
+		# No known failure mode recognised. Bubble up by returning yarn's exit code: the bare
+		# `build_dependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error — covering the
+		# yarn 1.x cases not yet migrated here.
 		return "${yarn_exit}"
 	fi
 
@@ -411,7 +410,7 @@ function package_managers::yarn::_match_classic_registry_404() {
 function package_managers::yarn::yarn2_install_dependencies() {
 	local build_dir="${1:-}"
 
-	echo "Running 'yarn install' with yarn.lock"
+	output::info "Running 'yarn install' with yarn.lock"
 	cd "${build_dir}" || return
 
 	local log_file
@@ -421,14 +420,13 @@ function package_managers::yarn::yarn2_install_dependencies() {
 	start=$(build_data::current_unix_realtime)
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
-	# Berry writes progress and errors across stdout+stderr; merge them with `2>&1` and pass the
-	# merged stream through `tee` for classification. Indentation is applied by the enclosing
-	# `build_dependencies | output "$LOG_FILE"` pipe in bin/compile — do not re-indent here or
-	# every yarn line would be indented twice.
+	# Berry writes progress and errors across stdout+stderr; merge them with `2>&1`, pass the
+	# merged stream through `tee` for classification, and indent it with `output::indent`.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { yarn install --immutable 2>&1 | tee "${log_file}"; }; then
+	if ! { yarn install --immutable 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `yarn 2>&1 | tee`, so [0] is yarn's exit code and [1] is tee's.
+		# The pipeline is `yarn 2>&1 | tee | output::indent`, so [0] is yarn's exit code (tee is
+		# [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local yarn_exit="${pipe_status[0]}"
 		build_data::set_duration "install_dependencies_time" "${start}"
@@ -462,11 +460,10 @@ function package_managers::yarn::yarn2_install_dependencies() {
 			failure::emit failure
 		fi
 
-		# No known failure mode recognised. Bubble up by returning yarn's exit code: the pipeline
-		# that runs this install (`build_dependencies | output "$LOG_FILE"`) then fails under
-		# errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error — covering the Berry YN codes (e.g. YN0001, YN0018) not yet
-		# migrated here.
+		# No known failure mode recognised. Bubble up by returning yarn's exit code: the bare
+		# `build_dependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error — covering the
+		# Berry YN codes (e.g. YN0001, YN0018) not yet migrated here.
 		return "${yarn_exit}"
 	fi
 
@@ -555,15 +552,15 @@ function package_managers::yarn::prune_devdependencies() {
 	# and any flavor-specific skip (e.g. YARN2_SKIP_PRUNING).
 	# shellcheck disable=SC2154 # set by the caller (bin/compile)
 	if [[ "${NODE_ENV}" == "test" ]]; then
-		echo "Skipping because NODE_ENV is 'test'"
+		output::info "Skipping because NODE_ENV is 'test'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ "${NODE_ENV}" != "production" ]]; then
-		echo "Skipping because NODE_ENV is not 'production'"
+		output::info "Skipping because NODE_ENV is not 'production'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif [[ -n "${YARN_PRODUCTION}" ]]; then
-		echo "Skipping because YARN_PRODUCTION is '${YARN_PRODUCTION}'"
+		output::info "Skipping because YARN_PRODUCTION is '${YARN_PRODUCTION}'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	elif ${YARN_2}; then
@@ -589,14 +586,13 @@ function package_managers::yarn::_prune_classic_devdependencies() {
 	start=$(build_data::current_unix_realtime)
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
-	# Yarn 1 writes progress and errors across stdout+stderr; merge them with `2>&1` and pass
-	# the merged stream through `tee` for classification. Indentation is applied by the
-	# enclosing `prune_devdependencies | output "$LOG_FILE"` pipe in bin/compile — do not
-	# re-indent here or every yarn line would be indented twice.
+	# Yarn 1 writes progress and errors across stdout+stderr; merge them with `2>&1`, pass the
+	# merged stream through `tee` for classification, and indent it with `output::indent`.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { yarn install --frozen-lockfile --ignore-engines --ignore-scripts --prefer-offline 2>&1 | tee "${log_file}"; }; then
+	if ! { yarn install --frozen-lockfile --ignore-engines --ignore-scripts --prefer-offline 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `yarn 2>&1 | tee`, so [0] is yarn's exit code and [1] is tee's.
+		# The pipeline is `yarn 2>&1 | tee | output::indent`, so [0] is yarn's exit code (tee is
+		# [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local yarn_exit="${pipe_status[0]}"
 		build_data::set_duration "prune_dev_dependencies_time" "${start}"
@@ -628,10 +624,10 @@ function package_managers::yarn::_prune_classic_devdependencies() {
 			failure::emit failure
 		fi
 
-		# No known prune failure mode recognised. Bubble up by returning yarn's exit code: the
-		# pipeline that runs this prune (`prune_devdependencies | output "$LOG_FILE"`) then fails
-		# under errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error — no migrated yarn-prune tool-error classifier exists here yet.
+		# No known prune failure mode recognised. Bubble up by returning yarn's exit code: the bare
+		# `prune_devdependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error — no migrated
+		# yarn-prune tool-error classifier exists here yet.
 		return "${yarn_exit}"
 	fi
 
@@ -697,13 +693,13 @@ function package_managers::yarn::_prune_berry_devdependencies() {
 
 	# shellcheck disable=SC2154 # YARN2_SKIP_PRUNING is a global set by the caller (bin/compile)
 	if [[ "${YARN2_SKIP_PRUNING}" == "true" ]]; then
-		echo "Skipping because YARN2_SKIP_PRUNING is '${YARN2_SKIP_PRUNING}'"
+		output::info "Skipping because YARN2_SKIP_PRUNING is '${YARN2_SKIP_PRUNING}'"
 		build_data::set_raw "skipped_prune" "true"
 		return 0
 	fi
 
 	cd "${build_dir}" || return
-	echo "Running 'yarn heroku prune'"
+	output::info "Running 'yarn heroku prune'"
 	export YARN_PLUGINS="${buildpack_dir}/yarn2-plugins/prune-dev-dependencies/bundles/@yarnpkg/plugin-prune-dev-dependencies.js"
 
 	local log_file
@@ -713,14 +709,13 @@ function package_managers::yarn::_prune_berry_devdependencies() {
 	start=$(build_data::current_unix_realtime)
 
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
-	# Berry writes progress and errors across stdout+stderr; merge them with `2>&1` and pass
-	# the merged stream through `tee` for classification. Indentation is applied by the
-	# enclosing `prune_devdependencies | output "$LOG_FILE"` pipe in bin/compile — do not
-	# re-indent here or every yarn line would be indented twice.
+	# Berry writes progress and errors across stdout+stderr; merge them with `2>&1`, pass the
+	# merged stream through `tee` for classification, and indent it with `output::indent`.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { yarn heroku prune 2>&1 | tee "${log_file}"; }; then
+	if ! { yarn heroku prune 2>&1 | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status first (before any other command clobbers PIPESTATUS).
-		# The pipeline is `yarn 2>&1 | tee`, so [0] is yarn's exit code and [1] is tee's.
+		# The pipeline is `yarn 2>&1 | tee | output::indent`, so [0] is yarn's exit code (tee is
+		# [1], output::indent [2]).
 		local pipe_status=("${PIPESTATUS[@]}")
 		local yarn_exit="${pipe_status[0]}"
 		build_data::set_duration "prune_dev_dependencies_time" "${start}"
@@ -739,10 +734,10 @@ function package_managers::yarn::_prune_berry_devdependencies() {
 			failure::emit failure
 		fi
 
-		# No known prune failure mode recognised. Bubble up by returning yarn's exit code: the
-		# pipeline that runs this prune (`prune_devdependencies | output "$LOG_FILE"`) then fails
-		# under errexit/pipefail and the generic failure::handle_uncaught ERR trap records it as
-		# failure=internal-error — no migrated yarn-prune tool-error classifier exists here yet.
+		# No known prune failure mode recognised. Bubble up by returning yarn's exit code: the bare
+		# `prune_devdependencies` call in bin/compile then fails under errexit and the generic
+		# failure::handle_uncaught ERR trap records it as failure=internal-error — no migrated
+		# yarn-prune tool-error classifier exists here yet.
 		return "${yarn_exit}"
 	fi
 
@@ -750,7 +745,7 @@ function package_managers::yarn::_prune_berry_devdependencies() {
 
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside; a false result just skips the cache cleanup
 	if package_managers::yarn::_berry_node_modules_enabled "${build_dir}"; then
-		echo "Removing local yarn cache to reduce slug size"
+		output::info "Removing local yarn cache to reduce slug size"
 		rm -rf "${build_dir}/.yarn/cache"
 	fi
 	build_data::set_raw "skipped_prune" "false"
@@ -985,7 +980,7 @@ function package_managers::yarn::run_script() {
 	local build_flags=${3:-}
 	local script
 
-	echo "Running ${script_name} (yarn)"
+	output::info "Running ${script_name} (yarn)"
 
 	script=$(utils::json::read "${build_dir}/package.json" ".scripts[\"${script_name}\"]")
 	if [[ -z "${script}" ]]; then
@@ -994,7 +989,7 @@ function package_managers::yarn::run_script() {
 
 	local command=(yarn run "${script_name}")
 	if [[ -n "${build_flags}" ]]; then
-		echo "Running with ${build_flags} flags"
+		output::info "Running with ${build_flags} flags"
 		command+=("${build_flags}")
 	fi
 

--- a/lib/runtimes/nodejs.sh
+++ b/lib/runtimes/nodejs.sh
@@ -34,11 +34,13 @@ function runtimes::nodejs::install() {
 	# Run inside `if !` so errexit is suppressed and we can inspect the failure ourselves.
 	# `_install` handles every failure it anticipates at the site (each `_fail_*` helper emits via
 	# `failure::emit` and exits the process), so control only reaches this branch on a genuinely
-	# unexpected, non-emitting failure. `tee` passes stdout through, so normal install output still
-	# reaches the caller's pipe; user-facing warnings/errors go to stderr and pass straight through.
+	# unexpected, non-emitting failure. `tee` captures the merged output for inspection and
+	# `output::indent` indents it under the caller's `output::step`; warnings/errors go to stderr
+	# and pass straight through.
 	# shellcheck disable=SC2310 # invoked in a condition so set -e is disabled inside
-	if ! { runtimes::nodejs::_install "${requested_version}" "${dir}" | tee "${log_file}"; }; then
+	if ! { runtimes::nodejs::_install "${requested_version}" "${dir}" | tee "${log_file}" | output::indent; }; then
 		# Capture the full pipe status before any other command clobbers PIPESTATUS.
+		# The pipeline is `_install | tee | output::indent`, so [0] is _install's exit code.
 		local install_exit="${PIPESTATUS[0]}"
 		build_data::set_duration "install_node_binary_time" "${start}"
 

--- a/lib/utils/command.sh
+++ b/lib/utils/command.sh
@@ -22,7 +22,7 @@ function utils::command::suppress_output() {
 
 	"$@" >"${TMP_COMMAND_OUTPUT}" 2>&1 || {
 		local exit_code="$?"
-		cat "${TMP_COMMAND_OUTPUT}"
+		output::indent <"${TMP_COMMAND_OUTPUT}"
 		return "${exit_code}"
 	}
 	return 0


### PR DESCRIPTION
The build steps in `bin/compile` relied on a top-level pipe (`step | output "$LOG_FILE"`) to indent their output. That pipe runs each step in a subshell. This layer of indirection can swallow exit codes and mask failures, which is the opposite of the direction we want as error handling migrates onto the call-site classification framework.

This runs each build step bare in `bin/compile` and moves output formatting into the steps themselves:
- headers use `output::step`
- one-off lines use the new `output::info`
- piped tool output is indented at the call site with `output::indent` 

The rendered build output is unchanged and there's one less subshell between a failing command and the error handler.

W-23927950
