### PR TITLE
Migrate bin/report into the linting/error-handling model

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 # Migrated shell files (kept in sync with the makefile's MIGRATED_FILES list). Tabs are used
 # so here-documents can be indented:
 # https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Documents
-[{bin/detect,bin/release,bin/test,bin/test-compile,lib/build_data.sh,lib/cache.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
+[{bin/detect,bin/release,bin/report,bin/test,bin/test-compile,lib/build_data.sh,lib/cache.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
 binary_next_line = true
 indent_style = tab
 shell_variant = bash

--- a/bin/report
+++ b/bin/report
@@ -14,16 +14,16 @@
 #
 # Note: The build system doesn't source the `export` script before running this script.
 
-# TODO: set -u after linting errors are addressed
-set -eo pipefail
-#shopt -s inherit_errexit
+set -euo pipefail
+shopt -s inherit_errexit
 
-# shellcheck disable=SC2034
-CACHE_DIR="${2}"
+# Consumed by lib/build_data.sh (sourced below) via "${CACHE_DIR:?}".
+CACHE_DIR="${2:-}"
 
 # The absolute path to the root of the buildpack.
 BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
 
+# shellcheck source=lib/build_data.sh
 source "${BUILDPACK_DIR}/lib/build_data.sh"
 
 build_data::print_bin_report_json

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@
 MIGRATED_FILES = \
 	bin/detect \
 	bin/release \
+	bin/report \
 	bin/test \
 	bin/test-compile \
 	lib/build_data.sh \


### PR DESCRIPTION
`bin/report` enables `set -euo pipefail` + `inherit_errexit` but not `errtrace`, following the same precedent as the other non-`compile` entrypoints (#1773): it installs no `ERR` trap and only sources the already-migrated `lib/build_data.sh`. Adding it to `MIGRATED_FILES` brings it under `shellcheck enable=all` + `shfmt`.

Behavior is unchanged — the cache-dir argument is guarded for `nounset` (`${2:-}`) and a ShellCheck `source=` directive lets `--check-sourced` see `CACHE_DIR` as consumed by the sourced lib, but the emitted build-report JSON and exit codes are identical.

Stacked on #1773.