### PR TITLE
Migrate bin/detect, bin/release, and bin/test into the linting/error-handling model

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 # Migrated shell files (kept in sync with the makefile's MIGRATED_FILES list). Tabs are used
 # so here-documents can be indented:
 # https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Documents
-[{lib/build_data.sh,lib/cache.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
+[{bin/detect,bin/release,bin/test,bin/test-compile,lib/build_data.sh,lib/cache.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
 binary_next_line = true
 indent_style = tab
 shell_variant = bash

--- a/bin/detect
+++ b/bin/detect
@@ -1,31 +1,36 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-[ "$BUILDPACK_XTRACE" ] && set -o xtrace
+set -euo pipefail
+shopt -s inherit_errexit
+
+[[ -n "${BUILDPACK_XTRACE:-}" ]] && set -o xtrace
+
+BUILD_DIR=${1:-}
 
 error() {
-  local c="2,999 s/^/ !     /"
+	local c="2,999 s/^/ !     /"
 	# send all of our output to stderr
 	exec 1>&2
 
 	echo -e "\033[1;31m" # bold; red
 	echo -n " !     ERROR: "
 	# this will be fed from stdin
-  case $(uname) in
-		Darwin) sed -l "$c";; # mac/bsd sed: -l buffers on line boundaries
-		*)      sed -u "$c";; # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
+	case $(uname) in
+		Darwin) sed -l "${c}" ;; # mac/bsd sed: -l buffers on line boundaries
+		*) sed -u "${c}" ;;      # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
 	esac
 	echo -e "\033[0m" # reset style
 	exit 1
 }
 
-if [ -f "$1/package.json" ]; then
-  echo 'Node.js'
-  exit 0
+if [[ -f "${BUILD_DIR}/package.json" ]]; then
+	echo 'Node.js'
+	exit 0
 fi
 
-if [[ -f "$1/.slugignore" ]] && grep -Fxq "package.json" "$1/.slugignore"; then
-  error << EOF
+if [[ -f "${BUILD_DIR}/.slugignore" ]] && grep -Fxq "package.json" "${BUILD_DIR}/.slugignore"; then
+	error <<EOF
 'package.json' listed in '.slugignore' file
 
 The 'heroku/nodejs' buildpack is set on this application, but was
@@ -35,8 +40,8 @@ the '.slugignore' file is removing it before the build begins.
 For more information, refer to the following documentation:
 https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore
 EOF
-elif [[ -f "$1/.gitignore" ]] && grep -Fxq "package.json" "$1/.gitignore"; then
-  error << EOF
+elif [[ -f "${BUILD_DIR}/.gitignore" ]] && grep -Fxq "package.json" "${BUILD_DIR}/.gitignore"; then
+	error <<EOF
 'package.json' listed in '.gitignore' file
 
 The 'heroku/nodejs' buildpack is set on this application, but was
@@ -48,29 +53,32 @@ For more information, refer to the following documentation:
 https://devcenter.heroku.com/articles/gitignore
 EOF
 else
-  error <<- EOF
-Application not supported by 'heroku/nodejs' buildpack
+	# Best-effort listing for the error message; ls's exit is not consulted (matches pre-migration behavior).
+	build_dir_listing=$(ls -1p "${BUILD_DIR}") || true
+	error <<-EOF
+		Application not supported by 'heroku/nodejs' buildpack
 
-The 'heroku/nodejs' buildpack is set on this application, but was
-unable to detect a Node.js codebase.
-    
-A Node.js app on Heroku requires a 'package.json' at the root of
-the directory structure.
+		The 'heroku/nodejs' buildpack is set on this application, but was
+		unable to detect a Node.js codebase.
+		    
+		A Node.js app on Heroku requires a 'package.json' at the root of
+		the directory structure.
 
-If you are trying to deploy a Node.js application, ensure that this
-file is present at the top level directory. This directory has the
-following files:
+		If you are trying to deploy a Node.js application, ensure that this
+		file is present at the top level directory. This directory has the
+		following files:
 
-$(ls -1p "$1")
-    
-If you are trying to deploy an application written in another
-language, you need to change the list of buildpacks set on your
-Heroku app using the 'heroku buildpacks' command.
-    
-For more information, refer to the following documentation:
-https://devcenter.heroku.com/articles/buildpacks
-https://devcenter.heroku.com/articles/nodejs-support#activation
-EOF
+		${build_dir_listing}
+		    
+		If you are trying to deploy an application written in another
+		language, you need to change the list of buildpacks set on your
+		Heroku app using the 'heroku buildpacks' command.
+		    
+		For more information, refer to the following documentation:
+		https://devcenter.heroku.com/articles/buildpacks
+		https://devcenter.heroku.com/articles/nodejs-support#activation
+	EOF
 fi
 
+# shellcheck disable=SC2317 # defensive fallback; every branch above already exits
 exit 1

--- a/bin/release
+++ b/bin/release
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
+set -euo pipefail
+shopt -s inherit_errexit
+
 BUILD_DIR=${1:-}
 
-if [ -f "$BUILD_DIR/Procfile" ] && grep -q -e "^\s*mcp.*:" "$BUILD_DIR/Procfile"; then
-  cat << EOF
+if [[ -f "${BUILD_DIR}/Procfile" ]] && grep -q -e "^\s*mcp.*:" "${BUILD_DIR}/Procfile"; then
+	cat <<EOF
 addons: []
 default_process_types: {}
 EOF
 else
-  cat << EOF
+	cat <<EOF
 addons: []
 default_process_types:
   web: npm start

--- a/bin/test
+++ b/bin/test
@@ -1,32 +1,35 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+shopt -s inherit_errexit
+
 BUILD_DIR=${1:-}
 
 read_package_json() {
-  local key="$1"
-  # shellcheck disable=SC2002
-  cat "$BUILD_DIR/package.json" | jq -c -M --raw-output "$key // \"\"" || return 1
+	local key="$1"
+	jq -c -M --raw-output "${key} // \"\"" "${BUILD_DIR}/package.json" || return 1
 }
 
 which_tool() {
-  yarn_engine=$(read_package_json ".engines.yarn")
-  pnpm_engine=$(read_package_json ".engines.pnpm")
-  package_manager=$(read_package_json ".packageManager")
-  if [ -n "$pnpm_engine" ] || [[ "$package_manager" == pnpm* ]]; then
-    echo "pnpm"
-  elif [ -n "$yarn_engine" ] || [[ "$package_manager" == yarn* ]]; then
-    echo "yarn"
-  else
-    echo "npm"
-  fi
+	local yarn_engine pnpm_engine package_manager
+	yarn_engine=$(read_package_json ".engines.yarn")
+	pnpm_engine=$(read_package_json ".engines.pnpm")
+	package_manager=$(read_package_json ".packageManager")
+	if [[ -n "${pnpm_engine}" ]] || [[ "${package_manager}" == pnpm* ]]; then
+		echo "pnpm"
+	elif [[ -n "${yarn_engine}" ]] || [[ "${package_manager}" == yarn* ]]; then
+		echo "yarn"
+	else
+		echo "npm"
+	fi
 }
 
 tool=$(which_tool)
 
-if [[ "$tool" == "pnpm" ]]; then
-  cd "$BUILD_DIR" && pnpm test
-elif [[ "$tool" == "yarn" ]]; then
-  cd "$BUILD_DIR" && yarn test
+if [[ "${tool}" == "pnpm" ]]; then
+	cd "${BUILD_DIR}" && pnpm test
+elif [[ "${tool}" == "yarn" ]]; then
+	cd "${BUILD_DIR}" && yarn test
 else
-  cd "$BUILD_DIR" && npm test
+	cd "${BUILD_DIR}" && npm test
 fi

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -3,16 +3,20 @@
 
 ### Configure environment
 
-set -o errexit    # always exit on error
-set -o pipefail   # don't ignore exit codes when piping output
+set -euo pipefail
+shopt -s inherit_errexit
 
 ### Configure directories
 
-BP_DIR=$(cd "$(dirname "${0:-}")" || exit; cd ..; pwd)
+BP_DIR=$(
+	cd "$(dirname "${0:-}")" || exit
+	cd .. || exit
+	pwd
+)
 
 ### Load dependencies
 # shellcheck source=lib/environment.sh
-source "$BP_DIR/lib/environment.sh"
+source "${BP_DIR}/lib/environment.sh"
 
 ### Set up test Node environment
 
@@ -21,5 +25,5 @@ export NODE_ENV=${NODE_ENV:-test}
 
 ### Compile the app
 
-"$BP_DIR/bin/compile" "$1" "$2" "$3"
-environment::write_ci_profile "$BP_DIR" "$1"
+"${BP_DIR}/bin/compile" "${1:-}" "${2:-}" "${3:-}"
+environment::write_ci_profile "${BP_DIR}" "${1:-}"

--- a/makefile
+++ b/makefile
@@ -3,6 +3,10 @@
 # source of truth for what gets linted/formatted (CI invokes these targets, it does
 # not maintain its own list).
 MIGRATED_FILES = \
+	bin/detect \
+	bin/release \
+	bin/test \
+	bin/test-compile \
 	lib/build_data.sh \
 	lib/cache.sh \
 	lib/environment.sh \


### PR DESCRIPTION
`bin/detect`, `bin/release`, `bin/test`, and `bin/test-compile` enable `set -euo pipefail` + `inherit_errexit` but not `errtrace`, following the Python buildpack's precedent for non-`compile` entrypoints, since none of them source `lib/failures.sh` or install an `ERR` trap. `bin/test-compile` runs `bin/compile` as a subprocess rather than sourcing it, so compile's own `ERR` trap continues to classify build failures and only compile's exit code crosses back — test-compile needs no trap of its own. Behavior is unchanged — this is a quoting, strict-mode-wrapper, and ShellCheck pass, not a logic change; rendered output and exit codes are identical across every branch (detection results, release YAML, test-runner selection, and CI compile).

Stacked on #1772.
