### PR TITLE
Land the strict-mode trap cleanup left out of #1768

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -378,6 +378,9 @@ install_bins
 if $PNPM; then
   # pnpm 11+ reads config from pnpm_config_* env vars (https://pnpm.io/blog/releases/11.0#highlights),
   # older versions use npm_config_*
+  # Deliberately unguarded (no `|| true`, unlike the version probes in install_bins and the store
+  # probe below): pnpm was just installed and verified, so a failure reading its version here is a
+  # genuine internal error that should abort via the ERR trap rather than silently degrade.
   pnpm_major=$(pnpm --version | cut -d "." -f 1)
   pnpm_store_dir_config_name="npm_config_store_dir"
   if (( pnpm_major >= 11 )); then

--- a/lib/failures.sh
+++ b/lib/failures.sh
@@ -50,10 +50,13 @@ function failure::emit() {
 	# shellcheck disable=SC2178 # nameref alias to the caller's associative array, not a string
 	local -n __failure="${1}"
 
-	# `output::step` writes the "Build failed" header to stdout; the message is piped through
-	# `output::error`, which styles it and writes to stderr. Every step in `bin/compile` now runs
-	# bare (no enclosing `output` pipe), so nothing emitted here is re-indented or double-styled.
-	output::step "Build failed"
+	# Write the whole failure block to stderr: the "Build failed" header via `output::step "..." >&2`,
+	# the message piped through `output::error` (already stderr). Routing the header to stderr too
+	# keeps it visible when emit fires inside a `$(...)`: with `errtrace` the ERR trap can fire inside
+	# a command substitution whose stdout the caller captures and discards, which would swallow a
+	# stdout header while the stderr message still reached the user. Every step in `bin/compile` now
+	# runs bare (no enclosing `output` pipe), so nothing emitted here is re-indented or double-styled.
+	output::step "Build failed" >&2
 	echo "${__failure[message]}" | output::error
 
 	build_data::set_string "failure" "${__failure[id]}"
@@ -74,17 +77,19 @@ function failure::emit() {
 # Python buildpack's `utils::err_trap`: it renders a neutral "internal error" message, records a
 # generic failure reason for observability, and terminates the build.
 function failure::handle_uncaught() {
-	# Capture the failing command FIRST, before any other command runs. Inside an ERR trap
-	# BASH_COMMAND holds the command that triggered the trap — a best-effort breadcrumb, not an exact
-	# pointer: for a failed pipeline it names the whole pipeline rather than the stage that failed, and
+	# Capture the failing command for the message and detail below. Inside an ERR trap BASH_COMMAND
+	# stays pinned to the command that triggered the trap — a best-effort breadcrumb, not an exact
+	# pointer: for a failed pipeline it names the pipeline's last stage (with pipefail, usually not the
+	# stage that actually failed), and
 	# once a failure has crossed a subshell/`$(...)` boundary it may name the boundary rather than the
 	# leaf command. Good enough for an observability detail; don't treat it as authoritative.
 	local failing_command="${BASH_COMMAND}"
 
 	# We enable `errtrace`, so this ERR trap fires inside functions, subshells, and command
-	# substitutions and can fire more than once as a single failure unwinds. Disarm it on entry so
-	# a failure inside this handler — e.g. while `failure::emit` records build data, before it
-	# writes the marker — can't re-enter and double-report.
+	# substitutions. Disarm it on entry so the `caller` stack-trace loop below can't feed the trap's
+	# own stdout back into its FIFO (see the HAZARD note there). Bash already suppresses synchronous
+	# re-entry of a running ERR trap and fires ERR once at the leaf, not per unwound frame, so this
+	# disarm is defence-in-depth, not a fix for a mid-handler double-report.
 	trap - ERR
 
 	# A migrated code path may have already classified, rendered, and recorded this failure via
@@ -98,8 +103,9 @@ function failure::handle_uncaught() {
 	local stack_trace
 	stack_trace=$(
 		local frame=0
-		# HAZARD: `while read ... < <(caller ...)` is safe here ONLY because the ERR trap was disarmed
-		# on entry (`trap - ERR` above) and `caller` is guarded with `|| true`. Under an *active*,
+		# HAZARD: `while read ... < <(caller ...)` is safe because either guard alone would prevent the
+		# hang described below; both are kept as defence in depth. The ERR trap is disarmed on entry
+		# (`trap - ERR` above) and `caller` is guarded with `|| true`. Under an *active*,
 		# stdout-writing ERR trap a failing command in the process substitution would feed the trap's
 		# own output back into this FIFO to be re-read as loop input — an infinite loop that hangs the
 		# build. Keep both guards, and don't replicate this pattern anywhere the ERR trap is still armed.

--- a/lib/utils/json.sh
+++ b/lib/utils/json.sh
@@ -19,8 +19,9 @@ function utils::json::read() {
 		# -M = strip any color
 		# --raw-output = if the filter’s result is a string then it will be written directly
 		#                to stdout rather than being formatted as a JSON string with quotes
-		# `|| echo ""`: on a jq error (e.g. the key resolves to a non-string type, which `// ""` can't
-		# coerce, or malformed JSON) degrade to an empty string rather than a hard failure. This
+		# `|| echo ""`: on a jq error (e.g. indexing into a value of the wrong type, which `// ""` does
+		# not rescue since it only substitutes null/false, or malformed JSON) degrade to an empty
+		# string rather than a hard failure. This
 		# matches the missing-file branch below and the sibling utils::yaml::read, and — critically
 		# under inherit_errexit — keeps a bad read from tripping the ERR trap and poisoning the failure
 		# marker at an unrelated call site.

--- a/test/run-general
+++ b/test/run-general
@@ -288,10 +288,10 @@ testMultipleRuns() {
 
 testBadJson() {
   compile "bad-json"
-  assertCaptured "Build failed"
   assertNotCaptured "Installing binaries"
   # The migrated invalid-package-json path renders the failure via failure::emit, which writes
-  # the message to stderr; no generic failure footer is printed.
+  # the "Build failed" header and the message to stderr; no generic failure footer is printed.
+  assertCapturedStderr "Build failed"
   assertCapturedError 1 "Unable to parse"
 }
 
@@ -479,11 +479,10 @@ testUnstableVersion() {
 testFailingBuild() {
   compile "failing-build"
   # The failing heroku-postbuild script matches no specific classifier, so run_script_command's
-  # build-script catch-all classifies it as unknown-build-script-error (classification=user):
-  # "Build failed" prints to stdout and the app-troubleshooting message goes to stderr via
-  # output::error.
-  assertCaptured "Build failed"
+  # build-script catch-all classifies it as unknown-build-script-error (classification=user).
+  # failure::emit writes both the "Build failed" header and the message to stderr via output::error.
   assertNotCaptured "Checking startup method"
+  assertCapturedStderr "Build failed"
   assertCapturedError 1 "A build script exited with a non-zero exit code"
 }
 

--- a/test/unit
+++ b/test/unit
@@ -669,6 +669,104 @@ testErrTrapNotPoisonedByGuardedVersionSub() {
   rm -f "$unguarded_capture" "$guarded_capture" "$unguarded_marker" "$guarded_marker"
 }
 
+testErrTrapReportsAndTerminatesOnUncaughtParentFailure() {
+  # A genuinely-uncaught failure at the top level of the build must fire the armed ERR trap,
+  # render the internal-error message, record failure=internal-error (plus the failing command as
+  # failure_detail), write the marker, and TERMINATE — the shell must not run past the failure.
+  # This is the run-past-failure / build-hang guard for the handler; it complements
+  # testErrTrapNotPoisonedByGuardedVersionSub (a *guarded* sub that must NOT fire the trap).
+  # Runs in a BACKGROUNDED subshell so `set -e` stays genuinely active (an inline `( … ) || true`
+  # or `if ( … )` would put it in a condition context and suppress errexit vacuously); `wait …
+  # || true` collects the exit code without aborting the runner. A regression that broke
+  # termination (or the caller stack-trace loop) would surface as "UNREACHABLE" in the output.
+  local out capture out_file marker
+  capture="$(mktemp)"
+  out_file="$(mktemp)"
+  marker="$(mktemp)" && rm -f "$marker"
+  (
+    build_data::set_string() { echo "$1=$2" >>"$capture"; }
+    build_data::set_duration() { :; }
+    build_start_time=0
+    export FAILURE_EMITTED_MARKER="$marker"
+    set -euo pipefail -o errtrace
+    shopt -s inherit_errexit
+    trap 'failure::handle_uncaught' ERR
+    heroku_broken_tool_zzz # bare, top-level, unclassified: must fire the trap and terminate
+    echo "UNREACHABLE"     # the handler must exit the build before this line runs
+  ) >"$out_file" 2>&1 &
+  wait "$!" || true
+  out="$(cat "$out_file")"
+
+  assertContains "should render the internal-error message" "$out" "An unexpected error occurred"
+  assertContains "should name the failing command in the output" "$out" "heroku_broken_tool_zzz"
+  assertNotContains "must terminate the build before running past the failure" "$out" "UNREACHABLE"
+  assertContains "should record failure=internal-error" "$(cat "$capture")" "failure=internal-error"
+  assertContains "should record the failing command as failure_detail" \
+    "$(cat "$capture")" "failure_detail=heroku_broken_tool_zzz"
+  assertTrue "should write the marker so a re-fire would be deduped" "[ -e '$marker' ]"
+  rm -f "$capture" "$out_file" "$marker"
+}
+
+testFailureEmitDisarmsTrapOnEntry() {
+  # emit disarms the ERR trap on its first line so a hiccup *inside* emit (here: the build_data
+  # write fails) can't re-enter failure::handle_uncaught and overwrite the real classification with
+  # a generic internal-error. Runs under the real strict mode with the live trap armed, in a
+  # BACKGROUNDED subshell so `set -e` stays active (see testErrTrapNotPoisonedByGuardedVersionSub).
+  # If the disarm regressed, set_string's failure would fire the trap and the capture would also
+  # contain failure=internal-error.
+  local capture marker
+  capture="$(mktemp)"
+  marker="$(mktemp)" && rm -f "$marker"
+  (
+    # set_string fails on every call, simulating a hiccup mid-emit.
+    build_data::set_string() {
+      echo "$1=$2" >>"$capture"
+      return 1
+    }
+    build_data::set_duration() { :; }
+    build_start_time=0
+    export FAILURE_EMITTED_MARKER="$marker"
+    declare -A failure
+    failure[id]="install-dependencies::npm"
+    failure[message]="Error: Unable to install dependencies using npm."
+    set -euo pipefail -o errtrace
+    shopt -s inherit_errexit
+    trap 'failure::handle_uncaught' ERR
+    failure::emit failure
+  ) >/dev/null 2>&1 &
+  wait "$!" || true
+
+  assertContains "should record the classified failure id" \
+    "$(cat "$capture")" "failure=install-dependencies::npm"
+  assertEquals "disarm must keep the trap from overwriting the classification with internal-error" "" \
+    "$(grep '^failure=internal-error' "$capture" || true)"
+  rm -f "$capture" "$marker"
+}
+
+testFailureHandleUncaughtRendersStackFrames() {
+  # The handler records a `caller` stack for observability. Drive it through a nested call chain so
+  # the trace has multiple frames, and assert each named frame appears — this exercises the
+  # `while read … < <(caller …)` loop past its first iteration and proves it terminates (a
+  # regression that broke the loop guards would hang instead of returning this output). Called
+  # directly (not via a real trap) so we can assert the exact frame names.
+  local out capture
+  capture=$(mktemp)
+  out=$(
+    fail() { exit 1; }
+    build_data::set_string() { echo "$1=$2" >>"$capture"; }
+    unset FAILURE_EMITTED_MARKER
+    _uncaught_frame_c() { failure::handle_uncaught; }
+    _uncaught_frame_b() { _uncaught_frame_c; }
+    _uncaught_frame_a() { _uncaught_frame_b; }
+    _uncaught_frame_a 2>&1 || true
+  )
+
+  assertContains "stack trace should name the innermost frame" "$out" "_uncaught_frame_c @"
+  assertContains "stack trace should name the middle frame" "$out" "_uncaught_frame_b @"
+  assertContains "stack trace should name the outermost frame" "$out" "_uncaught_frame_a @"
+  rm -f "$capture"
+}
+
 testFailureHandlePipefail() {
   # The generic pipefail helper hard-codes classification=buildpack and encodes the
   # PIPESTATUS array into failure_detail for observability. Callers pass the id and message.


### PR DESCRIPTION
#1768 hardened the uncaught-error trap for strict mode, but a follow-up cleanup commit meant to ship with it was never committed to the branch before it merged. This lands it.

The one behavior change: `failure::emit` now writes the "Build failed" header to stderr (`>&2`). With `errtrace`, the ERR trap can fire inside a `$(...)` whose stdout the caller captures and discards — a stdout-only header would be swallowed while the styled message (already on stderr) still reached the user.

The rest is non-behavioral: corrected strict-mode comments in `lib/failures.sh` and the `jq` comment in `lib/utils/json.sh`, a note on the deliberately-unguarded `pnpm_major` read in `bin/compile`, and the ERR-trap unit tests that should have accompanied #1768.
