### PR TITLE
Migrate lib/environment.sh into the linting model

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 # Migrated shell files (kept in sync with the makefile's MIGRATED_FILES list). Tabs are used
 # so here-documents can be indented:
 # https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Documents
-[{lib/build_data.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
+[{lib/build_data.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
 binary_next_line = true
 indent_style = tab
 shell_variant = bash

--- a/bin/compile
+++ b/bin/compile
@@ -110,10 +110,10 @@ runtimes::nodejs::fail_iojs_unsupported "$BUILD_DIR"
 ### Compile
 
 create_env() {
-  export_env_dir "$ENV_DIR"
-  create_default_env "$YARN"
-  write_profile "$BP_DIR" "$BUILD_DIR"
-  write_export "$BP_DIR" "$BUILD_DIR"
+  environment::export_env_dir "$ENV_DIR"
+  environment::create_default_env "$YARN"
+  environment::write_profile "$BP_DIR" "$BUILD_DIR"
+  environment::write_export "$BP_DIR" "$BUILD_DIR"
 }
 
 output::step "Creating runtime environment"
@@ -121,8 +121,8 @@ output::step "Creating runtime environment"
 mkdir -p "$BUILD_DIR/.heroku/node/"
 cd "$BUILD_DIR"
 create_env # can't pipe the whole thing because piping causes subshells, preventing exports
-list_node_config
-create_build_env
+environment::list_node_config
+environment::create_build_env
 
 
 ### Configure vendored package manager

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -22,4 +22,4 @@ export NODE_ENV=${NODE_ENV:-test}
 ### Compile the app
 
 "$BP_DIR/bin/compile" "$1" "$2" "$3"
-write_ci_profile "$BP_DIR" "$1"
+environment::write_ci_profile "$BP_DIR" "$1"

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -1,96 +1,116 @@
 #!/usr/bin/env bash
 
-get_os() {
-  uname | tr '[:upper:]' '[:lower:]'
+# Enable strict mode for ShellCheck's benefit, but restore the caller's options at the end of
+# the file (see epilogue) so these don't bleed into the un-migrated scripts that source this
+# lib. The caller's flags are read from `$-`, which reflects the *current* shell — a
+# `$(set +o)` capture runs in a command-substitution subshell where bash always forces errexit
+# off, so it would record (and later restore) errexit as disabled even when the caller had it
+# enabled. `$-` has no letter for pipefail, so that one option is captured separately (it is
+# reported correctly inside command substitution).
+# shellcheck disable=SC2034 # both are consumed by the epilogue
+__environment_saved_flags="$-"
+__environment_saved_pipefail="$(set +o | grep pipefail)"
+set -euo pipefail
+
+environment::get_os() {
+	uname | tr '[:upper:]' '[:lower:]'
 }
 
-create_default_env() {
-  local YARN=$1
+environment::create_default_env() {
+	local YARN="${1}"
 
-  export NPM_CONFIG_LOGLEVEL=${NPM_CONFIG_LOGLEVEL:-error}
-  export NODE_MODULES_CACHE=${NODE_MODULES_CACHE:-true}
-  export NODE_ENV=${NODE_ENV:-production}
-  export NODE_VERBOSE=${NODE_VERBOSE:-false}
+	export NPM_CONFIG_LOGLEVEL=${NPM_CONFIG_LOGLEVEL:-error}
+	export NODE_MODULES_CACHE=${NODE_MODULES_CACHE:-true}
+	export NODE_ENV=${NODE_ENV:-production}
+	export NODE_VERBOSE=${NODE_VERBOSE:-false}
 
-  if $YARN; then
-    export USE_YARN_CACHE=${USE_YARN_CACHE:-true}
-  fi
+	if "${YARN}"; then
+		export USE_YARN_CACHE=${USE_YARN_CACHE:-true}
+	fi
 
-  if [[ -n "$USE_NPM_INSTALL" ]]; then
-    export USE_NPM_INSTALL=${USE_NPM_INSTALL}
-  fi
+	if [[ -n "${USE_NPM_INSTALL:-}" ]]; then
+		export USE_NPM_INSTALL=${USE_NPM_INSTALL}
+	fi
 }
 
-create_build_env() {
-  # if the user hasn't set NODE_OPTIONS, increase the default amount of space
-  # that a node process can address to match that of the build dynos (2.5GB)
-  if [[ -z $NODE_OPTIONS ]]; then
-    export NODE_OPTIONS="--max_old_space_size=2560"
-  fi
+environment::create_build_env() {
+	# if the user hasn't set NODE_OPTIONS, increase the default amount of space
+	# that a node process can address to match that of the build dynos (2.5GB)
+	if [[ -z "${NODE_OPTIONS:-}" ]]; then
+		export NODE_OPTIONS="--max_old_space_size=2560"
+	fi
 }
 
-list_node_config() {
-  # Pure informational output (env dump + notes); indent the whole body under the caller's
-  # `output::step` so the call site can invoke this bare, like the other migrated steps.
-  {
-    echo ""
-    printenv | grep ^NPM_CONFIG_ || true
-    printenv | grep ^YARN_ || true
-    printenv | grep ^USE_NPM_ || true
-    printenv | grep ^USE_YARN_ || true
-    printenv | grep ^NODE_ || true
+environment::list_node_config() {
+	# Pure informational output (env dump + notes); indent the whole body under the caller's
+	# `output::step` so the call site can invoke this bare, like the other migrated steps.
+	{
+		echo ""
+		printenv | grep ^NPM_CONFIG_ || true
+		printenv | grep ^YARN_ || true
+		printenv | grep ^USE_NPM_ || true
+		printenv | grep ^USE_YARN_ || true
+		printenv | grep ^NODE_ || true
 
-    if [ "$NPM_CONFIG_PRODUCTION" = "true" ] && [ "$NODE_ENV" != "production" ]; then
-      echo ""
-      echo "npm scripts will see NODE_ENV=production (not '${NODE_ENV}')"
-      echo "https://docs.npmjs.com/misc/config#production"
-    fi
-  } | output::indent
+		if [[ "${NPM_CONFIG_PRODUCTION:-}" = "true" ]] && [[ "${NODE_ENV:-}" != "production" ]]; then
+			echo ""
+			echo "npm scripts will see NODE_ENV=production (not '${NODE_ENV:-}')"
+			echo "https://docs.npmjs.com/misc/config#production"
+		fi
+	} | output::indent
 }
 
-export_env_dir() {
-  local env_dir=$1
-  if [ -d "$env_dir" ]; then
-    local whitelist_regex=${2:-''}
-    local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG|BUILD_DIR)$'}
-    # shellcheck disable=SC2164
-    pushd "$env_dir" >/dev/null
-    for e in *; do
-      [ -e "$e" ] || continue
-      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
-      export "$e=$(cat "$e")"
-      :
-    done
-    # shellcheck disable=SC2164
-    popd >/dev/null
-  fi
+environment::export_env_dir() {
+	local env_dir="${1}"
+	if [[ -d "${env_dir}" ]]; then
+		local whitelist_regex=${2:-''}
+		local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG|BUILD_DIR)$'}
+		# shellcheck disable=SC2164
+		pushd "${env_dir}" >/dev/null
+		for e in *; do
+			[[ -e "${e}" ]] || continue
+			echo "${e}" | grep -E "${whitelist_regex}" | grep -qvE "${blacklist_regex}" \
+				&& export "${e}=$(cat "${e}")"
+			:
+		done
+		# shellcheck disable=SC2164
+		popd >/dev/null
+	fi
 }
 
-write_profile() {
-  local bp_dir="$1"
-  local build_dir="$2"
-  mkdir -p "$build_dir/.profile.d"
-  cp "$bp_dir"/profile/* "$build_dir/.profile.d/"
+environment::write_profile() {
+	local bp_dir="${1}"
+	local build_dir="${2}"
+	mkdir -p "${build_dir}/.profile.d"
+	cp "${bp_dir}"/profile/* "${build_dir}/.profile.d/"
 }
 
-write_ci_profile() {
-  local bp_dir="$1"
-  local build_dir="$2"
-  write_profile "$1" "$2"
-  cp "$bp_dir"/ci-profile/* "$build_dir/.profile.d/"
+environment::write_ci_profile() {
+	local bp_dir="${1}"
+	local build_dir="${2}"
+	environment::write_profile "${1}" "${2}"
+	cp "${bp_dir}"/ci-profile/* "${build_dir}/.profile.d/"
 }
 
-write_export() {
-  local bp_dir="$1"
-  local build_dir="$2"
+environment::write_export() {
+	local bp_dir="${1}"
+	local build_dir="${2}"
 
-  # only write the export script if the buildpack directory is writable.
-  # this may occur in situations outside of Heroku, such as running the
-  # buildpacks locally.
-  if [ -w "$bp_dir" ]; then
-    echo "export PATH=\"$build_dir/.heroku/node/bin:$build_dir/.heroku/yarn/bin:\$PATH:$build_dir/node_modules/.bin\"" > "$bp_dir/export"
-    echo "export NODE_HOME=\"$build_dir/.heroku/node\"" >> "$bp_dir/export"
-    # shellcheck disable=SC2016
-    echo 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' >> "$bp_dir/export"
-  fi
+	# only write the export script if the buildpack directory is writable.
+	# this may occur in situations outside of Heroku, such as running the
+	# buildpacks locally.
+	if [[ -w "${bp_dir}" ]]; then
+		echo "export PATH=\"${build_dir}/.heroku/node/bin:${build_dir}/.heroku/yarn/bin:\$PATH:${build_dir}/node_modules/.bin\"" >"${bp_dir}/export"
+		echo "export NODE_HOME=\"${build_dir}/.heroku/node\"" >>"${bp_dir}/export"
+		# shellcheck disable=SC2016
+		echo 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' >>"${bp_dir}/export"
+	fi
 }
+
+# Restore the sourcing shell's original options (see preamble) so strict mode doesn't leak
+# into un-migrated callers. errexit/nounset come from the saved `$-`; pipefail from its own
+# saved `set +o` line.
+case "${__environment_saved_flags}" in *e*) set -e ;; *) set +e ;; esac
+case "${__environment_saved_flags}" in *u*) set -u ;; *) set +u ;; esac
+eval "${__environment_saved_pipefail}"
+unset __environment_saved_flags __environment_saved_pipefail

--- a/lib/runtimes/nodejs.sh
+++ b/lib/runtimes/nodejs.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # BP_DIR is a global set by the caller; it is distinct from the bp_dir locals in the
 # metrics-plugin helpers below (SC2153 flags the case difference as a possible misspelling).
 # shellcheck disable=SC2154,SC2153
-RESOLVE="${BP_DIR}/lib/vendor/resolve-version-$(get_os)"
+RESOLVE="${BP_DIR}/lib/vendor/resolve-version-$(environment::get_os)"
 
 function runtimes::nodejs::_major_version() {
 	node --version | cut -d "." -f 1 | sed 's/^v//'

--- a/lib/utils/yaml.sh
+++ b/lib/utils/yaml.sh
@@ -8,10 +8,10 @@ __yaml_saved_flags="$-"
 __yaml_saved_pipefail="$(set +o | grep pipefail)"
 set -euo pipefail
 
-# BP_DIR is a global set by the caller (bin/compile) and get_os comes from lib/environment.sh,
+# BP_DIR is a global set by the caller (bin/compile) and environment::get_os comes from lib/environment.sh,
 # which is sourced first.
 # shellcheck disable=SC2154
-YQ="${BP_DIR}/lib/vendor/yq-4.52.4-$(get_os)"
+YQ="${BP_DIR}/lib/vendor/yq-4.52.4-$(environment::get_os)"
 
 # Reads a yq expression from a YAML file, emitting an empty string for a missing file or an
 # unreadable/unparseable one (mirrors utils::json::read's missing-file contract so callers that

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@
 # not maintain its own list).
 MIGRATED_FILES = \
 	lib/build_data.sh \
+	lib/environment.sh \
 	lib/failures.sh \
 	lib/output.sh \
 	lib/package_manager.sh \

--- a/test/quick
+++ b/test/quick
@@ -37,7 +37,7 @@ compileTest() {
   "$bp_dir/bin/test-compile" "$build_dir" "$cache_dir"
 
   export HOME=${build_dir}
-  export_env_dir $env_dir
+  environment::export_env_dir $env_dir
   for f in ${build_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
 
   "$bp_dir/bin/test" "$build_dir"

--- a/test/run-helpers
+++ b/test/run-helpers
@@ -109,7 +109,7 @@ executeStartup() {
 
   # we need to set any environment variables set via the env_dir and run
   # all of the .profile.d scripts
-  export_env_dir $env_dir
+  environment::export_env_dir $env_dir
 
   for f in ${compile_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
 }
@@ -143,7 +143,7 @@ compileTest() {
   # bin/test is not ran during build, rather during runtime, which means
   # we need to set any environment variables set via the env_dir and run
   # all of the .profile.d scripts
-  export_env_dir $env_dir
+  environment::export_env_dir $env_dir
   for f in ${compile_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
 
   capture ${bp_dir}/bin/test ${compile_dir}


### PR DESCRIPTION
`lib/environment.sh` was one of the last two `lib/*` files still outside `MIGRATED_FILES`. Bringing it in puts its functions under the shared `shellcheck enable=all` + `shfmt` rules and the `namespace::` convention, and adds the strict-mode preamble/epilogue so sourcing it no longer risks leaking `set -e`/`pipefail` into the still-un-migrated `bin/*` entry points and test helpers that source it.

Behavior is intentionally preserved: the `export_env_dir` errexit-swallow and the `true`/`false`-as-command env toggles are kept as-is, and the added `${var:-}` guards are behavior-neutral today (no entry point enables `nounset` yet) while making the file safe for that end state.

W-23972132
