### PR TITLE
Migrate profile/ runtime scripts into the linting/formatting model

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 # Migrated shell files (kept in sync with the makefile's MIGRATED_FILES list). Tabs are used
 # so here-documents can be indented:
 # https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Documents
-[{bin/compile,bin/detect,bin/release,bin/report,bin/test,bin/test-compile,lib/build_data.sh,lib/cache.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh}]
+[{bin/compile,bin/detect,bin/release,bin/report,bin/test,bin/test-compile,lib/build_data.sh,lib/cache.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh,profile/*.sh}]
 binary_next_line = true
 indent_style = tab
 shell_variant = bash

--- a/makefile
+++ b/makefile
@@ -1,7 +1,9 @@
-# Files migrated to tabs + shellcheck enable=all + namespace::function naming.
-# Add a file here only once it passes `make lint` cleanly. This list is the single
-# source of truth for what gets linted/formatted (CI invokes these targets, it does
-# not maintain its own list).
+# Files migrated to tabs + shellcheck enable=all. Build-time bin/lib scripts also adopt
+# namespace::function naming and the error-handling framework; runtime profile scripts
+# (sourced into the dyno boot shell, not the build) are lint/format-only — no namespace
+# renaming or strict-mode flags. Add a file here only once it passes `make lint` cleanly.
+# This list is the single source of truth for what gets linted/formatted (CI invokes these
+# targets, it does not maintain its own list).
 MIGRATED_FILES = \
 	bin/compile \
 	bin/detect \
@@ -22,7 +24,9 @@ MIGRATED_FILES = \
 	lib/utils/command.sh \
 	lib/utils/json.sh \
 	lib/utils/package_json.sh \
-	lib/utils/yaml.sh
+	lib/utils/yaml.sh \
+	profile/WEB_CONCURRENCY.sh \
+	profile/nodejs.sh
 
 .PHONY: lint lint-scripts check-format format
 

--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -1,66 +1,67 @@
 #!/usr/bin/env bash
 
 calculate_concurrency() {
-  local available=$1
-  local web_memory=$2
+	local available=$1
+	local web_memory=$2
 
-  echo $(( available / web_memory ))
+	echo $((available / web_memory))
 }
 
 validate_concurrency() {
-  local concurrency=$1
-  local ret=0
+	local concurrency=$1
+	local ret=0
 
-  if (( concurrency < 1 )); then
-    concurrency=1
-  elif (( concurrency > 200 )); then
-    # Ex: This will happen on Dokku on DO
-    concurrency=1
-    ret=1
-  fi
+	if ((concurrency < 1)); then
+		concurrency=1
+	elif ((concurrency > 200)); then
+		# Ex: This will happen on Dokku on DO
+		concurrency=1
+		ret=1
+	fi
 
-  echo "$concurrency"
-  return $ret
+	echo "${concurrency}"
+	return "${ret}"
 }
 
 log_concurrency() {
-  echo "Detected $MEMORY_AVAILABLE MB available memory, $WEB_MEMORY MB limit per process (WEB_MEMORY)"
-  echo "Recommending WEB_CONCURRENCY=$WEB_CONCURRENCY"
+	echo "Detected ${MEMORY_AVAILABLE} MB available memory, ${WEB_MEMORY} MB limit per process (WEB_MEMORY)"
+	echo "Recommending WEB_CONCURRENCY=${WEB_CONCURRENCY}"
 }
 
 detect_memory() {
-  local default=$1
+	local default=$1
 
-  if [ -e /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
-    echo $(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1048576))
-  else
-    echo "$default"
-  fi
+	if [[ -e /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+		# shellcheck disable=SC2312 # cat reads the cgroup byte count guarded by the [[ -e ]] above; masking its exit is intentional (matches pre-migration behavior)
+		echo $(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) / 1048576))
+	else
+		echo "${default}"
+	fi
 }
 
 bound_memory() {
-  local detected=$1
-  # Memory is bound to the maximum memory of known dyno types: ~126 GB
-  local max_detected_memory=129024
-  if (( detected > max_detected_memory )); then
-    echo "$max_detected_memory"
-  else
-    echo "$detected"
-  fi
+	local detected=$1
+	# Memory is bound to the maximum memory of known dyno types: ~126 GB
+	local max_detected_memory=129024
+	if ((detected > max_detected_memory)); then
+		echo "${max_detected_memory}"
+	else
+		echo "${detected}"
+	fi
 }
 
 default_web_memory() {
-    local available_memory=$1
-    # Allow more memory per process on memory heavy dyno types.
-    if (( available_memory > 16384 )); then
-        echo 2048
-    else
-        echo 512
-    fi
+	local available_memory=$1
+	# Allow more memory per process on memory heavy dyno types.
+	if ((available_memory > 16384)); then
+		echo 2048
+	else
+		echo 512
+	fi
 }
 
 warn_web_concurrency() {
-  echo "Could not determine a reasonable value for WEB_CONCURRENCY.
+	echo "Could not determine a reasonable value for WEB_CONCURRENCY.
 This is likely due to running the Heroku Node.js buildpack on a non-Heroku
 platform.
 
@@ -70,19 +71,19 @@ appropriate for your application.
 }
 
 DETECTED=$(detect_memory 512)
-export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(bound_memory "$DETECTED")}
-export WEB_MEMORY=${WEB_MEMORY-$(default_web_memory "$MEMORY_AVAILABLE")}
+export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(bound_memory "${DETECTED}")}
+export WEB_MEMORY=${WEB_MEMORY-$(default_web_memory "${MEMORY_AVAILABLE}")}
 
 # Calculate/validate WEB_CONCURRENCY if not already set
-if [ -z "${WEB_CONCURRENCY}" ]; then
-    calculated_concurrency=$(calculate_concurrency "$MEMORY_AVAILABLE" "$WEB_MEMORY")
-    if ! validated_concurrency=$(validate_concurrency "$calculated_concurrency"); then
-        warn_web_concurrency "$validated_concurrency"
-    fi
-    export WEB_CONCURRENCY=$validated_concurrency
-    export WEB_CONCURRENCY_SET_BY="heroku/nodejs"
+if [[ -z "${WEB_CONCURRENCY}" ]]; then
+	calculated_concurrency=$(calculate_concurrency "${MEMORY_AVAILABLE}" "${WEB_MEMORY}")
+	if ! validated_concurrency=$(validate_concurrency "${calculated_concurrency}"); then
+		warn_web_concurrency "${validated_concurrency}"
+	fi
+	export WEB_CONCURRENCY=${validated_concurrency}
+	export WEB_CONCURRENCY_SET_BY="heroku/nodejs"
 fi
 
-if [[ "${LOG_CONCURRENCY+isset}" && "$LOG_CONCURRENCY" == "true" ]]; then
-  log_concurrency
+if [[ -n "${LOG_CONCURRENCY+isset}" && "${LOG_CONCURRENCY}" == "true" ]]; then
+	log_concurrency
 fi

--- a/profile/nodejs.sh
+++ b/profile/nodejs.sh
@@ -1,28 +1,32 @@
-export PATH="$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin:$PATH:$HOME/bin:$HOME/node_modules/.bin"
-export NODE_HOME="$HOME/.heroku/node"
+#!/usr/bin/env bash
+
+export PATH="${HOME}/.heroku/node/bin:${HOME}/.heroku/yarn/bin:${PATH}:${HOME}/bin:${HOME}/node_modules/.bin"
+export NODE_HOME="${HOME}/.heroku/node"
 export NODE_ENV=${NODE_ENV:-production}
 
 # If the user has opted into the feature
-if [[ -n "$HEROKU_METRICS_URL" ]] && \
-   # if we're not on a one-off dyno
-   [[ "${DYNO}" != run\.* ]] && \
-   # the user has not opted out
-   [[ -z "$HEROKU_SKIP_NODE_PLUGIN" ]]; then
+if [[ -n "${HEROKU_METRICS_URL}" ]] \
+	&&
+	# if we're not on a one-off dyno
+	[[ "${DYNO:-}" != run\.* ]] \
+	&&
+	# the user has not opted out
+	[[ -z "${HEROKU_SKIP_NODE_PLUGIN}" ]]; then
 
-  if [[ -d $HOME/.heroku/heroku-nodejs-plugin ]]; then
-    # if the plugin was installed for this node version
-    metrics_handler="$HOME/.heroku/heroku-nodejs-plugin"
-  elif [[ -d $HOME/.heroku/metrics ]]; then
-    # or if the metrics script was installed
-    metrics_handler="$HOME/.heroku/metrics/metrics_collector.cjs"
-  else
-    return
-  fi
+	if [[ -d ${HOME}/.heroku/heroku-nodejs-plugin ]]; then
+		# if the plugin was installed for this node version
+		metrics_handler="${HOME}/.heroku/heroku-nodejs-plugin"
+	elif [[ -d ${HOME}/.heroku/metrics ]]; then
+		# or if the metrics script was installed
+		metrics_handler="${HOME}/.heroku/metrics/metrics_collector.cjs"
+	else
+		return
+	fi
 
-  # Don't clobber NODE_OPTIONS if the user has set it, just add the require flag to the end
-  if [[ -z "$NODE_OPTIONS" ]]; then
-    export NODE_OPTIONS="--require $metrics_handler"
-  else
-    export NODE_OPTIONS="${NODE_OPTIONS} --require $metrics_handler"
-  fi
+	# Don't clobber NODE_OPTIONS if the user has set it, just add the require flag to the end
+	if [[ -z "${NODE_OPTIONS}" ]]; then
+		export NODE_OPTIONS="--require ${metrics_handler}"
+	else
+		export NODE_OPTIONS="${NODE_OPTIONS} --require ${metrics_handler}"
+	fi
 fi

--- a/test/run-general
+++ b/test/run-general
@@ -598,8 +598,8 @@ testModulesCheckedInWithoutDevDependencies() {
 testProfileExport() {
   compile "stable-node"
   assertCaptured "Creating runtime environment"
-  assertFileContains "export PATH=\"\$HOME/.heroku/node/bin:\$HOME/.heroku/yarn/bin:\$PATH:\$HOME/bin:\$HOME/node_modules/.bin\"" "${compile_dir}/.profile.d/nodejs.sh"
-  assertFileContains "export NODE_HOME=\"\$HOME/.heroku/node\"" "${compile_dir}/.profile.d/nodejs.sh"
+  assertFileContains "export PATH=\"\${HOME}/.heroku/node/bin:\${HOME}/.heroku/yarn/bin:\${PATH}:\${HOME}/bin:\${HOME}/node_modules/.bin\"" "${compile_dir}/.profile.d/nodejs.sh"
+  assertFileContains "export NODE_HOME=\"\${HOME}/.heroku/node\"" "${compile_dir}/.profile.d/nodejs.sh"
   assertCapturedSuccessWithWarnings
 }
 


### PR DESCRIPTION
The classic buildpack is incrementally bringing every shell script under a single linting/formatting bar (shfmt tabs + shellcheck `--enable=all`). Build-time `bin/` and `lib/` scripts came first; the `profile/` runtime scripts are next because they ship in every slug and are sourced into the dyno's boot shell on every dyno start, yet were still outside the framework.

Unlike the build-time scripts, `profile/` scripts get no `namespace::function` renaming and no strict-mode flags: they run in the customer's boot shell, where `set -e` would kill the shell on any non-zero command and `set -u` would abort on an unset env var. So this is a lint/format-only pass — braces, quoting, and tabs — with behavior preserved.

Stacked on #1775.
