### PR TITLE
Lint and format every remaining shell script; drop the MIGRATED_FILES allowlist

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,10 +9,16 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# Migrated shell files (kept in sync with the makefile's MIGRATED_FILES list). Tabs are used
-# so here-documents can be indented:
+# Shell scripts. Tabs are used so here-documents can be indented:
 # https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Documents
-[{bin/compile,bin/detect,bin/release,bin/report,bin/test,bin/test-compile,lib/build_data.sh,lib/cache.sh,lib/environment.sh,lib/failures.sh,lib/output.sh,lib/package_manager.sh,lib/package_managers/*.sh,lib/utils/*.sh,profile/*.sh}]
+# Two non-obvious bits in this glob:
+#   - `**.sh`, not `*.sh`: EditorConfig anchors a whole {...} group to this directory as soon as
+#     any alternative contains a slash (bin/*, test/...), which would pin a plain `*.sh` to the
+#     repo root and silently skip lib/**/*.sh. `**.sh` matches *.sh at any depth.
+#   - the bin/ and test/ runners are extensionless (no .sh), so no glob can match them by
+#     extension; they must be listed by path. test/shunit2 is vendored (upstream shUnit2) and is
+#     intentionally the only shell script left out.
+[{**.sh,bin/*,test/quick,test/run-*,test/unit,test/utils}]
 binary_next_line = true
 indent_style = tab
 shell_variant = bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Install shfmt
         run: |
-          SHFMT_VERSION=v3.10.0
+          SHFMT_VERSION=v3.13.0
           curl -fsSL -o /usr/local/bin/shfmt \
             "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64"
           chmod +x /usr/local/bin/shfmt

--- a/ci-profile/nodejs.sh
+++ b/ci-profile/nodejs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export PATH="$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin:$PATH:$HOME/bin:$HOME/node_modules/.bin"
-export NODE_HOME="$HOME/.heroku/node"
+export PATH="${HOME}/.heroku/node/bin:${HOME}/.heroku/yarn/bin:${PATH}:${HOME}/bin:${HOME}/node_modules/.bin"
+export NODE_HOME="${HOME}/.heroku/node"
 export NODE_ENV=${NODE_ENV:-test}

--- a/etc/ci-setup.sh
+++ b/etc/ci-setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-[ "$CI" != "true" ] && echo "Not running on CI!" && exit 1
+[[ "${CI:-}" != "true" ]] && echo "Not running on CI!" && exit 1
 ci_repo_owner=${CIRCLE_PROJECT_USERNAME:-${GITHUB_REPOSITORY_OWNER}}
-[ "$ci_repo_owner" != "heroku" ] && echo "Run tests manually for forked PRs." && exit 0
+[[ "${ci_repo_owner}" != "heroku" ]] && echo "Run tests manually for forked PRs." && exit 0
 
 bundle exec hatchet ci:setup

--- a/etc/hatchet.sh
+++ b/etc/hatchet.sh
@@ -4,16 +4,17 @@ set -e
 
 ci_repo_owner=${CIRCLE_PROJECT_USERNAME:-${GITHUB_REPOSITORY_OWNER}}
 ci_repo_name=${CIRCLE_PROJECT_REPONAME:-${GITHUB_REPOSITORY}}
-ci_branch=${CIRCLE_BRANCH:-${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}}
+ci_branch=${CIRCLE_BRANCH:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}}
 
-[ "$ci_repo_owner" != "heroku" ] && echo "Run tests manually for forked PRs." && exit 0
+[[ "${ci_repo_owner}" != "heroku" ]] && echo "Run tests manually for forked PRs." && exit 0
 
-if [[ "$ci_repo_name" == *nodebin ]]; then
-  HATCHET_BUILDPACK_BRANCH="main"
-elif [ -n "$ci_branch" ]; then
-  HATCHET_BUILDPACK_BRANCH="$ci_branch"
+if [[ "${ci_repo_name}" == *nodebin ]]; then
+	HATCHET_BUILDPACK_BRANCH="main"
+elif [[ -n "${ci_branch}" ]]; then
+	HATCHET_BUILDPACK_BRANCH="${ci_branch}"
 else
-  HATCHET_BUILDPACK_BRANCH=$(git name-rev HEAD 2> /dev/null | sed 's#HEAD\ \(.*\)#\1#' | sed 's#tags\/##')
+	# shellcheck disable=SC2312 # best-effort branch detection; masking the pipe-stage exits is intentional (matches pre-migration behavior)
+	HATCHET_BUILDPACK_BRANCH=$(git name-rev HEAD 2>/dev/null | sed 's#HEAD\ \(.*\)#\1#' | sed 's#tags\/##')
 fi
 
 export HATCHET_BUILDPACK_BRANCH

--- a/etc/publish.sh
+++ b/etc/publish.sh
@@ -3,25 +3,26 @@
 set -e
 
 BP_NAME=${1:-"heroku/nodejs"}
-curVersion=$(heroku buildpacks:versions "$BP_NAME" | awk 'FNR == 3 { print $1 }')
+# shellcheck disable=SC2312 # awk extracts the current version column; masking the pipe exit is intentional (matches pre-migration behavior)
+curVersion=$(heroku buildpacks:versions "${BP_NAME}" | awk 'FNR == 3 { print $1 }')
 newVersion="v$((curVersion + 1))"
 
-read -r -p "Deploy as version: $newVersion [y/n]? " choice
-case "$choice" in
-  y|Y ) echo "";;
-  n|N ) exit 0;;
-  * ) exit 1;;
+read -r -p "Deploy as version: ${newVersion} [y/n]? " choice
+case "${choice}" in
+	y | Y) echo "" ;;
+	n | N) exit 0 ;;
+	*) exit 1 ;;
 esac
 
 originMain=$(git rev-parse origin/main)
-echo "Tagging commit $originMain with $newVersion... "
-git tag "$newVersion" "${originMain:?}"
-git push origin refs/tags/$newVersion
+echo "Tagging commit ${originMain} with ${newVersion}... "
+git tag "${newVersion}" "${originMain:?}"
+git push origin refs/tags/"${newVersion}"
 
-echo "Tagging commit $originMain with latest... "
+echo "Tagging commit ${originMain} with latest... "
 git tag -f latest "${originMain:?}"
 git push -f origin refs/tags/latest
 
-heroku buildpacks:publish "$BP_NAME" "$newVersion"
+heroku buildpacks:publish "${BP_NAME}" "${newVersion}"
 
 echo "Done."

--- a/lib/runtimes/nodejs.sh
+++ b/lib/runtimes/nodejs.sh
@@ -113,17 +113,17 @@ function runtimes::nodejs::_install() {
 			IFS=$'\t' read -r error lts_major <<<"${resolve_error}"
 
 			case "${resolve_status}" in
-			no-version-resolved)
-				runtimes::nodejs::_fail_no_version_resolved "${requested_version}" "${lts_major}"
-				;;
-			invalid-semver-requirement)
-				runtimes::nodejs::_fail_invalid_semver_requirement "${requested_version}" "${lts_major}"
-				;;
-			*)
-				# Catch-all for `internal-error` (inventory read/parse, unsupported OS/arch, missing
-				# recommended LTS) and any future/unknown status. Each _fail_* handler emits and exits.
-				runtimes::nodejs::_fail_resolve "${requested_version}" "${resolve_status}" "${error}"
-				;;
+				no-version-resolved)
+					runtimes::nodejs::_fail_no_version_resolved "${requested_version}" "${lts_major}"
+					;;
+				invalid-semver-requirement)
+					runtimes::nodejs::_fail_invalid_semver_requirement "${requested_version}" "${lts_major}"
+					;;
+				*)
+					# Catch-all for `internal-error` (inventory read/parse, unsupported OS/arch, missing
+					# recommended LTS) and any future/unknown status. Each _fail_* handler emits and exits.
+					runtimes::nodejs::_fail_resolve "${requested_version}" "${resolve_status}" "${error}"
+					;;
 			esac
 		fi
 
@@ -158,17 +158,17 @@ function runtimes::nodejs::_install() {
 
 	if [[ -z "${NODE_BINARY_URL}" ]]; then
 		case "${checksum_type}" in
-		"sha256")
-			echo "Validating checksum"
-			local actual_checksum
-			actual_checksum=$(sha256sum "${output_file}" | cut -d " " -f 1)
-			if [[ "${actual_checksum}" != "${checksum_value}" ]]; then
-				runtimes::nodejs::_fail_checksum_validation "${version}" "${checksum_type}" "${checksum_value}" "${actual_checksum}"
-			fi
-			;;
-		*)
-			runtimes::nodejs::_fail_unsupported_checksum "${version}" "${checksum_type}" "${checksum_value}"
-			;;
+			"sha256")
+				echo "Validating checksum"
+				local actual_checksum
+				actual_checksum=$(sha256sum "${output_file}" | cut -d " " -f 1)
+				if [[ "${actual_checksum}" != "${checksum_value}" ]]; then
+					runtimes::nodejs::_fail_checksum_validation "${version}" "${checksum_type}" "${checksum_value}" "${actual_checksum}"
+				fi
+				;;
+			*)
+				runtimes::nodejs::_fail_unsupported_checksum "${version}" "${checksum_type}" "${checksum_value}"
+				;;
 		esac
 	fi
 

--- a/makefile
+++ b/makefile
@@ -1,57 +1,23 @@
-# Files migrated to tabs + shellcheck enable=all. Build-time bin/lib scripts also adopt
-# namespace::function naming and the error-handling framework; runtime profile scripts
-# (sourced into the dyno boot shell, not the build) are lint/format-only — no namespace
-# renaming or strict-mode flags. Add a file here only once it passes `make lint` cleanly.
-# This list is the single source of truth for what gets linted/formatted (CI invokes these
-# targets, it does not maintain its own list).
-MIGRATED_FILES = \
-	bin/compile \
-	bin/detect \
-	bin/release \
-	bin/report \
-	bin/test \
-	bin/test-compile \
-	lib/build_data.sh \
-	lib/cache.sh \
-	lib/environment.sh \
-	lib/failures.sh \
-	lib/output.sh \
-	lib/package_manager.sh \
-	lib/package_managers/npm.sh \
-	lib/package_managers/pnpm.sh \
-	lib/package_managers/yarn.sh \
-	lib/runtimes/nodejs.sh \
-	lib/utils/command.sh \
-	lib/utils/json.sh \
-	lib/utils/package_json.sh \
-	lib/utils/yaml.sh \
-	profile/WEB_CONCURRENCY.sh \
-	profile/nodejs.sh
+# The migration is complete: every tracked shell script is linted (shellcheck enable=all) and
+# formatted (tabs). There is no longer an allowlist. Build-time bin/lib scripts adopt
+# namespace::function naming and the strict-mode/error-handling framework; runtime profile and
+# support/test scripts are lint/format-only. shfmt -f discovers shell scripts by extension and
+# shebang (so it catches the extensionless bin/ and test/ runners). test/shunit2 is vendored
+# (upstream shUnit2) and is the sole exclusion.
+SHELL_FILES = $(shell shfmt -f bin ci-profile etc lib profile test | grep -v '^test/shunit2$$')
 
 .PHONY: lint lint-scripts check-format format
 
 lint: lint-scripts check-format
 
 lint-scripts:
-	@if [ -n "$(strip $(MIGRATED_FILES))" ]; then \
-		shellcheck --check-sourced $(MIGRATED_FILES); \
-	else \
-		echo "lint-scripts: no migrated files yet"; \
-	fi
+	shellcheck --check-sourced $(SHELL_FILES)
 
 check-format:
-	@if [ -n "$(strip $(MIGRATED_FILES))" ]; then \
-		shfmt --diff $(MIGRATED_FILES); \
-	else \
-		echo "check-format: no migrated files yet"; \
-	fi
+	shfmt --diff $(SHELL_FILES)
 
 format:
-	@if [ -n "$(strip $(MIGRATED_FILES))" ]; then \
-		shfmt --write --list $(MIGRATED_FILES); \
-	else \
-		echo "format: no migrated files yet"; \
-	fi
+	shfmt --write --list $(SHELL_FILES)
 
 build-resolvers: build-resolver-linux
 

--- a/test/quick
+++ b/test/quick
@@ -1,53 +1,54 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1090,SC1091,SC2312 # test harness: dynamically-sourced fixtures resolve at runtime; masked command-substitution exits are inherent to a non-error-propagating test runner
+# shellcheck disable=SC2155,SC2231 # deferred: style nits (split declare/assign, quote-to-avoid-glob) triaged out of the mechanical migration
 
 source "$(pwd)"/lib/environment.sh
 
 mktmpdir() {
-  local dir=$(mktemp -t testXXXXX)
-  rm -rf $dir
-  mkdir $dir
-  echo $dir
+	local dir=$(mktemp -t testXXXXX)
+	rm -rf "${dir}"
+	mkdir "${dir}"
+	echo "${dir}"
 }
 
 compile() {
-  local fixture=$1
-  local bp_dir=$(mktmpdir)
-  local build_dir=$(mktmpdir)
-  local cache_dir=$(mktmpdir)
-  local env_dir=$(mktmpdir)
-  echo "Compiling $fixture"
-  echo "in $build_dir"
-  echo "(caching in $cache_dir)"
-  cp -a "$(pwd)"/* ${bp_dir}
-  cp -a ${bp_dir}/test/fixtures/$fixture/. ${build_dir}
-  "$bp_dir/bin/compile" "$build_dir" "$cache_dir"
+	local fixture=$1
+	local bp_dir=$(mktmpdir)
+	local build_dir=$(mktmpdir)
+	local cache_dir=$(mktmpdir)
+	local env_dir=$(mktmpdir)
+	echo "Compiling ${fixture}"
+	echo "in ${build_dir}"
+	echo "(caching in ${cache_dir})"
+	cp -a "$(pwd)"/* "${bp_dir}"
+	cp -a "${bp_dir}"/test/fixtures/"${fixture}"/. "${build_dir}"
+	"${bp_dir}/bin/compile" "${build_dir}" "${cache_dir}"
 }
 
 compileTest() {
-  local fixture=$1
-  local bp_dir=$(mktmpdir)
-  local build_dir=$(mktmpdir)
-  local cache_dir=$(mktmpdir)
-  local env_dir=$(mktmpdir)
-  echo "Compiling $fixture"
-  echo "in $build_dir"
-  echo "(caching in $cache_dir)"
-  cp -a "$(pwd)"/* ${bp_dir}
-  cp -a ${bp_dir}/test/fixtures/$fixture/. ${build_dir}
-  "$bp_dir/bin/test-compile" "$build_dir" "$cache_dir"
+	local fixture=$1
+	local bp_dir=$(mktmpdir)
+	local build_dir=$(mktmpdir)
+	local cache_dir=$(mktmpdir)
+	local env_dir=$(mktmpdir)
+	echo "Compiling ${fixture}"
+	echo "in ${build_dir}"
+	echo "(caching in ${cache_dir})"
+	cp -a "$(pwd)"/* "${bp_dir}"
+	cp -a "${bp_dir}"/test/fixtures/"${fixture}"/. "${build_dir}"
+	"${bp_dir}/bin/test-compile" "${build_dir}" "${cache_dir}"
 
-  export HOME=${build_dir}
-  environment::export_env_dir $env_dir
-  for f in ${build_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
+	export HOME=${build_dir}
+	environment::export_env_dir "${env_dir}"
+	for f in ${build_dir}/.profile.d/*; do source "${f}" >/dev/null 2>/dev/null; done
 
-  "$bp_dir/bin/test" "$build_dir"
+	"${bp_dir}/bin/test" "${build_dir}"
 }
 
 fixture=${1:-'stable-node'}
 
 if [[ "$2" == "test" ]]; then
-  compileTest "$fixture"
+	compileTest "${fixture}"
 else
-  compile "$fixture"
+	compile "${fixture}"
 fi
-

--- a/test/run-general
+++ b/test/run-general
@@ -1,573 +1,527 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2312 # test harness: dynamically-sourced fixtures resolve at runtime; masked command-substitution exits are inherent to a non-error-propagating test runner
+# shellcheck disable=SC2010,SC2154,SC2155 # deferred: style/test-fixture nits (ls|grep, globals, split declare/assign) triaged out of the mechanical migration
 
 source "$(pwd)"/test/run-helpers
 
 testFlatmapStream() {
-  compile "flatmap-stream"
-  # The migrated npm-install path renders this via failure::emit, which writes to stderr.
-  assertCapturedStderr "flatmap-stream module has been removed from the npm registry"
-  assertCapturedError
+	compile "flatmap-stream"
+	# The migrated npm-install path renders this via failure::emit, which writes to stderr.
+	assertCapturedStderr "flatmap-stream module has been removed from the npm registry"
+	assertCapturedError
 }
-
 
 testBuildScriptBehavior() {
-  # The 'build' script is run by default
-  compile "build-script"
-  assertCaptured "Running build"
-  assertCapturedSuccessWithWarnings
+	# The 'build' script is run by default
+	compile "build-script"
+	assertCaptured "Running build"
+	assertCapturedSuccessWithWarnings
 
-  # the 'heroku-postbuild' script takes precedence over the 'build' script
-  compile "build-script-override"
-  assertCaptured "Detected both \"build\" and \"heroku-postbuild\" scripts"
-  assertCaptured "Running heroku-postbuild"
-  assertCapturedSuccessWithWarnings
+	# the 'heroku-postbuild' script takes precedence over the 'build' script
+	compile "build-script-override"
+	assertCaptured "Detected both \"build\" and \"heroku-postbuild\" scripts"
+	assertCaptured "Running heroku-postbuild"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNgBuildScriptWarning() {
-  compile "ng-build-script"
-  assertCapturedStderr "\"ng build\" detected as build script. We recommend you use \`ng build --prod\` or add \`--prod\` to your build flags."
+	compile "ng-build-script"
+	assertCapturedStderr "\"ng build\" detected as build script. We recommend you use \`ng build --prod\` or add \`--prod\` to your build flags."
 }
-
 
 testBuildFlags() {
-  cache=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	cache=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  echo "--prod --optimize" > $env_dir/NODE_BUILD_FLAGS
-  compile "build-script" $cache $env_dir
-  assertCaptured "Running build"
-  assertCaptured "Running with --prod --optimize flags"
-  assertCaptured 'echo build hook message "--prod --optimize"'
-  assertCapturedSuccessWithWarnings
+	echo "--prod --optimize" >"${env_dir}"/NODE_BUILD_FLAGS
+	compile "build-script" "${cache}" "${env_dir}"
+	assertCaptured "Running build"
+	assertCaptured "Running with --prod --optimize flags"
+	assertCaptured 'echo build hook message "--prod --optimize"'
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPreferEmptyHerokuPostbuildOverBuild() {
-  compile "empty-heroku-postbuild"
-  assertCaptured "Detected both \"build\" and \"heroku-postbuild\" scripts"
-  assertCaptured "Running heroku-postbuild"
-  assertNotCaptured "build hook message"
-  assertCapturedSuccessWithWarnings
+	compile "empty-heroku-postbuild"
+	assertCaptured "Detected both \"build\" and \"heroku-postbuild\" scripts"
+	assertCaptured "Running heroku-postbuild"
+	assertNotCaptured "build hook message"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPrePostBuildScripts() {
-  compile "pre-post-build-scripts"
-  assertCaptured "Running heroku-prebuild"
-  assertCaptured "echo heroku-prebuild hook message"
-  assertCaptured "Running heroku-postbuild"
-  assertCaptured "echo heroku-postbuild hook message"
-  assertCapturedSuccessWithWarnings
+	compile "pre-post-build-scripts"
+	assertCaptured "Running heroku-prebuild"
+	assertCaptured "echo heroku-prebuild hook message"
+	assertCaptured "Running heroku-postbuild"
+	assertCaptured "echo heroku-postbuild hook message"
+	assertCapturedSuccessWithWarnings
 
-  compile "stable-node"
-  assertNotCaptured "Running heroku-prebuild"
-  assertNotCaptured "Running heroku-postbuild"
-  assertCapturedSuccessWithWarnings
+	compile "stable-node"
+	assertNotCaptured "Running heroku-prebuild"
+	assertNotCaptured "Running heroku-postbuild"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testCleanupScript() {
-  compile "cleanup-scripts"
-  assertCaptured "Running heroku-cleanup"
-  assertCaptured "echo heroku-cleanup hook message"
-  assertCapturedSuccessWithWarnings
+	compile "cleanup-scripts"
+	assertCaptured "Running heroku-cleanup"
+	assertCaptured "echo heroku-cleanup hook message"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNoVersion() {
-  compile "no-version"
-  assertCaptured "engines.node (package.json):   unspecified"
-  assertCaptured "No Node.js version specified, resolving current LTS version..."
-  assertCaptured "Downloading and installing node"
-  assertCapturedSuccess
+	compile "no-version"
+	assertCaptured "engines.node (package.json):   unspecified"
+	assertCaptured "No Node.js version specified, resolving current LTS version..."
+	assertCaptured "Downloading and installing node"
+	assertCapturedSuccess
 }
-
 
 testCustomNodeBinaryURL() {
-  cache=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	cache=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  echo "https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-x64.tar.gz" > $env_dir/NODE_BINARY_URL
-  compile "node-14" $cache $env_dir
-  assertCaptured "from https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-x64.tar.gz"
-  assertNotCaptured "Validating checksum"
-  # NODE_BINARY_URL bypasses version resolution entirely, so no EOL check runs.
-  assertCapturedSuccess
+	echo "https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-x64.tar.gz" >"${env_dir}"/NODE_BINARY_URL
+	compile "node-14" "${cache}" "${env_dir}"
+	assertCaptured "from https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-x64.tar.gz"
+	assertNotCaptured "Validating checksum"
+	# NODE_BINARY_URL bypasses version resolution entirely, so no EOL check runs.
+	assertCapturedSuccess
 }
 
-
 testNodeDownloadFailure() {
-  env_dir=$(mktmpdir)
-  echo "https://registry.invalid/node.tar.gz" > "$env_dir/NODE_BINARY_URL"
-  compile "no-version" "$(mktmpdir)" "$env_dir"
-  assertCapturedStderr "Unable to download Node.js"
-  assertCapturedStderr "https://registry.invalid/node.tar.gz"
-  assertCapturedStderr "https://status.nodejs.org/"
-  assertCapturedError
+	env_dir=$(mktmpdir)
+	echo "https://registry.invalid/node.tar.gz" >"${env_dir}/NODE_BINARY_URL"
+	compile "no-version" "$(mktmpdir)" "${env_dir}"
+	assertCapturedStderr "Unable to download Node.js"
+	assertCapturedStderr "https://registry.invalid/node.tar.gz"
+	assertCapturedStderr "https://status.nodejs.org/"
+	assertCapturedError
 }
 
 testDisableCache() {
-  cache=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	cache=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  echo "true" > $env_dir/NODE_VERBOSE
-  compile "node-modules-cache-1" $cache $env_dir
-  assertCaptured "lodash@1.0.0"
-  assertEquals "1" "$(ls -1 $cache/node/cache/node_modules | grep -c lodash | tr -d ' ')"
-  assertCapturedSuccessWithWarnings
+	echo "true" >"${env_dir}"/NODE_VERBOSE
+	compile "node-modules-cache-1" "${cache}" "${env_dir}"
+	assertCaptured "lodash@1.0.0"
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache/node_modules | grep -c lodash | tr -d ' ')"
+	assertCapturedSuccessWithWarnings
 
-  compile "node-modules-cache-2" $cache $env_dir
-  assertCaptured "lodash@1.0.0"
-  assertCapturedSuccessWithWarnings
+	compile "node-modules-cache-2" "${cache}" "${env_dir}"
+	assertCaptured "lodash@1.0.0"
+	assertCapturedSuccessWithWarnings
 
-  echo "false" > $env_dir/NODE_MODULES_CACHE
-  compile "node-modules-cache-2" $cache $env_dir
-  assertCaptured "lodash@1.3.1"
-  assertCapturedSuccessWithWarnings
+	echo "false" >"${env_dir}"/NODE_MODULES_CACHE
+	compile "node-modules-cache-2" "${cache}" "${env_dir}"
+	assertCaptured "lodash@1.3.1"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNodeModulesCached() {
-  cache=$(mktmpdir)
+	cache=$(mktmpdir)
 
-  compile "caching" $cache
-  assertCaptured "- node_modules"
-  assertEquals "1" "$(ls -1 $cache/node/cache/node_modules | grep -c express | tr -d ' ')"
-  assertCapturedSuccessWithWarnings
+	compile "caching" "${cache}"
+	assertCaptured "- node_modules"
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache/node_modules | grep -c express | tr -d ' ')"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testSetBuildEnv() {
-  cache=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	cache=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  compile "print-node-options"
-  assertCaptured "NODE_OPTIONS=--max_old_space_size=2560"
+	compile "print-node-options"
+	assertCaptured "NODE_OPTIONS=--max_old_space_size=2560"
 
-  echo "--max_old_space_size=1234" > $env_dir/NODE_OPTIONS
-  compile "print-node-options" $cache $env_dir
-  assertCaptured "NODE_OPTIONS=--max_old_space_size=1234"
+	echo "--max_old_space_size=1234" >"${env_dir}"/NODE_OPTIONS
+	compile "print-node-options" "${cache}" "${env_dir}"
+	assertCaptured "NODE_OPTIONS=--max_old_space_size=1234"
 }
-
 
 testBuildWithCache() {
-  cache=$(mktmpdir)
+	cache=$(mktmpdir)
 
-  compile "stable-node" $cache
-  assertNotCaptured "Restoring cache"
-  assertEquals "1" "$(ls -1 $cache/node/cache/node_modules | grep -c @heroku | tr -d ' ')"
-  assertCapturedSuccessWithWarnings
+	compile "stable-node" "${cache}"
+	assertNotCaptured "Restoring cache"
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache/node_modules | grep -c @heroku | tr -d ' ')"
+	assertCapturedSuccessWithWarnings
 
-  compile "stable-node" $cache
-  assertCaptured "- node_modules"
-  assertFileContains "${STACK}" "${cache}/node/signature"
-  assertCapturedSuccessWithWarnings
+	compile "stable-node" "${cache}"
+	assertCaptured "- node_modules"
+	assertFileContains "${STACK}" "${cache}/node/signature"
+	assertCapturedSuccessWithWarnings
 
-  rm -rf "$cache/node/cache/node_modules"
-  compile "stable-node" $cache
-  assertCaptured "- node_modules (not cached - skipping)"
-  assertCapturedSuccessWithWarnings
+	rm -rf "${cache}/node/cache/node_modules"
+	compile "stable-node" "${cache}"
+	assertCaptured "- node_modules (not cached - skipping)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testCacheWithPrebuild() {
-  local cache=$(mktmpdir)
-  local env_dir=$(mktmpdir)
-  echo 'true' > "$env_dir"/PREBUILD
+	local cache=$(mktmpdir)
+	local env_dir=$(mktmpdir)
+	echo 'true' >"${env_dir}"/PREBUILD
 
-  compile "cache-prebuild" $cache
-  assertCapturedSuccess
+	compile "cache-prebuild" "${cache}"
+	assertCapturedSuccess
 
-  compile "cache-prebuild" $cache $env_dir
-  assertCaptured "Cached directories were not restored due to a change in version of node"
-  assertCapturedSuccess
+	compile "cache-prebuild" "${cache}" "${env_dir}"
+	assertCaptured "Cached directories were not restored due to a change in version of node"
+	assertCapturedSuccess
 }
-
 
 testErrorYarnAndNpmLockfiles() {
-  compile "yarn-and-npm-lockfiles"
-  assertNotCaptured "Creating runtime environment"
-  assertCapturedStderr "Multiple lockfiles found"
-  assertCapturedStderr "Multiple package managers (npm,Yarn) have created lockfiles for this application"
-  assertCapturedStderr "If you use npm:"
-  assertCapturedStderr "git rm yarn.lock"
-  assertCapturedStderr "If you use Yarn:"
-  assertCapturedStderr "git rm package-lock.json"
-  assertCapturedError
+	compile "yarn-and-npm-lockfiles"
+	assertNotCaptured "Creating runtime environment"
+	assertCapturedStderr "Multiple lockfiles found"
+	assertCapturedStderr "Multiple package managers (npm,Yarn) have created lockfiles for this application"
+	assertCapturedStderr "If you use npm:"
+	assertCapturedStderr "git rm yarn.lock"
+	assertCapturedStderr "If you use Yarn:"
+	assertCapturedStderr "git rm package-lock.json"
+	assertCapturedError
 }
-
 
 testErrorYarnAndNpmShrinkwrap() {
-  compile "yarn-and-shrinkwrap-lockfiles"
-  assertNotCaptured "Creating runtime environment"
-  assertCapturedStderr "Multiple lockfiles conflicting with npm-shrinkwrap.json"
-  assertCapturedError
+	compile "yarn-and-shrinkwrap-lockfiles"
+	assertNotCaptured "Creating runtime environment"
+	assertCapturedStderr "Multiple lockfiles conflicting with npm-shrinkwrap.json"
+	assertCapturedError
 }
-
 
 testErrorYarnAndPnpmAndNpmLockfiles() {
-  compile "yarn-pnpm-and-npm-lockfiles"
-  assertNotCaptured "Creating runtime environment"
-  assertCapturedStderr "Multiple lockfiles found"
-  assertCapturedStderr "Multiple package managers (npm,pnpm,Yarn) have created lockfiles for this application"
-  assertCapturedStderr "If you use pnpm:"
-  assertCapturedStderr "git rm package-lock.json yarn.lock"
-  assertCapturedError
+	compile "yarn-pnpm-and-npm-lockfiles"
+	assertNotCaptured "Creating runtime environment"
+	assertCapturedStderr "Multiple lockfiles found"
+	assertCapturedStderr "Multiple package managers (npm,pnpm,Yarn) have created lockfiles for this application"
+	assertCapturedStderr "If you use pnpm:"
+	assertCapturedStderr "git rm package-lock.json yarn.lock"
+	assertCapturedError
 }
-
 
 testWarnNoStart() {
-  compile "no-start"
-  assertCapturedStderr "may not specify any way to start"
-  assertCapturedSuccessWithWarnings
-  compile "no-version"
-  assertNotCaptured "may not specify any way to start"
-  assertCapturedSuccess
+	compile "no-start"
+	assertCapturedStderr "may not specify any way to start"
+	assertCapturedSuccessWithWarnings
+	compile "no-version"
+	assertNotCaptured "may not specify any way to start"
+	assertCapturedSuccess
 }
-
 
 testEnvBlacklist() {
-  local cache=$(mktmpdir)
-  local env_dir=$(mktmpdir)
-  echo 'tr_TR.UTF-8' > "$env_dir"/LANG
-  echo 'safeVar' > "$env_dir"/SAFE
-  compile "echo-lang" $cache $env_dir
-  assertCaptured "safeVar"
-  assertNotCaptured "tr_TR.UTF-8"
-  assertCapturedSuccessWithWarnings
+	local cache=$(mktmpdir)
+	local env_dir=$(mktmpdir)
+	echo 'tr_TR.UTF-8' >"${env_dir}"/LANG
+	echo 'safeVar' >"${env_dir}"/SAFE
+	compile "echo-lang" "${cache}" "${env_dir}"
+	assertCaptured "safeVar"
+	assertNotCaptured "tr_TR.UTF-8"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testWarningsOnFailure() {
-  compile "many-warnings"
-  # The npm 404 install failure is now classified by failure::emit, which renders a specific
-  # message to stderr; no generic troubleshooting footer is printed. The old-npm warning is
-  # emitted at detection via output::warning (also stderr).
-  assertCapturedStderr "A package could not be found in the npm registry"
-  assertCapturedStderr "has several known issues"
-  assertNotCaptured "troubleshooting-node-deploys"
-  assertNotCaptured "please submit a ticket"
-  assertCapturedError
+	compile "many-warnings"
+	# The npm 404 install failure is now classified by failure::emit, which renders a specific
+	# message to stderr; no generic troubleshooting footer is printed. The old-npm warning is
+	# emitted at detection via output::warning (also stderr).
+	assertCapturedStderr "A package could not be found in the npm registry"
+	assertCapturedStderr "has several known issues"
+	assertNotCaptured "troubleshooting-node-deploys"
+	assertNotCaptured "please submit a ticket"
+	assertCapturedError
 }
-
 
 testDotHerokuCollision() {
-  compile "dot-heroku-collision"
-  assertCapturedStderr "The directory .heroku could not be created"
-  assertCapturedStderr ".heroku file is checked into this project"
-  assertNotCaptured "please submit a ticket"
-  assertCapturedError
+	compile "dot-heroku-collision"
+	assertCapturedStderr "The directory .heroku could not be created"
+	assertCapturedStderr ".heroku file is checked into this project"
+	assertNotCaptured "please submit a ticket"
+	assertCapturedError
 
-  compile "dot-heroku-collision-2"
-  assertNotCapturedStderr ".heroku file is checked into this project"
-  assertCapturedSuccessWithWarnings
+	compile "dot-heroku-collision-2"
+	assertNotCapturedStderr ".heroku file is checked into this project"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testDotHerokuNodeCollision() {
-  compile "dot-heroku-node-collision"
-  assertCapturedStderr "The directory .heroku/node could not be created"
-  assertCapturedStderr ".heroku file is checked into this project"
-  assertNotCaptured "please submit a ticket"
-  assertCapturedError
+	compile "dot-heroku-node-collision"
+	assertCapturedStderr "The directory .heroku/node could not be created"
+	assertCapturedStderr ".heroku file is checked into this project"
+	assertNotCaptured "please submit a ticket"
+	assertCapturedError
 }
-
 
 testMultipleRuns() {
-  local compileDir=$(mktmpdir)
-  local cacheDir=$(mktmpdir)
+	local compileDir=$(mktmpdir)
+	local cacheDir=$(mktmpdir)
 
-  cp -a test/fixtures/stable-node/. ${compileDir}
-  compileDir "$compileDir" "$cacheDir"
-  assertCapturedSuccessWithWarnings
-  compileDir "$compileDir" "$cacheDir"
-  assertCapturedSuccessWithWarnings
+	cp -a test/fixtures/stable-node/. "${compileDir}"
+	compileDir "${compileDir}" "${cacheDir}"
+	assertCapturedSuccessWithWarnings
+	compileDir "${compileDir}" "${cacheDir}"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testBadJson() {
-  compile "bad-json"
-  assertNotCaptured "Installing binaries"
-  # The migrated invalid-package-json path renders the failure via failure::emit, which writes
-  # the "Build failed" header and the message to stderr; no generic failure footer is printed.
-  assertCapturedStderr "Build failed"
-  assertCapturedError 1 "Unable to parse"
+	compile "bad-json"
+	assertNotCaptured "Installing binaries"
+	# The migrated invalid-package-json path renders the failure via failure::emit, which writes
+	# the "Build failed" header and the message to stderr; no generic failure footer is printed.
+	assertCapturedStderr "Build failed"
+	assertCapturedError 1 "Unable to parse"
 }
-
 
 testBuildWithUserCacheDirectoriesCamel() {
-  cache=$(mktmpdir)
+	cache=$(mktmpdir)
 
-  compile "cache-directories-camel" $cache
-  assertCaptured "- non/existent (nothing to cache)"
-  assertEquals "1" "$(ls -1 $cache/node/cache/server | grep -c node_modules | tr -d ' ')"
-  assertEquals "1" "$(ls -1 $cache/node/cache/client | grep -c node_modules | tr -d ' ')"
-  assertCapturedSuccessWithWarnings
+	compile "cache-directories-camel" "${cache}"
+	assertCaptured "- non/existent (nothing to cache)"
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache/server | grep -c node_modules | tr -d ' ')"
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache/client | grep -c node_modules | tr -d ' ')"
+	assertCapturedSuccessWithWarnings
 
-  compile "cache-directories-camel" $cache
-  assertCaptured "Loading from cacheDirectories"
-  assertCaptured "- server/node_modules"
-  assertCaptured "- client/node_modules"
-  assertCaptured "- non/existent (not cached - skipping)"
-  assertCapturedSuccessWithWarnings
+	compile "cache-directories-camel" "${cache}"
+	assertCaptured "Loading from cacheDirectories"
+	assertCaptured "- server/node_modules"
+	assertCaptured "- client/node_modules"
+	assertCaptured "- non/existent (not cached - skipping)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testConcurrency1X() {
-  LOG_CONCURRENCY=true MEMORY_AVAILABLE=512 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
-  assertCaptured "Detected 512 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=1"
-  assertCapturedSuccess
+	LOG_CONCURRENCY=true MEMORY_AVAILABLE=512 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	assertCaptured "Detected 512 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+	assertCaptured "Recommending WEB_CONCURRENCY=1"
+	assertCapturedSuccess
 }
-
 
 testConcurrency2X() {
-  LOG_CONCURRENCY=true MEMORY_AVAILABLE=1024 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
-  assertCaptured "Detected 1024 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=2"
-  assertCapturedSuccess
+	LOG_CONCURRENCY=true MEMORY_AVAILABLE=1024 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	assertCaptured "Detected 1024 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+	assertCaptured "Recommending WEB_CONCURRENCY=2"
+	assertCapturedSuccess
 }
-
 
 testConcurrencyPerformanceM() {
-  LOG_CONCURRENCY=true MEMORY_AVAILABLE=2560 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
-  assertCaptured "Detected 2560 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=5"
-  assertCapturedSuccess
+	LOG_CONCURRENCY=true MEMORY_AVAILABLE=2560 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	assertCaptured "Detected 2560 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+	assertCaptured "Recommending WEB_CONCURRENCY=5"
+	assertCapturedSuccess
 }
-
 
 testConcurrencyPerformanceL() {
-   LOG_CONCURRENCY=true MEMORY_AVAILABLE=14336 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
-   assertCaptured "Detected 14336 MB available memory, 512 MB limit per process (WEB_MEMORY)"
-   assertCaptured "Recommending WEB_CONCURRENCY=28"
-   assertCapturedSuccess
+	LOG_CONCURRENCY=true MEMORY_AVAILABLE=14336 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	assertCaptured "Detected 14336 MB available memory, 512 MB limit per process (WEB_MEMORY)"
+	assertCaptured "Recommending WEB_CONCURRENCY=28"
+	assertCapturedSuccess
 }
 
-
 testConcurrencyCustomLimit() {
-  LOG_CONCURRENCY=true MEMORY_AVAILABLE=1024 WEB_MEMORY=256 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
-  assertCaptured "Detected 1024 MB available memory, 256 MB limit per process (WEB_MEMORY)"
-  assertCaptured "Recommending WEB_CONCURRENCY=4"
-  assertCapturedSuccess
+	LOG_CONCURRENCY=true MEMORY_AVAILABLE=1024 WEB_MEMORY=256 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	assertCaptured "Detected 1024 MB available memory, 256 MB limit per process (WEB_MEMORY)"
+	assertCaptured "Recommending WEB_CONCURRENCY=4"
+	assertCapturedSuccess
 }
 
 # When /sys/fs/cgroup/memory/memory.limit_in_bytes lies and gives a ridiculous value
 # This happens on Dokku for example
 
 testConcurrencyTooHigh() {
-  LOG_CONCURRENCY=true MEMORY_AVAILABLE=10000000000 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
-  assertCaptured "Could not determine a reasonable value for WEB_CONCURRENCY"
-  assertCaptured "Recommending WEB_CONCURRENCY=1"
-  assertCapturedSuccess
+	LOG_CONCURRENCY=true MEMORY_AVAILABLE=10000000000 capture "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	assertCaptured "Could not determine a reasonable value for WEB_CONCURRENCY"
+	assertCaptured "Recommending WEB_CONCURRENCY=1"
+	assertCapturedSuccess
 }
-
 
 testInvalidNode() {
-  cache_dir=$(mktmpdir)
-  compile "invalid-node" "${cache_dir}"
-  assertCaptured "Resolving node version 0.11.333"
-  assertCapturedStderr "Error: No published Node.js version matches the requested range."
-  assertCapturedStderr "package.json (0.11.333)"
-  assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "invalid-node-version"
+	cache_dir=$(mktmpdir)
+	compile "invalid-node" "${cache_dir}"
+	assertCaptured "Resolving node version 0.11.333"
+	assertCapturedStderr "Error: No published Node.js version matches the requested range."
+	assertCapturedStderr "package.json (0.11.333)"
+	assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "invalid-node-version"
 }
-
 
 testInvalidNodeSemver() {
-  cache_dir=$(mktmpdir)
-  compile "invalid-node-semver" "${cache_dir}"
-  assertCaptured "Resolving node version stable"
-  assertCapturedStderr "Error: Invalid Node.js version requirement."
-  assertCapturedStderr "package.json (stable)"
-  assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "invalid-semver-requirement"
+	cache_dir=$(mktmpdir)
+	compile "invalid-node-semver" "${cache_dir}"
+	assertCaptured "Resolving node version stable"
+	assertCapturedStderr "Error: Invalid Node.js version requirement."
+	assertCapturedStderr "package.json (stable)"
+	assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "invalid-semver-requirement"
 }
-
 
 testSignatureInvalidation() {
-  cache=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	cache=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  compile "node-0.12.6" $cache
-  assertCaptured "Downloading and installing node 0.12.6"
-  assertCapturedSuccessWithWarnings
+	compile "node-0.12.6" "${cache}"
+	assertCaptured "Downloading and installing node 0.12.6"
+	assertCapturedSuccessWithWarnings
 
-  compile "node-0.12.7" $cache
-  assertCaptured "Downloading and installing node 0.12.7"
-  assertCaptured "Cached directories were not restored due to a change in version of node"
-  assertCapturedSuccessWithWarnings
+	compile "node-0.12.7" "${cache}"
+	assertCaptured "Downloading and installing node 0.12.7"
+	assertCaptured "Cached directories were not restored due to a change in version of node"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testModulesCheckedIn() {
-  cache=$(mktmpdir)
-  compile "modules-checked-in" $cache
-  assertCapturedSuccessWithWarnings
+	cache=$(mktmpdir)
+	compile "modules-checked-in" "${cache}"
+	assertCapturedSuccessWithWarnings
 
-  compile "modules-checked-in" $cache
-  assertCaptured "Prebuild detected"
-  assertCaptured "Rebuilding any native modules"
-  assertCaptured "(preinstall script)"
-  assertCaptured "Installing any new modules"
-  assertCaptured "(postinstall script)"
-  assertCapturedSuccessWithWarnings
+	compile "modules-checked-in" "${cache}"
+	assertCaptured "Prebuild detected"
+	assertCaptured "Rebuilding any native modules"
+	assertCaptured "(preinstall script)"
+	assertCaptured "Installing any new modules"
+	assertCaptured "(postinstall script)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testSkipModulesCheckedIn() {
-  env_dir=$(mktmpdir)
-  echo "true" > $env_dir/SKIP_NODE_MODULES_CHECK
+	env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}"/SKIP_NODE_MODULES_CHECK
 
-  compile "skip-modules-checked-in" "$(mktmpdir)" $env_dir
+	compile "skip-modules-checked-in" "$(mktmpdir)" "${env_dir}"
 
-  assertCaptured "Keeping existing node_modules because SKIP_NODE_MODULES_CHECK=true"
-  assertNotCaptured "node_modules checked into source"
-  assertCapturedSuccessWithWarnings
+	assertCaptured "Keeping existing node_modules because SKIP_NODE_MODULES_CHECK=true"
+	assertNotCaptured "node_modules checked into source"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testDetectWithPackageJson() {
-  detect "stable-node"
-  assertCaptured "Node.js"
-  assertCapturedSuccess
+	detect "stable-node"
+	assertCaptured "Node.js"
+	assertCapturedSuccess
 }
-
 
 testDetectWithoutPackageJson() {
-  detect "no-package-json"
-  assertCapturedError 1 ""
+	detect "no-package-json"
+	assertCapturedError 1 ""
 }
 
-
 testIoJs() {
-  compile "iojs"
-  assertCapturedError 1 "io.js is no longer supported"
+	compile "iojs"
+	assertCapturedError 1 "io.js is no longer supported"
 }
 
 ###
 # Yarn 2
 
 testSpecificVersion() {
-  compile "specific-version"
-  assertCaptured "Resolving node version"
-  assertCaptured "Downloading and installing node 14.15.3"
-  assertCaptured "Using default npm version: 6.14.9"
-  assertCapturedSuccessWithWarnings
+	compile "specific-version"
+	assertCaptured "Resolving node version"
+	assertCaptured "Downloading and installing node 14.15.3"
+	assertCaptured "Using default npm version: 6.14.9"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testStableVersion() {
-  compile "stable-node"
-  assertCaptured "Downloading and installing node 0.10."
-  assertNotCaptured "We're sorry this build is failing"
-  assertCapturedSuccessWithWarnings
+	compile "stable-node"
+	assertCaptured "Downloading and installing node 0.10."
+	assertNotCaptured "We're sorry this build is failing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testUnstableVersion() {
-  compile "unstable-version"
-  assertCaptured "Resolving node version 0.11.x"
-  assertCaptured "Downloading and installing node 0.11."
-  assertCapturedSuccessWithWarnings
+	compile "unstable-version"
+	assertCaptured "Resolving node version 0.11.x"
+	assertCaptured "Downloading and installing node 0.11."
+	assertCapturedSuccessWithWarnings
 }
-
 
 testFailingBuild() {
-  compile "failing-build"
-  # The failing heroku-postbuild script matches no specific classifier, so run_script_command's
-  # build-script catch-all classifies it as unknown-build-script-error (classification=user).
-  # failure::emit writes both the "Build failed" header and the message to stderr via output::error.
-  assertNotCaptured "Checking startup method"
-  assertCapturedStderr "Build failed"
-  assertCapturedError 1 "A build script exited with a non-zero exit code"
+	compile "failing-build"
+	# The failing heroku-postbuild script matches no specific classifier, so run_script_command's
+	# build-script catch-all classifies it as unknown-build-script-error (classification=user).
+	# failure::emit writes both the "Build failed" header and the message to stderr via output::error.
+	assertNotCaptured "Checking startup method"
+	assertCapturedStderr "Build failed"
+	assertCapturedError 1 "A build script exited with a non-zero exit code"
 }
-
 
 testInfoEmpty() {
-  compile "info-empty"
-  assertCaptured "engines.node (package.json):   unspecified"
-  assertCaptured "engines.npm (package.json):    unspecified"
-  assertCaptured "Installing node modules (package.json)"
-  assertCapturedSuccessWithWarnings
+	compile "info-empty"
+	assertCaptured "engines.node (package.json):   unspecified"
+	assertCaptured "engines.npm (package.json):    unspecified"
+	assertCaptured "Installing node modules (package.json)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testRangeWithSpace() {
-  compile "range-with-space"
-  assertCaptured "Resolving node version = 0.8.x"
-  assertCaptured "Downloading and installing node"
-  assertCapturedSuccessWithWarnings
+	compile "range-with-space"
+	assertCaptured "Resolving node version = 0.8.x"
+	assertCaptured "Downloading and installing node"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testInvalidDependency() {
-  compile "invalid-dependency"
-  # The 404 is now classified by failure::emit: the specific message goes to stderr and the
-  # legacy troubleshooting footer is skipped. The raw npm output still appears on stdout.
-  assertCaptured "npm ERR! 404"
-  assertCapturedStderr "A package could not be found in the npm registry"
-  assertNotCaptured "troubleshooting-node-deploys"
-  assertNotCaptured "please submit a ticket"
-  assertNotCaptured "possible problems"
-  assertCapturedError 1 ""
+	compile "invalid-dependency"
+	# The 404 is now classified by failure::emit: the specific message goes to stderr and the
+	# legacy troubleshooting footer is skipped. The raw npm output still appears on stdout.
+	assertCaptured "npm ERR! 404"
+	assertCapturedStderr "A package could not be found in the npm registry"
+	assertNotCaptured "troubleshooting-node-deploys"
+	assertNotCaptured "please submit a ticket"
+	assertNotCaptured "possible problems"
+	assertCapturedError 1 ""
 }
-
 
 testBuildWithUserCacheDirectories() {
-  cache=$(mktmpdir)
+	cache=$(mktmpdir)
 
-  compile "cache-directories" $cache
-  assertCaptured "Saving cacheDirectories"
-  assertEquals "1" "$(ls -1 $cache/node/cache | grep -c bower_components | tr -d ' ')"
-  assertEquals "1" "$(ls -1 $cache/node/cache | grep -c node_modules | tr -d ' ')"
-  assertCapturedSuccessWithWarnings
+	compile "cache-directories" "${cache}"
+	assertCaptured "Saving cacheDirectories"
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache | grep -c bower_components | tr -d ' ')"
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache | grep -c node_modules | tr -d ' ')"
+	assertCapturedSuccessWithWarnings
 
-  compile "cache-directories" $cache
-  assertCaptured "Loading from cacheDirectories"
-  assertCaptured "- node_modules"
-  assertCaptured "- bower_components"
-  assertCapturedSuccessWithWarnings
+	compile "cache-directories" "${cache}"
+	assertCaptured "Loading from cacheDirectories"
+	assertCaptured "- node_modules"
+	assertCaptured "- bower_components"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testDefaultProcType() {
-  release "stable-node"
-  assertCaptured "web: npm start"
-  assertCapturedSuccess
+	release "stable-node"
+	assertCaptured "web: npm start"
+	assertCapturedSuccess
 }
-
 
 testDynamicProcfile() {
-  compile "dynamic-procfile"
-  assertFileContains "web: node index.js customArg" "${compile_dir}/Procfile"
-  assertCapturedSuccessWithWarnings
+	compile "dynamic-procfile"
+	assertFileContains "web: node index.js customArg" "${compile_dir}/Procfile"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testEnvVars() {
-  env_dir=$(mktmpdir)
-  echo "false" > $env_dir/NPM_CONFIG_PRODUCTION
-  echo "true" > $env_dir/USE_NPM_INSTALL
-  compile "stable-node" "$(mktmpdir)" $env_dir
-  assertCaptured "NPM_CONFIG_PRODUCTION=false"
-  assertCaptured "USE_NPM_INSTALL=true"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "false" >"${env_dir}"/NPM_CONFIG_PRODUCTION
+	echo "true" >"${env_dir}"/USE_NPM_INSTALL
+	compile "stable-node" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "NPM_CONFIG_PRODUCTION=false"
+	assertCaptured "USE_NPM_INSTALL=true"
+	assertCapturedSuccessWithWarnings
 }
 
-
 testNonFileEnvVars() {
-  export NPM_CONFIG_FOO=bar
-  export NPM_CONFIG_PRODUCTION=false
-  compile "stable-node"
-  assertCaptured "NPM_CONFIG_FOO=bar"
-  assertCaptured "NPM_CONFIG_PRODUCTION=false"
-  assertCapturedSuccessWithWarnings
-  unset NPM_CONFIG_FOO
-  unset NPM_CONFIG_PRODUCTION
+	export NPM_CONFIG_FOO=bar
+	export NPM_CONFIG_PRODUCTION=false
+	compile "stable-node"
+	assertCaptured "NPM_CONFIG_FOO=bar"
+	assertCaptured "NPM_CONFIG_PRODUCTION=false"
+	assertCapturedSuccessWithWarnings
+	unset NPM_CONFIG_FOO
+	unset NPM_CONFIG_PRODUCTION
 }
 
 # In the following tests "lodash" is defined as a devDependency
@@ -577,460 +531,430 @@ testNonFileEnvVars() {
 # Default behavior: install devDependencies then prunes them away
 
 testModulesCheckedInWithDevDependencies() {
-  compile "dependencies-modules-checked-in-with-devdependencies"
-  assertCaptured "Rebuilding any native modules"
-  assertCaptured "lodash"
-  assertCaptured "removed 1 package"
-  assertCapturedSuccessWithWarnings
+	compile "dependencies-modules-checked-in-with-devdependencies"
+	assertCaptured "Rebuilding any native modules"
+	assertCaptured "lodash"
+	assertCaptured "removed 1 package"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testModulesCheckedInWithoutDevDependencies() {
-  compile "dependencies-modules-checked-in-without-devdependencies"
-  assertCaptured "Rebuilding any native modules"
-  assertCaptured "added 1 package"
-  assertCaptured "lodash"
-  assertCaptured "removed 1 package"
-  assertCapturedSuccessWithWarnings
+	compile "dependencies-modules-checked-in-without-devdependencies"
+	assertCaptured "Rebuilding any native modules"
+	assertCaptured "added 1 package"
+	assertCaptured "lodash"
+	assertCaptured "removed 1 package"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testProfileExport() {
-  compile "stable-node"
-  assertCaptured "Creating runtime environment"
-  assertFileContains "export PATH=\"\${HOME}/.heroku/node/bin:\${HOME}/.heroku/yarn/bin:\${PATH}:\${HOME}/bin:\${HOME}/node_modules/.bin\"" "${compile_dir}/.profile.d/nodejs.sh"
-  assertFileContains "export NODE_HOME=\"\${HOME}/.heroku/node\"" "${compile_dir}/.profile.d/nodejs.sh"
-  assertCapturedSuccessWithWarnings
+	compile "stable-node"
+	assertCaptured "Creating runtime environment"
+	assertFileContains "export PATH=\"\${HOME}/.heroku/node/bin:\${HOME}/.heroku/yarn/bin:\${PATH}:\${HOME}/bin:\${HOME}/node_modules/.bin\"" "${compile_dir}/.profile.d/nodejs.sh"
+	assertFileContains "export NODE_HOME=\"\${HOME}/.heroku/node\"" "${compile_dir}/.profile.d/nodejs.sh"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testMultiExport() {
-  compile "stable-node"
-  assertFileContains "export PATH=" "${bp_dir}/export"
-  assertFileContains "/.heroku/node/bin" "${bp_dir}/export"
-  assertFileContains "/.heroku/yarn/bin" "${bp_dir}/export"
-  assertFileContains "/node_modules/.bin" "${bp_dir}/export"
-  assertFileContains "export NODE_HOME=" "${bp_dir}/export"
-  assertFileContains "/.heroku/node\"" "${bp_dir}/export"
-  # shellcheck disable=SC2016
-  assertFileContains 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' "${bp_dir}/export"
-  assertCapturedSuccessWithWarnings
+	compile "stable-node"
+	assertFileContains "export PATH=" "${bp_dir}/export"
+	assertFileContains "/.heroku/node/bin" "${bp_dir}/export"
+	assertFileContains "/.heroku/yarn/bin" "${bp_dir}/export"
+	assertFileContains "/node_modules/.bin" "${bp_dir}/export"
+	assertFileContains "export NODE_HOME=" "${bp_dir}/export"
+	assertFileContains "/.heroku/node\"" "${bp_dir}/export"
+	# shellcheck disable=SC2016
+	assertFileContains 'export NODE_OPTIONS=${NODE_OPTIONS:-"--max_old_space_size=2560"}' "${bp_dir}/export"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testCIEnvVars() {
-  compileTest "ci-env-test"
-  assertCaptured "NODE_ENV: test"
-  assertCapturedSuccess
+	compileTest "ci-env-test"
+	assertCaptured "NODE_ENV: test"
+	assertCapturedSuccess
 }
-
 
 testCIEnvVarsOverride() {
-  env_dir=$(mktmpdir)
-  echo "banana" > $env_dir/NODE_ENV
+	env_dir=$(mktmpdir)
+	echo "banana" >"${env_dir}"/NODE_ENV
 
-  compileTest "ci-env-test" "$(mktmpdir)" $env_dir
+	compileTest "ci-env-test" "$(mktmpdir)" "${env_dir}"
 
-  assertCaptured "NODE_ENV: banana"
-  assertCapturedSuccess
+	assertCaptured "NODE_ENV: banana"
+	assertCapturedSuccess
 }
-
 
 testNodeEnv() {
-  compile "node-env-consistency"
-  assertCaptured "heroku-prebuild: production"
-  assertCaptured "preinstall: production"
-  assertCaptured "postinstall: production"
-  assertCaptured "heroku-postbuild: production"
-  assertCapturedSuccessWithWarnings
+	compile "node-env-consistency"
+	assertCaptured "heroku-prebuild: production"
+	assertCaptured "preinstall: production"
+	assertCaptured "postinstall: production"
+	assertCaptured "heroku-postbuild: production"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testAvoidHttpProxyVersionResolutionIssue() {
-  env_dir=$(mktmpdir)
-  # Set a non-sense http proxy address. This will cause version resolution to fail
-  echo "http://localhost:5001" > $env_dir/HTTP_PROXY
-  # Set the NO_PROXY value, as described in documentation. This will exclude the domain
-  #  from the proxy
-  echo "amazonaws.com" > $env_dir/NO_PROXY
-  compile "node-14" "$(mktmpdir)" $env_dir
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	# Set a non-sense http proxy address. This will cause version resolution to fail
+	echo "http://localhost:5001" >"${env_dir}"/HTTP_PROXY
+	# Set the NO_PROXY value, as described in documentation. This will exclude the domain
+	#  from the proxy
+	echo "amazonaws.com" >"${env_dir}"/NO_PROXY
+	compile "node-14" "$(mktmpdir)" "${env_dir}"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPluginInstallationBuildTime() {
-  # The plugin should be installed for Node 8, 9, 10
-  compile "node-8"
-  assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	# The plugin should be installed for Node 8, 9, 10
+	compile "node-8"
+	assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 
-  compile "node-9"
-  assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	compile "node-9"
+	assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 
-  compile "node-10"
-  assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	compile "node-10"
+	assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 
-  compile "node-11"
-  assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	compile "node-11"
+	assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 
-  compile "node-12"
-  assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	compile "node-12"
+	assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 
-  compile "node-13"
-  assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	compile "node-13"
+	assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 
-  compile "node-14.9"
-  assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	compile "node-14.9"
+	assertFileExists "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 
-  compile "node-14"
-  assertFileExists "${compile_dir}/.heroku/metrics/metrics_collector.cjs"
+	compile "node-14"
+	assertFileExists "${compile_dir}/.heroku/metrics/metrics_collector.cjs"
 
-  compile "node-21"
-  assertFileExists "${compile_dir}/.heroku/metrics/metrics_collector.cjs"
+	compile "node-21"
+	assertFileExists "${compile_dir}/.heroku/metrics/metrics_collector.cjs"
 
-  # but not for earlier versions
-  compile "node-6"
-  assertFileDoesNotExist "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
+	# but not for earlier versions
+	compile "node-6"
+	assertFileDoesNotExist "${compile_dir}/.heroku/heroku-nodejs-plugin/heroku-nodejs-plugin.node"
 }
-
 
 testPluginInstallationRunTimeNodeAddon() {
-  local env_dir=$(mktmpdir)
-  compile "node-14.9" "$(mktmpdir)" $env_dir
+	local env_dir=$(mktmpdir)
+	compile "node-14.9" "$(mktmpdir)" "${env_dir}"
 
-  # by default $NODE_OPTIONS is unmodified
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# by default $NODE_OPTIONS is unmodified
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # If $HEROKU_METRICS_URL is defined at run time, the script
-  # should add a require statement to $NODE_OPTIONS
-  export HEROKU_METRICS_URL=https://localhost:5000
-  executeStartup $env_dir
-  assertEquals "--require $compile_dir/.heroku/heroku-nodejs-plugin" "$NODE_OPTIONS"
-  cleanupStartup
+	# If $HEROKU_METRICS_URL is defined at run time, the script
+	# should add a require statement to $NODE_OPTIONS
+	export HEROKU_METRICS_URL=https://localhost:5000
+	executeStartup "${env_dir}"
+	assertEquals "--require ${compile_dir}/.heroku/heroku-nodejs-plugin" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # unless $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# unless $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # if $NODE_OPTIONS already exists, it will append the require command
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128 --require $compile_dir/.heroku/heroku-nodejs-plugin" "$NODE_OPTIONS"
-  cleanupStartup
+	# if $NODE_OPTIONS already exists, it will append the require command
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128 --require ${compile_dir}/.heroku/heroku-nodejs-plugin" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128" "$NODE_OPTIONS"
-  cleanupStartup
+	# and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128" "${NODE_OPTIONS}"
+	cleanupStartup
 }
-
 
 testPluginInstallationRunTimeNodeScript() {
-  local env_dir=$(mktmpdir)
-  compile "node-14" "$(mktmpdir)" $env_dir
-  assertNotCaptured "The native addon for Node.js language metrics is no longer supported. Unset the HEROKU_LEGACY_NODE_PLUGIN environment variable to migrate to the new metrics collector."
+	local env_dir=$(mktmpdir)
+	compile "node-14" "$(mktmpdir)" "${env_dir}"
+	assertNotCaptured "The native addon for Node.js language metrics is no longer supported. Unset the HEROKU_LEGACY_NODE_PLUGIN environment variable to migrate to the new metrics collector."
 
-  # by default $NODE_OPTIONS is unmodified
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# by default $NODE_OPTIONS is unmodified
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # If $HEROKU_METRICS_URL is defined at run time, the script
-  # should add a require statement to $NODE_OPTIONS
-  export HEROKU_METRICS_URL=https://localhost:5000
-  executeStartup $env_dir
-  assertEquals "--require $compile_dir/.heroku/metrics/metrics_collector.cjs" "$NODE_OPTIONS"
-  cleanupStartup
+	# If $HEROKU_METRICS_URL is defined at run time, the script
+	# should add a require statement to $NODE_OPTIONS
+	export HEROKU_METRICS_URL=https://localhost:5000
+	executeStartup "${env_dir}"
+	assertEquals "--require ${compile_dir}/.heroku/metrics/metrics_collector.cjs" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # unless $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# unless $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # if $NODE_OPTIONS already exists, it will append the require command
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128 --require $compile_dir/.heroku/metrics/metrics_collector.cjs" "$NODE_OPTIONS"
-  cleanupStartup
+	# if $NODE_OPTIONS already exists, it will append the require command
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128 --require ${compile_dir}/.heroku/metrics/metrics_collector.cjs" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128" "$NODE_OPTIONS"
-  cleanupStartup
+	# and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128" "${NODE_OPTIONS}"
+	cleanupStartup
 }
-
 
 testPluginInstallationRunTimeNodeScriptWhenLegacyPluginIsRequested() {
-  local env_dir=$(mktmpdir)
-  echo "true" > $env_dir/HEROKU_LEGACY_NODE_PLUGIN
-  compile "node-14" "$(mktmpdir)" $env_dir
-  assertCapturedStderr "The native addon for Node.js language metrics is no longer supported. Unset the HEROKU_LEGACY_NODE_PLUGIN environment variable to migrate to the new metrics collector."
+	local env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}"/HEROKU_LEGACY_NODE_PLUGIN
+	compile "node-14" "$(mktmpdir)" "${env_dir}"
+	assertCapturedStderr "The native addon for Node.js language metrics is no longer supported. Unset the HEROKU_LEGACY_NODE_PLUGIN environment variable to migrate to the new metrics collector."
 
-  # by default $NODE_OPTIONS is unmodified
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# by default $NODE_OPTIONS is unmodified
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # Since $HEROKU_LEGACY_NODE_PLUGIN was defined at build time, the script
-  # should add a require statement to $NODE_OPTIONS for the legacy plugin
-  export HEROKU_METRICS_URL=https://localhost:5000
-  executeStartup $env_dir
-  assertEquals "--require $compile_dir/.heroku/heroku-nodejs-plugin" "$NODE_OPTIONS"
-  cleanupStartup
+	# Since $HEROKU_LEGACY_NODE_PLUGIN was defined at build time, the script
+	# should add a require statement to $NODE_OPTIONS for the legacy plugin
+	export HEROKU_METRICS_URL=https://localhost:5000
+	executeStartup "${env_dir}"
+	assertEquals "--require ${compile_dir}/.heroku/heroku-nodejs-plugin" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # unless $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# unless $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # Since $HEROKU_LEGACY_NODE_PLUGIN was defined at build time,
-  # if $NODE_OPTIONS already exists, it will append the legacy plugin to the require command
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128 --require $compile_dir/.heroku/heroku-nodejs-plugin" "$NODE_OPTIONS"
-  cleanupStartup
+	# Since $HEROKU_LEGACY_NODE_PLUGIN was defined at build time,
+	# if $NODE_OPTIONS already exists, it will append the legacy plugin to the require command
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128 --require ${compile_dir}/.heroku/heroku-nodejs-plugin" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128" "$NODE_OPTIONS"
-  cleanupStartup
+	# and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128" "${NODE_OPTIONS}"
+	cleanupStartup
 }
-
 
 testPluginInstallationRunTimeNodeScriptWithNoLegacyFallback() {
-  local env_dir=$(mktmpdir)
-  echo "true" > $env_dir/HEROKU_LEGACY_NODE_PLUGIN
-  compile "node-21" "$(mktmpdir)" $env_dir
-  assertNotCaptured "The native addon for Node.js language metrics is no longer supported. Unset the HEROKU_LEGACY_NODE_PLUGIN environment variable to migrate to the new metrics collector."
+	local env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}"/HEROKU_LEGACY_NODE_PLUGIN
+	compile "node-21" "$(mktmpdir)" "${env_dir}"
+	assertNotCaptured "The native addon for Node.js language metrics is no longer supported. Unset the HEROKU_LEGACY_NODE_PLUGIN environment variable to migrate to the new metrics collector."
 
-  # by default $NODE_OPTIONS is unmodified
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# by default $NODE_OPTIONS is unmodified
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # If $HEROKU_METRICS_URL is defined at run time, the script
-  # should add a require statement to $NODE_OPTIONS
-  export HEROKU_METRICS_URL=https://localhost:5000
-  executeStartup $env_dir
-  assertEquals "--require $compile_dir/.heroku/metrics/metrics_collector.cjs" "$NODE_OPTIONS"
-  cleanupStartup
+	# If $HEROKU_METRICS_URL is defined at run time, the script
+	# should add a require statement to $NODE_OPTIONS
+	export HEROKU_METRICS_URL=https://localhost:5000
+	executeStartup "${env_dir}"
+	assertEquals "--require ${compile_dir}/.heroku/metrics/metrics_collector.cjs" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # unless $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# unless $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # if $NODE_OPTIONS already exists, it will append the require command
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128 --require $compile_dir/.heroku/metrics/metrics_collector.cjs" "$NODE_OPTIONS"
-  cleanupStartup
+	# if $NODE_OPTIONS already exists, it will append the require command
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128 --require ${compile_dir}/.heroku/metrics/metrics_collector.cjs" "${NODE_OPTIONS}"
+	cleanupStartup
 
-  # and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
-  export HEROKU_METRICS_URL=https://localhost:5000
-  export NODE_OPTIONS="--max-old-space-size=128"
-  export HEROKU_SKIP_NODE_PLUGIN=true
-  executeStartup $env_dir
-  assertEquals "--max-old-space-size=128" "$NODE_OPTIONS"
-  cleanupStartup
+	# and it will leave it unchanged if $HEROKU_SKIP_NODE_PLUGIN is defined
+	export HEROKU_METRICS_URL=https://localhost:5000
+	export NODE_OPTIONS="--max-old-space-size=128"
+	export HEROKU_SKIP_NODE_PLUGIN=true
+	executeStartup "${env_dir}"
+	assertEquals "--max-old-space-size=128" "${NODE_OPTIONS}"
+	cleanupStartup
 }
-
 
 testPluginInstallationUnsupportedNodeRunTime() {
-  local env_dir=$(mktmpdir)
-  compile "node-6" "$(mktmpdir)" $env_dir
+	local env_dir=$(mktmpdir)
+	compile "node-6" "$(mktmpdir)" "${env_dir}"
 
-  # This can happen if a user opts-in to the feature but is not using a supported node version
-  export HEROKU_METRICS_URL=https://localhost:5000
-  executeStartup $env_dir
-  assertEquals "" "$NODE_OPTIONS"
-  cleanupStartup
+	# This can happen if a user opts-in to the feature but is not using a supported node version
+	export HEROKU_METRICS_URL=https://localhost:5000
+	executeStartup "${env_dir}"
+	assertEquals "" "${NODE_OPTIONS}"
+	cleanupStartup
 }
-
 
 testFailingBuildMetaData() {
-  cache_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
 
-  compile "bad-json" "${cache_dir}"
-  assertMetricEqualsString "${cache_dir}" "failure" "invalid-package-json"
-  assertCapturedError
+	compile "bad-json" "${cache_dir}"
+	assertMetricEqualsString "${cache_dir}" "failure" "invalid-package-json"
+	assertCapturedError
 
-  compile "yarn-lockfile-out-of-date" "${cache_dir}"
-  assertMetricEqualsString "${cache_dir}" "failure" "outdated-yarn-lockfile"
-  assertCapturedError
+	compile "yarn-lockfile-out-of-date" "${cache_dir}"
+	assertMetricEqualsString "${cache_dir}" "failure" "outdated-yarn-lockfile"
+	assertCapturedError
 }
-
 
 testBinDetectWarnings() {
-  detect "slugignore-package-json"
-  assertCapturedError "'package.json' listed in '.slugignore' file"
-  assertCapturedError "https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore"
+	detect "slugignore-package-json"
+	assertCapturedError "'package.json' listed in '.slugignore' file"
+	assertCapturedError "https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore"
 
-  detect "gitignore-package-json"
-  assertCapturedError "'package.json' listed in '.gitignore' file"
-  assertCapturedError "https://devcenter.heroku.com/articles/gitignore"
+	detect "gitignore-package-json"
+	assertCapturedError "'package.json' listed in '.gitignore' file"
+	assertCapturedError "https://devcenter.heroku.com/articles/gitignore"
 
-  detect "node-project-missing-package-json"
-  assertCapturedError "Application not supported by 'heroku/nodejs' buildpack"
-  assertCapturedError "https://devcenter.heroku.com/articles/nodejs-support#activation"
-  assertCapturedError "index.js"
-  assertCapturedError "src/"
+	detect "node-project-missing-package-json"
+	assertCapturedError "Application not supported by 'heroku/nodejs' buildpack"
+	assertCapturedError "https://devcenter.heroku.com/articles/nodejs-support#activation"
+	assertCapturedError "index.js"
+	assertCapturedError "src/"
 }
-
 
 testBinReportSuccess() {
-  cache_dir=$(mktmpdir)
-  compile_and_report "node-14" "$cache_dir"
-  assertCaptured "$(jq --sort-keys '.' "$cache_dir/build-data/nodejs.json")"
-  assertCapturedSuccess
+	cache_dir=$(mktmpdir)
+	compile_and_report "node-14" "${cache_dir}"
+	assertCaptured "$(jq --sort-keys '.' "${cache_dir}/build-data/nodejs.json")"
+	assertCapturedSuccess
 }
-
 
 testBinReportScriptsWithQuotes() {
-  cache_dir=$(mktmpdir)
-  compile_and_report "complex-scripts" "$cache_dir"
-  assertCaptured "$(jq --sort-keys '.' "$cache_dir/build-data/nodejs.json")"
-  assertCapturedSuccess
+	cache_dir=$(mktmpdir)
+	compile_and_report "complex-scripts" "${cache_dir}"
+	assertCaptured "$(jq --sort-keys '.' "${cache_dir}/build-data/nodejs.json")"
+	assertCapturedSuccess
 }
-
 
 testWarningNode_22_5_0() {
-  compile "node-22.5.0-warning"
-  assertCapturedStderr "Issues with Node.js v22.5.0"
-  assertCapturedSuccessWithWarnings
+	compile "node-22.5.0-warning"
+	assertCapturedStderr "Issues with Node.js v22.5.0"
+	assertCapturedSuccessWithWarnings
 }
 
-
 testConflictingPackageManagerMetadata() {
-  compile "conflicting-package-manager-metadata"
-  # The migrated conflicting-metadata guard renders the failure via failure::emit, which writes
-  # the message and every detected-field line to stderr through output::error.
-  assertCapturedStderr "Multiple package managers declared in package.json"
-  assertCapturedStderr "- npm version detected in engines.npm (10.x)"
-  assertCapturedStderr "- yarn version declared in engines.yarn (4.x)"
-  assertCapturedStderr "- pnpm version declared in engines.pnpm (9.x)"
-  assertCapturedStderr "- pnpm version declared in packageManager (pnpm@9.9.0)"
-  assertCapturedError
+	compile "conflicting-package-manager-metadata"
+	# The migrated conflicting-metadata guard renders the failure via failure::emit, which writes
+	# the message and every detected-field line to stderr through output::error.
+	assertCapturedStderr "Multiple package managers declared in package.json"
+	assertCapturedStderr "- npm version detected in engines.npm (10.x)"
+	assertCapturedStderr "- yarn version declared in engines.yarn (4.x)"
+	assertCapturedStderr "- pnpm version declared in engines.pnpm (9.x)"
+	assertCapturedStderr "- pnpm version declared in packageManager (pnpm@9.9.0)"
+	assertCapturedError
 }
 
 # Error classifications
 
-
 testErrorPrebuildScript() {
-  cache_dir=$(mktmpdir)
-  compile "error-prebuild-script" "${cache_dir}"
-  assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
-  assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
+	cache_dir=$(mktmpdir)
+	compile "error-prebuild-script" "${cache_dir}"
+	assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
+	assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
 }
-
 
 testErrorBuildScript() {
-  cache_dir=$(mktmpdir)
-  compile "error-build-script" "${cache_dir}"
-  assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
-  assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
+	cache_dir=$(mktmpdir)
+	compile "error-build-script" "${cache_dir}"
+	assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
+	assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
 }
-
 
 testErrorPostbuildScript() {
-  cache_dir=$(mktmpdir)
-  compile "error-postbuild-script" "${cache_dir}"
-  assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
-  assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
+	cache_dir=$(mktmpdir)
+	compile "error-postbuild-script" "${cache_dir}"
+	assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
+	assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
 }
-
 
 testErrorCleanupScript() {
-  cache_dir=$(mktmpdir)
-  compile "error-cleanup-script" "${cache_dir}"
-  assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
-  assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
+	cache_dir=$(mktmpdir)
+	compile "error-cleanup-script" "${cache_dir}"
+	assertMetricEqualsString "${cache_dir}" "failure" "unknown-build-script-error"
+	assertMetricEqualsString "${cache_dir}" "failure_classification" "user"
 }
-
 
 testErrorOpensslUnsupportedAlgorithm() {
-  cache_dir=$(mktmpdir)
-  compile 'error-openssl-unsupported-algorithm' "${cache_dir}"
-  assertCapturedStderr "Unsupported cryptographic algorithm used"
-  assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "openssl-unsupported-algorithm"
+	cache_dir=$(mktmpdir)
+	compile 'error-openssl-unsupported-algorithm' "${cache_dir}"
+	assertCapturedStderr "Unsupported cryptographic algorithm used"
+	assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "openssl-unsupported-algorithm"
 }
-
 
 testErrorOpensslUnsupportedAlgorithmInWebpack() {
-  cache_dir=$(mktmpdir)
-  compile 'error-openssl-unsupported-algorithm-in-webpack' "${cache_dir}"
-  assertCapturedStderr "Unsupported cryptographic algorithm used"
-  assertCapturedStderr "https://webpack.js.org/configuration/output/#outputhashfunction"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "openssl-unsupported-algorithm-webpack"
+	cache_dir=$(mktmpdir)
+	compile 'error-openssl-unsupported-algorithm-in-webpack' "${cache_dir}"
+	assertCapturedStderr "Unsupported cryptographic algorithm used"
+	assertCapturedStderr "https://webpack.js.org/configuration/output/#outputhashfunction"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "openssl-unsupported-algorithm-webpack"
 }
-
 
 testErrorOOM() {
-  cache_dir=$(mktmpdir)
-  compile "error-oom" "${cache_dir}"
-  assertCapturedStderr "Node.js Out-Of-Memory (OOM)"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "node-out-of-memory"
+	cache_dir=$(mktmpdir)
+	compile "error-oom" "${cache_dir}"
+	assertCapturedStderr "Node.js Out-Of-Memory (OOM)"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "node-out-of-memory"
 }
-
 
 testOptOutOfWideVersionDowngrade() {
-  env_dir=$(mktmpdir)
-  echo "true" > "$env_dir/NODEJS_ALLOW_WIDE_RANGE"
-  compile "version-bounds-wide" "$(mktmpdir)" "$env_dir"
-  assertCapturedStderr "The requested Node.js version is using a wide range"
-  assertNotCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}/NODEJS_ALLOW_WIDE_RANGE"
+	compile "version-bounds-wide" "$(mktmpdir)" "${env_dir}"
+	assertCapturedStderr "The requested Node.js version is using a wide range"
+	assertNotCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testVersionBoundsWide() {
-  compile "version-bounds-wide"
-  assertCapturedStderr "The requested Node.js version is using a wide range"
-  assertCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
-  assertCapturedSuccessWithWarnings
+	compile "version-bounds-wide"
+	assertCapturedStderr "The requested Node.js version is using a wide range"
+	assertCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testVersionBoundsNarrow() {
-  compile "version-bounds-narrow"
-  assertNotCapturedStderr "The requested Node.js version is using a wide range"
-  assertNotCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
-  assertCapturedSuccessWithWarnings
+	compile "version-bounds-narrow"
+	assertNotCapturedStderr "The requested Node.js version is using a wide range"
+	assertNotCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
+	assertCapturedSuccessWithWarnings
 }
 
-
 testVersionBoundsExplicitlyGreaterThanLTS() {
-  compile "version-bounds-explicitly-greater-than-lts"
-  assertCapturedStderr "The requested Node.js version is using a wide range"
-  assertNotCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
-  assertCapturedSuccessWithWarnings
+	compile "version-bounds-explicitly-greater-than-lts"
+	assertCapturedStderr "The requested Node.js version is using a wide range"
+	assertNotCapturedStderr "The resolved Node.js version has been limited to the Active LTS"
+	assertCapturedSuccessWithWarnings
 }
 
 source "$(pwd)"/test/shunit2

--- a/test/run-helpers
+++ b/test/run-helpers
@@ -1,36 +1,38 @@
 #!/usr/bin/env bash
 # Shared helper functions for split test runners.
 # Source this file from each test runner; it does NOT source shunit2.
+# shellcheck disable=SC1090,SC1091,SC2312 # test harness: dynamically-sourced fixtures resolve at runtime; masked command-substitution exits are inherent to a non-error-propagating test runner
+# shellcheck disable=SC2155,SC2231 # deferred: style nits (split declare/assign, quote-to-avoid-glob) triaged out of the mechanical migration
 
-pushd "$(dirname 0)" >/dev/null
-popd >/dev/null
+pushd "$(dirname 0)" >/dev/null || exit
+popd >/dev/null || exit
 
 source "$(pwd)"/test/utils
 source "$(pwd)"/lib/environment.sh
 
 mktmpdir() {
-  dir=$(mktemp -t testXXXXX)
-  rm -rf $dir
-  mkdir $dir
-  echo $dir
+	dir=$(mktemp -t testXXXXX)
+	rm -rf "${dir}"
+	mkdir "${dir}"
+	echo "${dir}"
 }
 
 compile_dir=""
 
 default_process_types_cleanup() {
-  file="/tmp/default_process_types"
-  if [ -f "$file" ]; then
-    rm "$file"
-  fi
+	file="/tmp/default_process_types"
+	if [[ -f "${file}" ]]; then
+		rm "${file}"
+	fi
 }
 
 detect() {
-  default_process_types_cleanup
-  bp_dir=$(mktmpdir)
-  compile_dir=$(mktmpdir)
-  cp -a "$(pwd)"/* ${bp_dir}
-  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
-  capture ${bp_dir}/bin/detect ${compile_dir}
+	default_process_types_cleanup
+	bp_dir=$(mktmpdir)
+	compile_dir=$(mktmpdir)
+	cp -a "$(pwd)"/* "${bp_dir}"
+	cp -a "${bp_dir}"/test/fixtures/"$1"/. "${compile_dir}"
+	capture "${bp_dir}"/bin/detect "${compile_dir}"
 }
 
 # $1 - The fixture to compile
@@ -43,33 +45,33 @@ detect() {
 #        `compile "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR"` but this would require all existing tests
 #        to reorder their arguments as allowing a configurable compile directory was added last.
 compile() {
-  default_process_types_cleanup
+	default_process_types_cleanup
 
-  bp_dir=$(mktmpdir)
-  compile_dir=${4:-$(mktmpdir)}
+	bp_dir=$(mktmpdir)
+	compile_dir=${4:-$(mktmpdir)}
 
-  cp -a "$(pwd)"/* ${bp_dir}
-  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
+	cp -a "$(pwd)"/* "${bp_dir}"
+	cp -a "${bp_dir}"/test/fixtures/"$1"/. "${compile_dir}"
 
-  capture ${bp_dir}/bin/compile ${compile_dir} ${2:-$(mktmpdir)} $3
+	capture "${bp_dir}"/bin/compile "${compile_dir}" "${2:-$(mktmpdir)}" "$3"
 }
 
 # run compile on a fixture and then capture the output of bin/report
 # ran after bin/compile completes, reusing the cache and env dirs. Note
 # that the output of bin/compile will not be captured
 compile_and_report() {
-  default_process_types_cleanup
-  cache_dir=${2:-$(mktmpdir)}
-  env_dir=${3:-$(mktmpdir)}
+	default_process_types_cleanup
+	cache_dir=${2:-$(mktmpdir)}
+	env_dir=${3:-$(mktmpdir)}
 
-  bp_dir=$(mktmpdir)
-  cp -a "$(pwd)"/* ${bp_dir}
+	bp_dir=$(mktmpdir)
+	cp -a "$(pwd)"/* "${bp_dir}"
 
-  compile_dir=$(mktmpdir)
-  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
+	compile_dir=$(mktmpdir)
+	cp -a "${bp_dir}"/test/fixtures/"$1"/. "${compile_dir}"
 
-  ${bp_dir}/bin/compile ${compile_dir} $cache_dir $env_dir > /dev/null 2>/dev/null
-  capture ${bp_dir}/bin/report ${compile_dir} $cache_dir $env_dir
+	"${bp_dir}"/bin/compile "${compile_dir}" "${cache_dir}" "${env_dir}" >/dev/null 2>/dev/null
+	capture "${bp_dir}"/bin/report "${compile_dir}" "${cache_dir}" "${env_dir}"
 }
 
 # Run bin/report on a set of given directories without first invoking bin/compile
@@ -77,111 +79,110 @@ compile_and_report() {
 # any binaries will be installed or any part of the cache available, and bin/report
 # should be resilient in that case.
 report() {
-  default_process_types_cleanup
+	default_process_types_cleanup
 
-  compile_dir=${1:-$(mktmpdir)}
-  cache_dir=${2:-$(mktmpdir)}
-  env_dir=${3:-$(mktmpdir)}
+	compile_dir=${1:-$(mktmpdir)}
+	cache_dir=${2:-$(mktmpdir)}
+	env_dir=${3:-$(mktmpdir)}
 
-  bp_dir=$(mktmpdir)
-  cp -a "$(pwd)"/* ${bp_dir}
+	bp_dir=$(mktmpdir)
+	cp -a "$(pwd)"/* "${bp_dir}"
 
-  capture ${bp_dir}/bin/report ${compile_dir} ${cache_dir} ${env_dir}
+	capture "${bp_dir}"/bin/report "${compile_dir}" "${cache_dir}" "${env_dir}"
 }
 
 testCompile() {
-  default_process_types_cleanup
-  bp_dir=$(mktmpdir)
-  compile_dir=$(mktmpdir)
-  cp -a "$(pwd)"/* ${bp_dir}
-  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
-  capture ${bp_dir}/bin/test-compile ${compile_dir} ${2:-$(mktmpdir)} $3
+	default_process_types_cleanup
+	bp_dir=$(mktmpdir)
+	compile_dir=$(mktmpdir)
+	cp -a "$(pwd)"/* "${bp_dir}"
+	cp -a "${bp_dir}"/test/fixtures/"$1"/. "${compile_dir}"
+	capture "${bp_dir}"/bin/test-compile "${compile_dir}" "${2:-$(mktmpdir)}" "$3"
 }
 
 # This is meant to be run after `compile`. `cleanupStartup` must be run
 # after this function is called before other tests are executed
 executeStartup() {
-  local env_dir=$1
+	local env_dir=$1
 
-  # On Heroku, $HOME is the /app dir, so we need to set it to
-  # the compile_dir here
-  export HOME=${compile_dir}
+	# On Heroku, $HOME is the /app dir, so we need to set it to
+	# the compile_dir here
+	export HOME=${compile_dir}
 
-  # we need to set any environment variables set via the env_dir and run
-  # all of the .profile.d scripts
-  environment::export_env_dir $env_dir
+	# we need to set any environment variables set via the env_dir and run
+	# all of the .profile.d scripts
+	environment::export_env_dir "${env_dir}"
 
-  for f in ${compile_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
+	for f in ${compile_dir}/.profile.d/*; do source "${f}" >/dev/null 2>/dev/null; done
 }
 
 cleanupStartup() {
-  unset HOME
-  unset NODE_ENV
-  unset NODE_HOME
-  unset NODE_OPTIONS
-  unset DYNO
-  unset HEROKU_METRICS_URL
-  unset HEROKU_SKIP_NODE_PLUGIN
+	unset HOME
+	unset NODE_ENV
+	unset NODE_HOME
+	unset NODE_OPTIONS
+	unset DYNO
+	unset HEROKU_METRICS_URL
+	unset HEROKU_SKIP_NODE_PLUGIN
 }
 
 compileTest() {
-  default_process_types_cleanup
+	default_process_types_cleanup
 
-  local bp_dir=$(mktmpdir)
-  local compile_dir=$(mktmpdir)
-  local cache_dir=${2:-$(mktmpdir)}
-  local env_dir=$3
+	local bp_dir=$(mktmpdir)
+	local compile_dir=$(mktmpdir)
+	local cache_dir=${2:-$(mktmpdir)}
+	local env_dir=$3
 
-  cp -a "$(pwd)"/* ${bp_dir}
-  cp -a ${bp_dir}/test/fixtures/$1/. ${compile_dir}
-  capture ${bp_dir}/bin/test-compile ${compile_dir} ${2:-$(mktmpdir)} $3
+	cp -a "$(pwd)"/* "${bp_dir}"
+	cp -a "${bp_dir}"/test/fixtures/"$1"/. "${compile_dir}"
+	capture "${bp_dir}"/bin/test-compile "${compile_dir}" "${2:-$(mktmpdir)}" "$3"
 
-  # On Heroku, $HOME is the /app dir, so we need to set it to
-  # the compile_dir here
-  export HOME=${compile_dir}
+	# On Heroku, $HOME is the /app dir, so we need to set it to
+	# the compile_dir here
+	export HOME=${compile_dir}
 
-  # bin/test is not ran during build, rather during runtime, which means
-  # we need to set any environment variables set via the env_dir and run
-  # all of the .profile.d scripts
-  environment::export_env_dir $env_dir
-  for f in ${compile_dir}/.profile.d/*; do source $f > /dev/null 2> /dev/null ; done
+	# bin/test is not ran during build, rather during runtime, which means
+	# we need to set any environment variables set via the env_dir and run
+	# all of the .profile.d scripts
+	environment::export_env_dir "${env_dir}"
+	for f in ${compile_dir}/.profile.d/*; do source "${f}" >/dev/null 2>/dev/null; done
 
-  capture ${bp_dir}/bin/test ${compile_dir}
+	capture "${bp_dir}"/bin/test "${compile_dir}"
 
-  unset HOME
-  unset NODE_ENV
-  unset NODE_HOME
+	unset HOME
+	unset NODE_ENV
+	unset NODE_HOME
 }
 
 compileDir() {
-  default_process_types_cleanup
+	default_process_types_cleanup
 
-  local bp_dir=$(mktmpdir)
-  local compile_dir=${1:-$(mktmpdir)}
-  local cache_dir=${2:-$(mktmpdir)}
-  local env_dir=$3
+	local bp_dir=$(mktmpdir)
+	local compile_dir=${1:-$(mktmpdir)}
+	local cache_dir=${2:-$(mktmpdir)}
+	local env_dir=$3
 
-  cp -a "$(pwd)"/* ${bp_dir}
-  capture ${bp_dir}/bin/compile ${compile_dir} ${cache_dir} ${env_dir}
+	cp -a "$(pwd)"/* "${bp_dir}"
+	capture "${bp_dir}"/bin/compile "${compile_dir}" "${cache_dir}" "${env_dir}"
 }
 
 release() {
-  bp_dir=$(mktmpdir)
-  cp -a "$(pwd)"/* ${bp_dir}
-  capture ${bp_dir}/bin/release ${bp_dir}/test/fixtures/$1
+	bp_dir=$(mktmpdir)
+	cp -a "$(pwd)"/* "${bp_dir}"
+	capture "${bp_dir}"/bin/release "${bp_dir}"/test/fixtures/"$1"
 }
 
 assertFile() {
-  assertEquals "$1" "$(cat ${compile_dir}/$2)"
+	assertEquals "$1" "$(cat "${compile_dir}"/"$2")"
 }
 
 tearDown() {
-  # Remove any testing temporary directories created during tests to prevent
-  # CI from running out of disk space.
-  for dir in $bp_dir $compile_dir $cache_dir $env_dir;
-  do
-    if [[ -d $dir ]] && [[ "$dir" =~ test[[:alnum:]]{5}$ ]]; then
-      rm -rf $dir
-    fi
-  done
+	# Remove any testing temporary directories created during tests to prevent
+	# CI from running out of disk space.
+	for dir in ${bp_dir} ${compile_dir} ${cache_dir} ${env_dir}; do
+		if [[ -d ${dir} ]] && [[ "${dir}" =~ test[[:alnum:]]{5}$ ]]; then
+			rm -rf "${dir}"
+		fi
+	done
 }

--- a/test/run-npm
+++ b/test/run-npm
@@ -1,437 +1,412 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2312 # test harness: dynamically-sourced fixtures resolve at runtime; masked command-substitution exits are inherent to a non-error-propagating test runner
+# shellcheck disable=SC2034,SC2154,SC2155 # deferred: style/test-fixture nits triaged out of the mechanical migration
 
 source "$(pwd)"/test/run-helpers
 
 testNpmCi() {
-  local log_file cache
-  build_dir=$(mktmpdir)
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	local log_file cache
+	build_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  compile "node-14-npm-ci" "$cache_dir" "$env_dir" "$build_dir"
+	compile "node-14-npm-ci" "${cache_dir}" "${env_dir}" "${build_dir}"
 
-   # make sure that build scripts are being called
-  assertCaptured "heroku-prebuild script"
-  assertCaptured "build script"
-  assertCaptured "postinstall script"
-  assertCapturedSuccessWithWarnings
-  assertFileExists "$build_dir/.heroku/node/bin/npm"
+	# make sure that build scripts are being called
+	assertCaptured "heroku-prebuild script"
+	assertCaptured "build script"
+	assertCaptured "postinstall script"
+	assertCapturedSuccessWithWarnings
+	assertFileExists "${build_dir}/.heroku/node/bin/npm"
 
-   # test metrics
-  assertMetricEqualsRaw "$cache_dir" "use_npm_ci" "true"
+	# test metrics
+	assertMetricEqualsRaw "${cache_dir}" "use_npm_ci" "true"
 
-   # test re-using the cache
-  compile "node-14-npm-ci" "$cache_dir"
-  assertCapturedSuccessWithWarnings
+	# test re-using the cache
+	compile "node-14-npm-ci" "${cache_dir}"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmCiShrinkwrap() {
-  cache_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
 
-  compile "node-10-npm-ci-shrinkwrap" "$cache_dir"
+	compile "node-10-npm-ci-shrinkwrap" "${cache_dir}"
 
-   # make sure that build scripts are being called
-  assertCaptured "heroku-prebuild script"
-  assertCaptured "build script"
-  assertCaptured "postinstall script"
-  assertCapturedSuccessWithWarnings
+	# make sure that build scripts are being called
+	assertCaptured "heroku-prebuild script"
+	assertCaptured "build script"
+	assertCaptured "postinstall script"
+	assertCapturedSuccessWithWarnings
 
-   # test metrics
-  assertMetricEqualsRaw "$cache_dir" "use_npm_ci" "true"
+	# test metrics
+	assertMetricEqualsRaw "${cache_dir}" "use_npm_ci" "true"
 
-   # test re-using the cache
-  compile "node-10-npm-ci-shrinkwrap" "$cache_dir"
-  assertCapturedSuccessWithWarnings
+	# test re-using the cache
+	compile "node-10-npm-ci-shrinkwrap" "${cache_dir}"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmCiFallback() {
-  cache_dir=$(mktmpdir)
-  # without a lockfile we should use "npm install" instead of "npm ci"
-  compile "node-14-npm-ci-no-lockfile" "${cache_dir}"
-  assertCapturedSuccessWithWarnings
-  # detecting that we shouldn't use npm ci
-  assertMetricEqualsRaw "$cache_dir" "use_npm_ci" "false"
+	cache_dir=$(mktmpdir)
+	# without a lockfile we should use "npm install" instead of "npm ci"
+	compile "node-14-npm-ci-no-lockfile" "${cache_dir}"
+	assertCapturedSuccessWithWarnings
+	# detecting that we shouldn't use npm ci
+	assertMetricEqualsRaw "${cache_dir}" "use_npm_ci" "false"
 }
-
 
 testNpmCiDisabled() {
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  log_file=$(mktemp)
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	log_file=$(mktemp)
 
-  echo "true" > $env_dir/USE_NPM_INSTALL
+	echo "true" >"${env_dir}"/USE_NPM_INSTALL
 
-  compile "node-14-npm-ci" $cache_dir $env_dir
+	compile "node-14-npm-ci" "${cache_dir}" "${env_dir}"
 
-  assertMetricEqualsRaw "$cache_dir" "use_npm_ci" "false"
-  assertCapturedSuccessWithWarnings
+	assertMetricEqualsRaw "${cache_dir}" "use_npm_ci" "false"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpm5CacheDirectory() {
-  local cache=$(mktmpdir)
-  local env_dir=$(mktmpdir)
-  local cache_dir=$(mktmpdir)
-  echo "${cache_dir}/npm"> "$env_dir"/NPM_CONFIG_CACHE
-  compile "npm5" $cache $env_dir
-  # These will be created if npm is using the directory for its cache
-  assertDirectoryExists ${cache_dir}/npm
-  assertDirectoryExists ${cache_dir}/npm/_cacache
-  assertCapturedSuccessWithWarnings
+	local cache=$(mktmpdir)
+	local env_dir=$(mktmpdir)
+	local cache_dir=$(mktmpdir)
+	echo "${cache_dir}/npm" >"${env_dir}"/NPM_CONFIG_CACHE
+	compile "npm5" "${cache}" "${env_dir}"
+	# These will be created if npm is using the directory for its cache
+	assertDirectoryExists "${cache_dir}"/npm
+	assertDirectoryExists "${cache_dir}"/npm/_cacache
+	assertCapturedSuccessWithWarnings
 }
-
 
 testDefaultToNpm5() {
-  compile "npm-lockfile-no-version"
-  assertCaptured "Using default npm version"
-  assertCaptured "Installing node modules (package.json + package-lock)"
-  assertCapturedSuccessWithWarnings
+	compile "npm-lockfile-no-version"
+	assertCaptured "Using default npm version"
+	assertCaptured "Installing node modules (package.json + package-lock)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testDefaultToNpm5WithNode6() {
-  compile "npm-lockfile-node-6-no-version"
-  assertCaptured "Detected package-lock.json"
-  assertCaptured "Bootstrapping npm 5"
-  assertCaptured "Installing node modules (package.json + package-lock)"
-  assertCapturedSuccessWithWarnings
+	compile "npm-lockfile-node-6-no-version"
+	assertCaptured "Detected package-lock.json"
+	assertCaptured "Bootstrapping npm 5"
+	assertCaptured "Installing node modules (package.json + package-lock)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testOldNpmWithLockfile() {
-  compile "npm-lockfile-old-version"
-  assertCapturedStderr "This version of npm"
-  assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
-  assertCapturedSuccessWithWarnings
+	compile "npm-lockfile-old-version"
+	assertCapturedStderr "This version of npm"
+	assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-an-npm-version"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testOldNpm() {
-  compile "old-npm"
-  # warn_old_npm now emits via output::warning, which writes to stderr.
-  assertCapturedStderr "This version of npm (1.2.8000) has several known issues. Please update your npm version in package.json."
-  assertNotCaptured "integer expression expected"
-  assertCapturedError
+	compile "old-npm"
+	# warn_old_npm now emits via output::warning, which writes to stderr.
+	assertCapturedStderr "This version of npm (1.2.8000) has several known issues. Please update your npm version in package.json."
+	assertNotCaptured "integer expression expected"
+	assertCapturedError
 }
-
 
 testNonexistentNpm() {
-  compile "nonexistent-npm"
-  assertCapturedStderr "Unable to install npm 1.1.65"
-  assertCapturedError 1 ""
+	compile "nonexistent-npm"
+	assertCapturedStderr "Unable to install npm 1.1.65"
+	assertCapturedError 1 ""
 }
-
 
 testSameNpm() {
-  compile "same-npm"
-  assertCaptured "npm 1.4.28 already installed"
-  assertCapturedSuccessWithWarnings
+	compile "same-npm"
+	assertCaptured "npm 1.4.28 already installed"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmVersionRange() {
-  compile "npm-version-range"
-  assertCaptured "Bootstrapping npm 5.7.x"
-  assertCapturedSuccessWithWarnings
+	compile "npm-version-range"
+	assertCaptured "Bootstrapping npm 5.7.x"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmVersionSpecific() {
-  compile "npm-version-specific"
-  assertCaptured "Bootstrapping npm 2.1.11"
-  assertNotCaptured "WARNING"
-  assertCapturedSuccessWithWarnings
+	compile "npm-version-specific"
+	assertCaptured "Bootstrapping npm 2.1.11"
+	assertNotCaptured "WARNING"
+	assertCapturedSuccessWithWarnings
 }
 
-
 testNpmVersionIncompatible() {
-  compile "npm-version-incompat"
-  assertCapturedStderr "Unable to install npm 10.x"
-  assertCapturedStderr "Is npm 10.x compatible with this Node.js version?"
-  assertCapturedError
+	compile "npm-version-incompat"
+	assertCapturedStderr "Unable to install npm 10.x"
+	assertCapturedStderr "Is npm 10.x compatible with this Node.js version?"
+	assertCapturedError
 }
 
 # https://github.com/heroku/heroku-buildpack-nodejs/issues/1590
 # Node 22.22.2 ships npm 10.9.7 which fails to bootstrap npm 11.x
 # due to a missing `promise-retry` module in @npmcli/arborist
 testNode22Npm11BootstrapRegressionWorkaround() {
-  compile "node-22-npm-11-regression"
-  assertCaptured "Installing npm@~11.10.0 to workaround Node.js 22.22.2 regression"
-  assertCaptured "Bootstrapping npm 11."
-  assertCaptured "npm 11."
-  assertCapturedSuccessWithWarnings
+	compile "node-22-npm-11-regression"
+	assertCaptured "Installing npm@~11.10.0 to workaround Node.js 22.22.2 regression"
+	assertCaptured "Bootstrapping npm 11."
+	assertCaptured "npm 11."
+	assertCapturedSuccessWithWarnings
 }
 
 # https://github.com/heroku/heroku-buildpack-nodejs/issues/1702
 # npm 12 removed the --unsafe-perm flag; the buildpack must not pass it.
 testNpm12UnsafePermRemoved() {
-  compile "npm-12-unsafe-perm"
-  assertCaptured "npm 12"
-  assertNotCaptured "Unknown cli flag"
-  assertNotCaptured "EUNKNOWNCONFIG"
-  assertCapturedSuccessWithWarnings
+	compile "npm-12-unsafe-perm"
+	assertCaptured "npm 12"
+	assertNotCaptured "Unknown cli flag"
+	assertNotCaptured "EUNKNOWNCONFIG"
+	assertCapturedSuccessWithWarnings
 }
 
 testUserConfig() {
-  compile "userconfig"
-  assertCaptured "www.google.com"
-  assertCaptured "registry error"
-  assertCapturedError 1 ""
+	compile "userconfig"
+	assertCaptured "www.google.com"
+	assertCaptured "registry error"
+	assertCapturedError 1 ""
 }
 
-
 testDevDependenciesInstalled() {
-  compile "dependencies"
-  assertCaptured "lodash"
-  assertCaptured "Pruning devDependencies"
-  assertCaptured "removed 1 package"
-  assertCapturedSuccessWithWarnings
+	compile "dependencies"
+	assertCaptured "lodash"
+	assertCaptured "Pruning devDependencies"
+	assertCaptured "removed 1 package"
+	assertCapturedSuccessWithWarnings
 }
 
 # Default behavior: install devDependencies then prunes them away with Yarn
 
 testDevDepenenciesWithNoPruning() {
-  env_dir=$(mktmpdir)
-  echo "false" > $env_dir/NPM_CONFIG_PRODUCTION
-  compile "dependencies" "$(mktmpdir)" $env_dir
-  assertCaptured "lodash"
-  assertCaptured "Skipping because NPM_CONFIG_PRODUCTION is 'false'"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "false" >"${env_dir}"/NPM_CONFIG_PRODUCTION
+	compile "dependencies" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "lodash"
+	assertCaptured "Skipping because NPM_CONFIG_PRODUCTION is 'false'"
+	assertCapturedSuccessWithWarnings
 
-  env_dir=$(mktmpdir)
-  echo "true" > $env_dir/NPM_CONFIG_PRODUCTION
-  compile "dependencies" "$(mktmpdir)" $env_dir
-  assertNotCaptured "lodash"
-  assertCaptured "Skipping because NPM_CONFIG_PRODUCTION is 'true'"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}"/NPM_CONFIG_PRODUCTION
+	compile "dependencies" "$(mktmpdir)" "${env_dir}"
+	assertNotCaptured "lodash"
+	assertCaptured "Skipping because NPM_CONFIG_PRODUCTION is 'true'"
+	assertCapturedSuccessWithWarnings
 }
 
 # When NPM_CONFIG_PRODUCTION = false we should not prune the devDependencies with Yarn
 
 testNodeEnvTestDepenencies() {
-  env_dir=$(mktmpdir)
-  echo "not-production" > $env_dir/NODE_ENV
-  compile "dependencies" "$(mktmpdir)" $env_dir
-  assertCaptured "lodash"
-  assertCaptured "Skipping because NODE_ENV is not 'production'"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "not-production" >"${env_dir}"/NODE_ENV
+	compile "dependencies" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "lodash"
+	assertCaptured "Skipping because NODE_ENV is not 'production'"
+	assertCapturedSuccessWithWarnings
 }
 
 # When NODE_ENV != production we should not prune the devDependencies with Yarn
 
 testOptionalDependencies() {
-  env_dir=$(mktmpdir)
-  compile "optional-dependencies" "$(mktmpdir)" $env_dir
-  assertNotCaptured "NPM_CONFIG_OPTIONAL"
-  assertCaptured "less"
-  assertCaptured "mime"
-  assertCaptured "mkdirp"
-  assertCaptured "clean-css"
-  assertCaptured "request"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	compile "optional-dependencies" "$(mktmpdir)" "${env_dir}"
+	assertNotCaptured "NPM_CONFIG_OPTIONAL"
+	assertCaptured "less"
+	assertCaptured "mime"
+	assertCaptured "mkdirp"
+	assertCaptured "clean-css"
+	assertCaptured "request"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNoOptionalDependencies() {
-  env_dir=$(mktmpdir)
-  echo "false" > $env_dir/NPM_CONFIG_OPTIONAL
-  compile "optional-dependencies" "$(mktmpdir)" $env_dir
-  assertCaptured "NPM_CONFIG_OPTIONAL=false"
-  assertCaptured "less"
-  assertNotCaptured "mime"
-  assertNotCaptured "mkdirp"
-  assertNotCaptured "clean-css"
-  assertNotCaptured "request"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "false" >"${env_dir}"/NPM_CONFIG_OPTIONAL
+	compile "optional-dependencies" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "NPM_CONFIG_OPTIONAL=false"
+	assertCaptured "less"
+	assertNotCaptured "mime"
+	assertNotCaptured "mkdirp"
+	assertNotCaptured "clean-css"
+	assertNotCaptured "request"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmrc() {
-  compile "dev-dependencies-npmrc"
-  assertCaptured "lodash"
-  assertCapturedSuccessWithWarnings
+	compile "dev-dependencies-npmrc"
+	assertCaptured "lodash"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testShrinkwrap() {
-  compile "shrinkwrap"
-  assertCaptured "express@4.10.4"
-  assertCaptured "lodash@2.4.0"
-  assertCaptured "mocha@2.0.1"
-  assertCapturedSuccessWithWarnings
+	compile "shrinkwrap"
+	assertCaptured "express@4.10.4"
+	assertCaptured "lodash@2.4.0"
+	assertCaptured "mocha@2.0.1"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testCIDependencies() {
-  compileTest "ci-dependencies"
-  assertCaptured "lodash"
-  assertCapturedSuccess
+	compileTest "ci-dependencies"
+	assertCaptured "lodash"
+	assertCapturedSuccess
 }
 
-
 testNodeEnvNpmConfigProductionFalse() {
-  env_dir=$(mktmpdir)
-  echo "false" > $env_dir/NPM_CONFIG_PRODUCTION
-  compile "node-env-consistency" "$(mktmpdir)" $env_dir
-  assertCaptured "heroku-prebuild: production"
-  assertCaptured "preinstall: production"
-  assertCaptured "postinstall: production"
-  assertCaptured "heroku-postbuild: production"
-  assertEquals "Expected successful exit code" "0" "${RETURN}"
+	env_dir=$(mktmpdir)
+	echo "false" >"${env_dir}"/NPM_CONFIG_PRODUCTION
+	compile "node-env-consistency" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "heroku-prebuild: production"
+	assertCaptured "preinstall: production"
+	assertCaptured "postinstall: production"
+	assertCaptured "heroku-postbuild: production"
+	assertEquals "Expected successful exit code" "0" "${RETURN}"
 }
 
 # Avoid this issue
 # https://github.com/npm/npm/issues/17781
 
 testNpmPrune53Issue() {
-  compile "npm-prune-5-3-issue"
-  assertCaptured "npm 5.3.0 installed"
-  assertCaptured "Skipping because npm 5.3.0 fails"
-  assertCaptured "https://github.com/npm/npm/issues/17781"
-  assertCapturedSuccessWithWarnings
+	compile "npm-prune-5-3-issue"
+	assertCaptured "npm 5.3.0 installed"
+	assertCaptured "Skipping because npm 5.3.0 fails"
+	assertCaptured "https://github.com/npm/npm/issues/17781"
+	assertCapturedSuccessWithWarnings
 }
 
 # Avoid this issue for users with git dependencies
 # https://github.com/npm/npm/issues/19356
 
 testNpmPrune56Issue() {
-  compile "npm-prune-5-6-issue"
-  assertCaptured "npm 5.6.0"
-  assertCaptured "Skipping because npm 5.6.0 sometimes fails"
-  assertCaptured "https://github.com/npm/npm/issues/19356"
-  assertCapturedSuccessWithWarnings
+	compile "npm-prune-5-6-issue"
+	assertCaptured "npm 5.6.0"
+	assertCaptured "Skipping because npm 5.6.0 sometimes fails"
+	assertCaptured "https://github.com/npm/npm/issues/19356"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmBuildMetaData() {
-  cache_dir=$(mktmpdir)
-  compile "pre-post-build-scripts" "${cache_dir}"
-  assertMetrics "${cache_dir}" <<-'EOF'
-    select(.build_step == "finished")
-    select(.build_time | type == "number")
-    select(.bundled_npm_version == "6.14.12")
-    select(.cache_status == "not-found")
-    select(.has_cached_bower_components == false)
-    select(.has_custom_cache_dirs == false)
-    select(.has_procfile == false)
-    select(.heroku_postbuild_script == "echo heroku-postbuild hook message")
-    select(.heroku_prebuild_script == "echo heroku-prebuild hook message")
-    select(.install_dependencies_time | type == "number")
-    select(.install_node_binary_time | type == "number")
-    select(.node_version == "v10.24.1")
-    select(.node_version_eol == true)
-    select(.node_version_major == 10)
-    select(.node_version_request == "10.x")
-    select(.npm_version == "6.14.12")
-    select(.package_manager == "npm")
-    select(.package_manager_version == "6.14.12")
-    select(.prune_dev_dependencies_time | type == "number")
-    select(.restore_cache_time | type == "number")
-    select(.save_cache_time | type == "number")
-    select(.skipped_prune == false)
-    select(.use_npm_ci == false)
-EOF
+	cache_dir=$(mktmpdir)
+	compile "pre-post-build-scripts" "${cache_dir}"
+	assertMetrics "${cache_dir}" <<-'EOF'
+		    select(.build_step == "finished")
+		    select(.build_time | type == "number")
+		    select(.bundled_npm_version == "6.14.12")
+		    select(.cache_status == "not-found")
+		    select(.has_cached_bower_components == false)
+		    select(.has_custom_cache_dirs == false)
+		    select(.has_procfile == false)
+		    select(.heroku_postbuild_script == "echo heroku-postbuild hook message")
+		    select(.heroku_prebuild_script == "echo heroku-prebuild hook message")
+		    select(.install_dependencies_time | type == "number")
+		    select(.install_node_binary_time | type == "number")
+		    select(.node_version == "v10.24.1")
+		    select(.node_version_eol == true)
+		    select(.node_version_major == 10)
+		    select(.node_version_request == "10.x")
+		    select(.npm_version == "6.14.12")
+		    select(.package_manager == "npm")
+		    select(.package_manager_version == "6.14.12")
+		    select(.prune_dev_dependencies_time | type == "number")
+		    select(.restore_cache_time | type == "number")
+		    select(.save_cache_time | type == "number")
+		    select(.skipped_prune == false)
+		    select(.use_npm_ci == false)
+	EOF
 }
-
 
 testNpmCiCaching() {
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  echo "http" > $env_dir/NPM_CONFIG_LOGLEVEL
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	echo "http" >"${env_dir}"/NPM_CONFIG_LOGLEVEL
 
-  compile "ci-caching" $cache_dir $env_dir
-  assertNotCaptured "Restoring cache"
-  assertCaptured "Caching build"
-  assertCaptured "- npm cache"
-  assertCaptured "npm http fetch GET"
-  assertCapturedSuccessWithWarnings
+	compile "ci-caching" "${cache_dir}" "${env_dir}"
+	assertNotCaptured "Restoring cache"
+	assertCaptured "Caching build"
+	assertCaptured "- npm cache"
+	assertCaptured "npm http fetch GET"
+	assertCapturedSuccessWithWarnings
 
-  compile "ci-caching" $cache_dir $env_dir
-  assertCaptured "Restoring cache"
-  assertCaptured "Caching build"
-  assertCaptured "- npm cache"
-  assertNotCaptured "npm http fetch GET"
-  assertCapturedSuccessWithWarnings
+	compile "ci-caching" "${cache_dir}" "${env_dir}"
+	assertCaptured "Restoring cache"
+	assertCaptured "Caching build"
+	assertCaptured "- npm cache"
+	assertNotCaptured "npm http fetch GET"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmCiCachingWhenUseNpmInstallIsTrue() {
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  echo "true" > $env_dir/USE_NPM_INSTALL
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}"/USE_NPM_INSTALL
 
-  compile "ci-caching" $cache_dir $env_dir
-  assertNotCaptured "Restoring cache"
-  assertCaptured "Caching build"
-  assertNotCaptured "- npm cache"
-  assertCaptured "- node_modules"
-  assertCapturedSuccessWithWarnings
+	compile "ci-caching" "${cache_dir}" "${env_dir}"
+	assertNotCaptured "Restoring cache"
+	assertCaptured "Caching build"
+	assertNotCaptured "- npm cache"
+	assertCaptured "- node_modules"
+	assertCapturedSuccessWithWarnings
 
-  compile "ci-caching" $cache_dir $env_dir
-  assertCaptured "Restoring cache"
-  assertCaptured "Caching build"
-  assertCaptured "- node_modules"
-  assertNotCaptured "- npm cache"
-  assertCapturedSuccessWithWarnings
+	compile "ci-caching" "${cache_dir}" "${env_dir}"
+	assertCaptured "Restoring cache"
+	assertCaptured "Caching build"
+	assertCaptured "- node_modules"
+	assertNotCaptured "- npm cache"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testNpmCiCachingWhenUseNpmInstallIsFalse() {
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  echo "http" > $env_dir/NPM_CONFIG_LOGLEVEL
-  echo "false" > $env_dir/USE_NPM_INSTALL
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	echo "http" >"${env_dir}"/NPM_CONFIG_LOGLEVEL
+	echo "false" >"${env_dir}"/USE_NPM_INSTALL
 
-  compile "ci-caching" $cache_dir $env_dir
-  assertNotCaptured "Restoring cache"
-  assertCaptured "Caching build"
-  assertCaptured "- npm cache"
-  assertCaptured "npm http fetch GET"
-  assertCapturedSuccessWithWarnings
+	compile "ci-caching" "${cache_dir}" "${env_dir}"
+	assertNotCaptured "Restoring cache"
+	assertCaptured "Caching build"
+	assertCaptured "- npm cache"
+	assertCaptured "npm http fetch GET"
+	assertCapturedSuccessWithWarnings
 
-  compile "ci-caching" $cache_dir $env_dir
-  assertCaptured "Restoring cache"
-  assertCaptured "Caching build"
-  assertCaptured "- npm cache"
-  assertNotCaptured "npm http fetch GET"
-  assertCapturedSuccessWithWarnings
+	compile "ci-caching" "${cache_dir}" "${env_dir}"
+	assertCaptured "Restoring cache"
+	assertCaptured "Caching build"
+	assertCaptured "- npm cache"
+	assertNotCaptured "npm http fetch GET"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testUseNpm10() {
-  compile "use-npm-v10"
-  assertNotCaptured "Detected package-lock.json: defaulting npm to version 5.x.x"
-  assertCaptured "Using default npm version: 10"
-  assertCapturedSuccessWithWarnings
+	compile "use-npm-v10"
+	assertNotCaptured "Detected package-lock.json: defaulting npm to version 5.x.x"
+	assertCaptured "Using default npm version: 10"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testErrorNpmLockfileOutOfSync() {
-  cache_dir=$(mktmpdir)
-  compile "error-npm-lockfile-out-of-sync" "${cache_dir}"
-  assertCapturedStderr "npm lockfile is not in sync"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "npm-lockfile-out-of-sync"
+	cache_dir=$(mktmpdir)
+	compile "error-npm-lockfile-out-of-sync" "${cache_dir}"
+	assertCapturedStderr "npm lockfile is not in sync"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "npm-lockfile-out-of-sync"
 }
-
 
 testErrorNpmGitDependency() {
-  cache_dir=$(mktmpdir)
-  compile "error-npm-git-error" "${cache_dir}"
-  assertCapturedStderr "npm Git dependency error (code 128)"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "npm-install-git-dependency"
+	cache_dir=$(mktmpdir)
+	compile "error-npm-git-error" "${cache_dir}"
+	assertCapturedStderr "npm Git dependency error (code 128)"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "npm-install-git-dependency"
 }
 
-
 testErrorPeerDependencyConflict() {
-  cache_dir=$(mktmpdir)
-  compile "error-npm-peer-dependency-conflict" "${cache_dir}"
-  assertCapturedStderr "Conflict detected in requested npm dependencies"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "npm-peer-dependency-conflict"
+	cache_dir=$(mktmpdir)
+	compile "error-npm-peer-dependency-conflict" "${cache_dir}"
+	assertCapturedStderr "Conflict detected in requested npm dependencies"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "npm-peer-dependency-conflict"
 }
 
 # TODO: Investigate this recently failing test. The error state was difficult to model
@@ -443,6 +418,5 @@ testErrorPeerDependencyConflict() {
 #   compile "error-prune" "${cache_dir}"
 #   assertMetricEqualsString "${cache_dir}" "failure" "unknown-prune-dependencies-error"
 # }
-
 
 source "$(pwd)"/test/shunit2

--- a/test/run-pnpm
+++ b/test/run-pnpm
@@ -1,185 +1,179 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2312 # test harness: dynamically-sourced fixtures resolve at runtime; masked command-substitution exits are inherent to a non-error-propagating test runner
+# shellcheck disable=SC2154 # deferred: test-fixture globals triaged out of the mechanical migration
 
 source "$(pwd)"/test/run-helpers
 
 testPnpmBuildMetaData() {
-  cache_dir=$(mktmpdir)
-  compile "pnpm-8.15.5" "${cache_dir}"
-  assertMetrics "${cache_dir}" <<-'EOF'
-    select(.build_step == "finished")
-    select(.build_time | type == "number")
-    select(.bundled_npm_version | type == "string")
-    select(.cache_status == "not-found")
-    select(.has_cached_bower_components == false)
-    select(.has_custom_cache_dirs == false)
-    select(.has_procfile == false)
-    select(.install_dependencies_time | type == "number")
-    select(.install_node_binary_time | type == "number")
-    select(.install_pnpm_binary_time | type == "number")
-    select(.node_version | test("v22.\\d+\\.\\d+"))
-    select(.node_version_eol == false)
-    select(.node_version_major == 22)
-    select(.node_version_request == "22.x")
-    select(.package_manager == "pnpm")
-    select(.package_manager_request == "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589")
-    select(.package_manager_version == "8.15.5")
-    select(.pnpm_version == "8.15.5")
-    select(.prune_dev_dependencies_time | type == "number")
-    select(.restore_cache_time | type == "number")
-    select(.save_cache_time | type == "number")
-    select(.skipped_prune == false)
-    select(.start_script == "node foo.js")
-EOF
+	cache_dir=$(mktmpdir)
+	compile "pnpm-8.15.5" "${cache_dir}"
+	assertMetrics "${cache_dir}" <<-'EOF'
+		    select(.build_step == "finished")
+		    select(.build_time | type == "number")
+		    select(.bundled_npm_version | type == "string")
+		    select(.cache_status == "not-found")
+		    select(.has_cached_bower_components == false)
+		    select(.has_custom_cache_dirs == false)
+		    select(.has_procfile == false)
+		    select(.install_dependencies_time | type == "number")
+		    select(.install_node_binary_time | type == "number")
+		    select(.install_pnpm_binary_time | type == "number")
+		    select(.node_version | test("v22.\\d+\\.\\d+"))
+		    select(.node_version_eol == false)
+		    select(.node_version_major == 22)
+		    select(.node_version_request == "22.x")
+		    select(.package_manager == "pnpm")
+		    select(.package_manager_request == "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589")
+		    select(.package_manager_version == "8.15.5")
+		    select(.pnpm_version == "8.15.5")
+		    select(.prune_dev_dependencies_time | type == "number")
+		    select(.restore_cache_time | type == "number")
+		    select(.save_cache_time | type == "number")
+		    select(.skipped_prune == false)
+		    select(.start_script == "node foo.js")
+	EOF
 }
-
 
 testPnpmWithCustomCache() {
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  echo "ndjson" > "$env_dir/PNPM_INSTALL_REPORTER"
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	echo "ndjson" >"${env_dir}/PNPM_INSTALL_REPORTER"
 
-  compile "pnpm-custom-cache" "$cache_dir" "$env_dir"
-  assertCaptured "pnpm:fetching-progress"
-  assertCaptured "Saving cacheDirectories (package.json):"
-  assertCaptured "- node_modules (skipping because pnpm is used)"
-  assertCaptured "- data"
-  assertCaptured "- pnpm store (included because pnpm is used)"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-custom-cache" "${cache_dir}" "${env_dir}"
+	assertCaptured "pnpm:fetching-progress"
+	assertCaptured "Saving cacheDirectories (package.json):"
+	assertCaptured "- node_modules (skipping because pnpm is used)"
+	assertCaptured "- data"
+	assertCaptured "- pnpm store (included because pnpm is used)"
+	assertCapturedSuccessWithWarnings
 
-  compile "pnpm-custom-cache" "$cache_dir" "$env_dir"
-  assertCaptured " Loading from cacheDirectories (package.json):"
-  assertCaptured "- node_modules (skipping because pnpm is used)"
-  assertCaptured "- data (exists - skipping)"
-  assertCaptured "- pnpm store (included because pnpm is used)"
-  assertNotCaptured "pnpm:fetching-progress"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-custom-cache" "${cache_dir}" "${env_dir}"
+	assertCaptured " Loading from cacheDirectories (package.json):"
+	assertCaptured "- node_modules (skipping because pnpm is used)"
+	assertCaptured "- data (exists - skipping)"
+	assertCaptured "- pnpm store (included because pnpm is used)"
+	assertNotCaptured "pnpm:fetching-progress"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpm7Pnp() {
-  build_dir=$(mktmpdir)
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  compile "pnpm-7-pnp" "$cache_dir" "$env_dir" "$build_dir"
-  assertCaptured "engines.pnpm (package.json):   unspecified (use default)"
-  assertCaptured "packageManager (package.json): pnpm@7.32.3"
-  assertCaptured "Downloading and installing pnpm (7.32.3)"
-  assertCaptured "Using pnpm 7.32.3"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCaptured "+ dotenv"
-  assertCaptured "- dotenv"
-  assertCaptured "heroku-prebuild"
-  assertCaptured "heroku-build"
-  assertCaptured "heroku-cleanup"
-  assertCapturedSuccessWithWarnings
-  assertFileExists "$build_dir/.heroku/node/bin/pnpm"
+	build_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	compile "pnpm-7-pnp" "${cache_dir}" "${env_dir}" "${build_dir}"
+	assertCaptured "engines.pnpm (package.json):   unspecified (use default)"
+	assertCaptured "packageManager (package.json): pnpm@7.32.3"
+	assertCaptured "Downloading and installing pnpm (7.32.3)"
+	assertCaptured "Using pnpm 7.32.3"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCaptured "+ dotenv"
+	assertCaptured "- dotenv"
+	assertCaptured "heroku-prebuild"
+	assertCaptured "heroku-build"
+	assertCaptured "heroku-cleanup"
+	assertCapturedSuccessWithWarnings
+	assertFileExists "${build_dir}/.heroku/node/bin/pnpm"
 }
-
 
 testPnpm8Hoist() {
-  compile "pnpm-8-hoist"
-  assertCaptured "engines.pnpm (package.json):   unspecified (use default)"
-  assertCaptured "packageManager (package.json): pnpm@8.4.0"
-  assertCaptured "Downloading and installing pnpm (8.4.0)"
-  assertCaptured "Using pnpm 8.4.0"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCapturedSuccess
+	compile "pnpm-8-hoist"
+	assertCaptured "engines.pnpm (package.json):   unspecified (use default)"
+	assertCaptured "packageManager (package.json): pnpm@8.4.0"
+	assertCaptured "Downloading and installing pnpm (8.4.0)"
+	assertCaptured "Using pnpm 8.4.0"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCapturedSuccess
 }
-
 
 testPnpm8Nuxt() {
-  compile "pnpm-8-nuxt"
-  assertCaptured "engines.pnpm (package.json):   unspecified (use default)"
-  assertCaptured "packageManager (package.json): pnpm@8.11.0"
-  assertCaptured "Downloading and installing pnpm (8.11.0)"
-  assertCaptured "Using pnpm 8.11.0"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCaptured "> nuxt prepare"
-  assertCaptured "> pnpm-8-nuxt@ build"
-  assertCaptured "> nuxt build"
-  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
+	compile "pnpm-8-nuxt"
+	assertCaptured "engines.pnpm (package.json):   unspecified (use default)"
+	assertCaptured "packageManager (package.json): pnpm@8.11.0"
+	assertCaptured "Downloading and installing pnpm (8.11.0)"
+	assertCaptured "Using pnpm 8.11.0"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCaptured "> nuxt prepare"
+	assertCaptured "> pnpm-8-nuxt@ build"
+	assertCaptured "> nuxt build"
+	assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
 }
-
 
 testPnpmEngine() {
-  build_dir=$(mktmpdir)
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  compile "pnpm-engine" "$cache_dir" "$env_dir" "$build_dir"
-  assertCaptured "engines.pnpm (package.json):   8.x"
-  assertCaptured "Downloading and installing pnpm (8.x)"
-  assertCaptured "Using pnpm 8"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCapturedSuccess
-  assertFileExists "$build_dir/.heroku/node/bin/pnpm"
+	build_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	compile "pnpm-engine" "${cache_dir}" "${env_dir}" "${build_dir}"
+	assertCaptured "engines.pnpm (package.json):   8.x"
+	assertCaptured "Downloading and installing pnpm (8.x)"
+	assertCaptured "Using pnpm 8"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCapturedSuccess
+	assertFileExists "${build_dir}/.heroku/node/bin/pnpm"
 }
-
 
 testPnpmWithCorepackAndEngine() {
-  compile "pnpm-with-corepack-and-engine"
-  assertCaptured "engines.pnpm (package.json):   8.x"
-  assertCaptured "packageManager (package.json): pnpm@8.4.0"
-  assertCapturedStderr "Multiple pnpm versions declared"
-  assertCapturedStderr "The package.json file indicates the target version of pnpm to install in two fields:"
-  assertCapturedStderr '- "packageManager": "pnpm@8.4.0"'
-  assertCapturedStderr '- "engines.pnpm": "8.x"'
-  assertCapturedStderr 'If both fields are present, then "packageManager" will take precedence and "pnpm@8.4.0" will be installed.'
-  assertCapturedStderr "To ensure we install the version of pnpm you want, remove one of these fields."
-  assertCaptured "Downloading and installing pnpm (8.4.0)"
-  assertCaptured "Using pnpm 8.4.0"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-with-corepack-and-engine"
+	assertCaptured "engines.pnpm (package.json):   8.x"
+	assertCaptured "packageManager (package.json): pnpm@8.4.0"
+	assertCapturedStderr "Multiple pnpm versions declared"
+	assertCapturedStderr "The package.json file indicates the target version of pnpm to install in two fields:"
+	assertCapturedStderr '- "packageManager": "pnpm@8.4.0"'
+	assertCapturedStderr '- "engines.pnpm": "8.x"'
+	assertCapturedStderr 'If both fields are present, then "packageManager" will take precedence and "pnpm@8.4.0" will be installed.'
+	assertCapturedStderr "To ensure we install the version of pnpm you want, remove one of these fields."
+	assertCaptured "Downloading and installing pnpm (8.4.0)"
+	assertCaptured "Using pnpm 8.4.0"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpmStorePruning() {
-  default_counter_value="40"
-  cache_dir=$(mktmpdir)
+	default_counter_value="40"
+	cache_dir=$(mktmpdir)
 
-  # initial state, no counter exists
-  compile "pnpm-7-pnp" "$cache_dir"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertNotCaptured "Cleaning up pnpm store"
-  assertCapturedSuccessWithWarnings
-  counter=$(<"$cache_dir/pnpm_prune_store_counter")
-  assertEquals "Expected pnpm prune store counter to be $(( default_counter_value - 1 )); was <${counter}>" "$(( default_counter_value - 1 ))" "${counter}"
+	# initial state, no counter exists
+	compile "pnpm-7-pnp" "${cache_dir}"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertNotCaptured "Cleaning up pnpm store"
+	assertCapturedSuccessWithWarnings
+	counter=$(<"${cache_dir}/pnpm_prune_store_counter")
+	assertEquals "Expected pnpm prune store counter to be $((default_counter_value - 1)); was <${counter}>" "$((default_counter_value - 1))" "${counter}"
 
-  # set the counter to right before it triggers the store to be pruned
-  echo "1" > "$cache_dir/pnpm_prune_store_counter"
-  compile "pnpm-7-pnp" "$cache_dir"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertNotCaptured "Cleaning up pnpm store"
-  assertCapturedSuccessWithWarnings
-  counter=$(<"$cache_dir/pnpm_prune_store_counter")
-  assertEquals "Expected pnpm prune store counter to be 0; was <${counter}>" "0" "${counter}"
+	# set the counter to right before it triggers the store to be pruned
+	echo "1" >"${cache_dir}/pnpm_prune_store_counter"
+	compile "pnpm-7-pnp" "${cache_dir}"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertNotCaptured "Cleaning up pnpm store"
+	assertCapturedSuccessWithWarnings
+	counter=$(<"${cache_dir}/pnpm_prune_store_counter")
+	assertEquals "Expected pnpm prune store counter to be 0; was <${counter}>" "0" "${counter}"
 
-  # the store should be pruned on the next build and counter reset
-  compile "pnpm-7-pnp" "$cache_dir"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCaptured "Cleaning up pnpm store"
-  assertCapturedSuccessWithWarnings
-  counter=$(<"$cache_dir/pnpm_prune_store_counter")
-  assertEquals "Expected pnpm prune store counter to be $default_counter_value; was <${counter}>" "$default_counter_value" "${counter}"
+	# the store should be pruned on the next build and counter reset
+	compile "pnpm-7-pnp" "${cache_dir}"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCaptured "Cleaning up pnpm store"
+	assertCapturedSuccessWithWarnings
+	counter=$(<"${cache_dir}/pnpm_prune_store_counter")
+	assertEquals "Expected pnpm prune store counter to be ${default_counter_value}; was <${counter}>" "${default_counter_value}" "${counter}"
 
-  # ensure the cache can't get into a bad state (negative counter) and it resets to the initial state
-  echo "-1" > "$cache_dir/pnpm_prune_store_counter"
-  compile "pnpm-7-pnp" "$cache_dir"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertNotCaptured "Cleaning up pnpm store"
-  assertCapturedSuccessWithWarnings
-  counter=$(<"$cache_dir/pnpm_prune_store_counter")
-  assertEquals "Expected pnpm prune store counter to be $(( default_counter_value - 1 )); was <${counter}>" "$(( default_counter_value - 1 ))" "${counter}"
+	# ensure the cache can't get into a bad state (negative counter) and it resets to the initial state
+	echo "-1" >"${cache_dir}/pnpm_prune_store_counter"
+	compile "pnpm-7-pnp" "${cache_dir}"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertNotCaptured "Cleaning up pnpm store"
+	assertCapturedSuccessWithWarnings
+	counter=$(<"${cache_dir}/pnpm_prune_store_counter")
+	assertEquals "Expected pnpm prune store counter to be $((default_counter_value - 1)); was <${counter}>" "$((default_counter_value - 1))" "${counter}"
 
-  # ensure the cache can't get into a bad state (non-integer counter) and it resets to the initial state
-  echo "" > "$cache_dir/pnpm_prune_store_counter"
-  compile "pnpm-7-pnp" "$cache_dir"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertNotCaptured "Cleaning up pnpm store"
-  assertCapturedSuccessWithWarnings
-  counter=$(<"$cache_dir/pnpm_prune_store_counter")
-  assertEquals "Expected pnpm prune store counter to be $(( default_counter_value - 1 )); was <${counter}>" "$(( default_counter_value - 1 ))" "${counter}"
+	# ensure the cache can't get into a bad state (non-integer counter) and it resets to the initial state
+	echo "" >"${cache_dir}/pnpm_prune_store_counter"
+	compile "pnpm-7-pnp" "${cache_dir}"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertNotCaptured "Cleaning up pnpm store"
+	assertCapturedSuccessWithWarnings
+	counter=$(<"${cache_dir}/pnpm_prune_store_counter")
+	assertEquals "Expected pnpm prune store counter to be $((default_counter_value - 1)); was <${counter}>" "$((default_counter_value - 1))" "${counter}"
 }
-
 
 # Regression test: when a project has no dependencies, `pnpm install` does not
 # create the content-addressable file directory (e.g. `<store>/v3/files`) under
@@ -191,216 +185,202 @@ testPnpmStorePruning() {
 # into a smoke test and stop guarding against regressions in the
 # lib/dependencies.sh workaround.
 testPnpmStorePruneWithEmptyStore() {
-  cache_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
 
-  # force the next compile to enter the prune branch
-  mkdir -p "$cache_dir"
-  echo "0" > "$cache_dir/pnpm_prune_store_counter"
+	# force the next compile to enter the prune branch
+	mkdir -p "${cache_dir}"
+	echo "0" >"${cache_dir}/pnpm_prune_store_counter"
 
-  compile "pnpm-empty-deps" "$cache_dir"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCaptured "Cleaning up pnpm store"
-  assertNotCaptured "ENOENT"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-empty-deps" "${cache_dir}"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCaptured "Cleaning up pnpm store"
+	assertNotCaptured "ENOENT"
+	assertCapturedSuccessWithWarnings
 
-  # the counter should still advance past 0 after the benign ENOENT
-  counter=$(<"$cache_dir/pnpm_prune_store_counter")
-  assertNotEquals "Expected pnpm prune store counter to no longer be 0; was <${counter}>" "0" "${counter}"
+	# the counter should still advance past 0 after the benign ENOENT
+	counter=$(<"${cache_dir}/pnpm_prune_store_counter")
+	assertNotEquals "Expected pnpm prune store counter to no longer be 0; was <${counter}>" "0" "${counter}"
 }
-
 
 testPnpmCacheSimple() {
-  cache_dir=$(mktmpdir)
-  compile "pnpm-7-pnp" "$cache_dir"
-  assertNotCaptured "Restoring cache"
-  assertCaptured "- pnpm cache"
-  assertCapturedSuccessWithWarnings
+	cache_dir=$(mktmpdir)
+	compile "pnpm-7-pnp" "${cache_dir}"
+	assertNotCaptured "Restoring cache"
+	assertCaptured "- pnpm cache"
+	assertCapturedSuccessWithWarnings
 
-  compile "pnpm-7-pnp" "$cache_dir"
-  assertCaptured "Restoring cache"
-  assertCaptured "- pnpm cache"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-7-pnp" "${cache_dir}"
+	assertCaptured "Restoring cache"
+	assertCaptured "- pnpm cache"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpmCacheComplex() {
-  cache_dir=$(mktmpdir)
-  compile "pnpm-8-nuxt" "$cache_dir"
-  assertNotCaptured "Restoring cache"
-  assertCaptured "- pnpm cache"
-  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
+	cache_dir=$(mktmpdir)
+	compile "pnpm-8-nuxt" "${cache_dir}"
+	assertNotCaptured "Restoring cache"
+	assertCaptured "- pnpm cache"
+	assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
 
-  compile "pnpm-8-nuxt" "$cache_dir"
-  assertCaptured "Restoring cache"
-  assertCaptured "- pnpm cache"
-  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
+	compile "pnpm-8-nuxt" "${cache_dir}"
+	assertCaptured "Restoring cache"
+	assertCaptured "- pnpm cache"
+	assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
 }
-
 
 testPnpm10StoreDirExport() {
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  pnpm_config_cache="${cache_dir}/pnpm-store"
-  echo "$pnpm_config_cache" > "$env_dir/PNPM_CONFIG_CACHE"
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	pnpm_config_cache="${cache_dir}/pnpm-store"
+	echo "${pnpm_config_cache}" >"${env_dir}/PNPM_CONFIG_CACHE"
 
-  compile "pnpm-10" "$cache_dir" "$env_dir"
+	compile "pnpm-10" "${cache_dir}" "${env_dir}"
 
-  assertFileContains "export npm_config_store_dir=\"${pnpm_config_cache}\"" "${bp_dir}/export"
-  assertFileNotContains "export pnpm_config_store_dir=" "${bp_dir}/export"
-  actual_store_dir=$(source "${bp_dir}/export" && cd "${compile_dir}" && pnpm config get store-dir)
-  assertEquals "$pnpm_config_cache" "$actual_store_dir"
-  assertNotCaptured "pnpm store cache may not work"
-  assertCapturedSuccessWithWarnings
+	assertFileContains "export npm_config_store_dir=\"${pnpm_config_cache}\"" "${bp_dir}/export"
+	assertFileNotContains "export pnpm_config_store_dir=" "${bp_dir}/export"
+	actual_store_dir=$(source "${bp_dir}/export" && cd "${compile_dir}" && pnpm config get store-dir)
+	assertEquals "${pnpm_config_cache}" "${actual_store_dir}"
+	assertNotCaptured "pnpm store cache may not work"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpm11StoreDirExport() {
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  pnpm_config_cache="${cache_dir}/pnpm-store"
-  echo "$pnpm_config_cache" > "$env_dir/PNPM_CONFIG_CACHE"
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	pnpm_config_cache="${cache_dir}/pnpm-store"
+	echo "${pnpm_config_cache}" >"${env_dir}/PNPM_CONFIG_CACHE"
 
-  compile "pnpm-11" "$cache_dir" "$env_dir"
+	compile "pnpm-11" "${cache_dir}" "${env_dir}"
 
-  assertFileContains "export pnpm_config_store_dir=\"${pnpm_config_cache}\"" "${bp_dir}/export"
-  assertFileNotContains "export npm_config_store_dir=" "${bp_dir}/export"
-  actual_store_dir=$(source "${bp_dir}/export" && cd "${compile_dir}" && pnpm config get store-dir)
-  assertEquals "$pnpm_config_cache" "$actual_store_dir"
-  assertNotCaptured "pnpm store cache may not work"
-  assertCapturedSuccessWithWarnings
+	assertFileContains "export pnpm_config_store_dir=\"${pnpm_config_cache}\"" "${bp_dir}/export"
+	assertFileNotContains "export npm_config_store_dir=" "${bp_dir}/export"
+	actual_store_dir=$(source "${bp_dir}/export" && cd "${compile_dir}" && pnpm config get store-dir)
+	assertEquals "${pnpm_config_cache}" "${actual_store_dir}"
+	assertNotCaptured "pnpm store cache may not work"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpmWithNoPackageManagerEntry() {
-  compile "pnpm-unknown-version"
-  assertCaptured "Downloading and installing pnpm (latest)"
-  assertCaptured "Using pnpm"
-  assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
-  assertCapturedStderr "Default pnpm version used"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-unknown-version"
+	assertCaptured "Downloading and installing pnpm (latest)"
+	assertCaptured "Using pnpm"
+	assertCaptured "Running 'pnpm install' with pnpm-lock.yaml"
+	assertCapturedStderr "Default pnpm version used"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpmSafePruningSupport() {
-  # no pre/post install script is safe to prune (<8.15.6)
-  compile "pnpm-8.15.5"
-  assertCaptured "- dotenv 16.4.5"
-  assertCapturedSuccess
+	# no pre/post install script is safe to prune (<8.15.6)
+	compile "pnpm-8.15.5"
+	assertCaptured "- dotenv 16.4.5"
+	assertCapturedSuccess
 
-  # a pre/post install script is not safe to prune (<8.15.6)
-  compile "pnpm-8.15.5-with-pre-post-install"
-  assertNotCaptured "- dotenv 16.4.5"
-  assertCapturedStderr "Pruning skipped due to presence of lifecycle scripts"
-  assertCapturedTimes 1 "'pnpm:devPreinstall_0'"
-  assertCapturedTimes 1 "'preinstall_1'"
-  assertCapturedTimes 1 "'install_2'"
-  assertCapturedTimes 1 "'postinstall_3'"
-  assertCapturedTimes 0 "'prepublish_4'"
-  assertCapturedTimes 0 "'preprepare_5'"
-  assertCapturedTimes 1 "'prepare_6'"
-  assertCapturedTimes 0 "'postprepare_7'"
-  assertCapturedSuccessWithWarnings
+	# a pre/post install script is not safe to prune (<8.15.6)
+	compile "pnpm-8.15.5-with-pre-post-install"
+	assertNotCaptured "- dotenv 16.4.5"
+	assertCapturedStderr "Pruning skipped due to presence of lifecycle scripts"
+	assertCapturedTimes 1 "'pnpm:devPreinstall_0'"
+	assertCapturedTimes 1 "'preinstall_1'"
+	assertCapturedTimes 1 "'install_2'"
+	assertCapturedTimes 1 "'postinstall_3'"
+	assertCapturedTimes 0 "'prepublish_4'"
+	assertCapturedTimes 0 "'preprepare_5'"
+	assertCapturedTimes 1 "'prepare_6'"
+	assertCapturedTimes 0 "'postprepare_7'"
+	assertCapturedSuccessWithWarnings
 
-  # a pre/post install script is safe to prune (>=8.15.6)
-  compile "pnpm-8.15.6-with-pre-post-install"
-  assertCaptured "- dotenv 16.4.5"
-  assertCapturedTimes 1 "'pnpm:devPreinstall_0'"
-  assertCapturedTimes 1 "'preinstall_1'"
-  assertCapturedTimes 1 "'install_2'"
-  assertCapturedTimes 1 "'postinstall_3'"
-  assertCapturedTimes 0 "'prepublish_4'"
-  assertCapturedTimes 0 "'preprepare_5'"
-  assertCapturedTimes 1 "'prepare_6'"
-  assertCapturedTimes 0 "'postprepare_7'"
-  assertCapturedSuccess
+	# a pre/post install script is safe to prune (>=8.15.6)
+	compile "pnpm-8.15.6-with-pre-post-install"
+	assertCaptured "- dotenv 16.4.5"
+	assertCapturedTimes 1 "'pnpm:devPreinstall_0'"
+	assertCapturedTimes 1 "'preinstall_1'"
+	assertCapturedTimes 1 "'install_2'"
+	assertCapturedTimes 1 "'postinstall_3'"
+	assertCapturedTimes 0 "'prepublish_4'"
+	assertCapturedTimes 0 "'preprepare_5'"
+	assertCapturedTimes 1 "'prepare_6'"
+	assertCapturedTimes 0 "'postprepare_7'"
+	assertCapturedSuccess
 }
-
 
 testPnpmSkipPruning() {
-  cache_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
 
-  # skip pruning in test environment
-  env_dir=$(mktmpdir)
-  echo "test" > "$env_dir/NODE_ENV"
-  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
-  assertCaptured "Pruning devDependencies"
-  assertCaptured "Skipping because NODE_ENV is 'test'"
-  assertCapturedSuccess
+	# skip pruning in test environment
+	env_dir=$(mktmpdir)
+	echo "test" >"${env_dir}/NODE_ENV"
+	compile "pnpm-8.15.5" "${cache_dir}" "${env_dir}"
+	assertCaptured "Pruning devDependencies"
+	assertCaptured "Skipping because NODE_ENV is 'test'"
+	assertCapturedSuccess
 
-  # skip pruning in non-production environment
-  env_dir=$(mktmpdir)
-  echo "development" > "$env_dir/NODE_ENV"
-  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
-  assertCaptured "Pruning devDependencies"
-  assertCaptured "Skipping because NODE_ENV is not 'production'"
-  assertCapturedSuccess
+	# skip pruning in non-production environment
+	env_dir=$(mktmpdir)
+	echo "development" >"${env_dir}/NODE_ENV"
+	compile "pnpm-8.15.5" "${cache_dir}" "${env_dir}"
+	assertCaptured "Pruning devDependencies"
+	assertCaptured "Skipping because NODE_ENV is not 'production'"
+	assertCapturedSuccess
 
-  # skip pruning if explicitly configured to do so
-  env_dir=$(mktmpdir)
-  echo "true" > "$env_dir/PNPM_SKIP_PRUNING"
-  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
-  assertCaptured "Pruning devDependencies"
-  assertCaptured "Skipping because PNPM_SKIP_PRUNING is 'true'"
-  assertCapturedSuccess
+	# skip pruning if explicitly configured to do so
+	env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}/PNPM_SKIP_PRUNING"
+	compile "pnpm-8.15.5" "${cache_dir}" "${env_dir}"
+	assertCaptured "Pruning devDependencies"
+	assertCaptured "Skipping because PNPM_SKIP_PRUNING is 'true'"
+	assertCapturedSuccess
 
-  # otherwise, prune away
-  env_dir=$(mktmpdir)
-  echo "production" > "$env_dir/NODE_ENV"
-  echo "false" > "$env_dir/PNPM_SKIP_PRUNING"
-  compile "pnpm-8.15.5" "$cache_dir" "$env_dir"
-  assertCaptured "Pruning devDependencies"
-  assertCaptured "- dotenv 16.4.5"
-  assertCapturedSuccess
+	# otherwise, prune away
+	env_dir=$(mktmpdir)
+	echo "production" >"${env_dir}/NODE_ENV"
+	echo "false" >"${env_dir}/PNPM_SKIP_PRUNING"
+	compile "pnpm-8.15.5" "${cache_dir}" "${env_dir}"
+	assertCaptured "Pruning devDependencies"
+	assertCaptured "- dotenv 16.4.5"
+	assertCapturedSuccess
 }
-
 
 testPnpmWorkspaceBinaries() {
-  compile "pnpm-workspace-binaries"
-  assertCaptured "pnpm -r build"
-  assertCaptured "packages/one build$ next --version"
-  assertCaptured "packages/two build$ next --version"
-  assertCaptured "Next.js v15.0.0-rc.0"
-  assertCaptured "Scope: all 3 workspace projects"
-  assertCaptured "devDependencies: skipped because NODE_ENV is set to production"
-  assertNotCaptured "Skipping because pruning is not supported for pnpm workspaces"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-workspace-binaries"
+	assertCaptured "pnpm -r build"
+	assertCaptured "packages/one build$ next --version"
+	assertCaptured "packages/two build$ next --version"
+	assertCaptured "Next.js v15.0.0-rc.0"
+	assertCaptured "Scope: all 3 workspace projects"
+	assertCaptured "devDependencies: skipped because NODE_ENV is set to production"
+	assertNotCaptured "Skipping because pruning is not supported for pnpm workspaces"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpmWorkspaceFileExistsButNotConfiguredAsWorkspace() {
-  compile "pnpm-workspace-file-exists-but-not-configured-as-workspace"
-  assertCaptured "+ dotenv"
-  assertCaptured "- dotenv"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-workspace-file-exists-but-not-configured-as-workspace"
+	assertCaptured "+ dotenv"
+	assertCaptured "- dotenv"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpmWorkspacePruningWithLifecycleScriptInProject() {
-  compile "pnpm-workspace-with-lifecycle-script-project"
-  assertCapturedStderr "Pruning skipped due to presence of lifecycle scripts"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-workspace-with-lifecycle-script-project"
+	assertCapturedStderr "Pruning skipped due to presence of lifecycle scripts"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testPnpmWorkspacePruningWithLifecycleScriptInRoot() {
-  compile "pnpm-workspace-with-lifecycle-script-root"
-  assertCapturedStderr "Pruning skipped due to presence of lifecycle scripts"
-  assertCapturedSuccessWithWarnings
+	compile "pnpm-workspace-with-lifecycle-script-root"
+	assertCapturedStderr "Pruning skipped due to presence of lifecycle scripts"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testExecWithPnpmAndCorepack() {
-  compileTest "test-pnpm-with-corepack"
-  assertCaptured "pnpm test run"
-  assertCapturedSuccess
+	compileTest "test-pnpm-with-corepack"
+	assertCaptured "pnpm test run"
+	assertCapturedSuccess
 }
-
 
 testExecWithPnpmAndEngine() {
-  compileTest "test-pnpm-with-engine"
-  assertCaptured "pnpm test run"
-  assertCapturedSuccess
+	compileTest "test-pnpm-with-engine"
+	assertCaptured "pnpm test run"
+	assertCapturedSuccess
 }
-
 
 source "$(pwd)"/test/shunit2

--- a/test/run-yarn
+++ b/test/run-yarn
@@ -1,173 +1,159 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2312 # test harness: dynamically-sourced fixtures resolve at runtime; masked command-substitution exits are inherent to a non-error-propagating test runner
+# shellcheck disable=SC2010,SC2155 # deferred: style nits (ls|grep, split declare/assign) triaged out of the mechanical migration
 
 source "$(pwd)"/test/run-helpers
 
 testBuildScriptYarn() {
-  compile "build-script-yarn"
-  assertCaptured "Running build (yarn)"
-  assertCaptured "build hook message"
-  assertCapturedSuccessWithWarnings
+	compile "build-script-yarn"
+	assertCaptured "Running build (yarn)"
+	assertCaptured "build hook message"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testBuildFlagsWithYarn() {
-  cache=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	cache=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  echo "--prod --optimize" > $env_dir/NODE_BUILD_FLAGS
-  compile "build-script-yarn" $cache $env_dir
-  assertCaptured "Running build"
-  assertCaptured "Running with --prod --optimize flags"
-  assertCaptured "$ echo build hook message '--prod --optimize'"
-  assertCapturedSuccessWithWarnings
+	echo "--prod --optimize" >"${env_dir}"/NODE_BUILD_FLAGS
+	compile "build-script-yarn" "${cache}" "${env_dir}"
+	assertCaptured "Running build"
+	assertCaptured "Running with --prod --optimize flags"
+	assertCaptured "$ echo build hook message '--prod --optimize'"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testEmptyHerokuPostbuildWithYarn() {
-  compile "empty-heroku-postbuild-yarn"
-  assertCaptured "Running heroku-postbuild (yarn)"
-  assertNotCaptured "build hook message"
-  assertNotCaptured "Script must exist"
-  assertCapturedSuccessWithWarnings
+	compile "empty-heroku-postbuild-yarn"
+	assertCaptured "Running heroku-postbuild (yarn)"
+	assertNotCaptured "build hook message"
+	assertNotCaptured "Script must exist"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnRun() {
-  compile "yarn-run"
-  assertCaptured "Running heroku-postbuild (yarn)"
-  assertCaptured "foobar"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-run"
+	assertCaptured "Running heroku-postbuild (yarn)"
+	assertCaptured "foobar"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testCustomYarnBinaryURL() {
-  cache=$(mktmpdir)
-  env_dir=$(mktmpdir)
+	cache=$(mktmpdir)
+	env_dir=$(mktmpdir)
 
-  echo "testurl" > $env_dir/YARN_BINARY_URL
-  compile "yarn" $cache $env_dir
-  assertCaptured "from testurl"
+	echo "testurl" >"${env_dir}"/YARN_BINARY_URL
+	compile "yarn" "${cache}" "${env_dir}"
+	assertCaptured "from testurl"
 }
-
 
 testYarn() {
-  compile "yarn"
-  assertCaptured "installing yarn"
-  assertCaptured "Installing node modules (yarn.lock)"
-  assertNotCaptured "Installing node modules (package.json)"
-  assertCapturedSuccessWithWarnings
+	compile "yarn"
+	assertCaptured "installing yarn"
+	assertCaptured "Installing node modules (yarn.lock)"
+	assertNotCaptured "Installing node modules (package.json)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnCache() {
-  local cache=$(mktmpdir)
+	local cache=$(mktmpdir)
 
-  compile "yarn" $cache
+	compile "yarn" "${cache}"
 
-  # assert that devDependencies are cached
-  assertEquals "1" "$(ls -1 $cache/node/cache/yarn/v6 | grep -c debug | tr -d ' ')"
+	# assert that devDependencies are cached
+	assertEquals "1" "$(ls -1 "${cache}"/node/cache/yarn/v6 | grep -c debug | tr -d ' ')"
 
-  assertCapturedSuccessWithWarnings
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnNativeCache() {
-  local cache=$(mktmpdir)
+	local cache=$(mktmpdir)
 
-  compile "yarn-native-cache" $cache
-  # These will be created if yarn is using the directory for its cache
+	compile "yarn-native-cache" "${cache}"
+	# These will be created if yarn is using the directory for its cache
 
-  # Run this again with a cache
-  compile "yarn-native-cache" $cache
+	# Run this again with a cache
+	compile "yarn-native-cache" "${cache}"
 
-  assertCapturedSuccessWithWarnings
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnSemver() {
-  compile "yarn-semver"
-  assertCaptured "Downloading and installing yarn (~0.28"
-  assertCaptured "Installed yarn 0.28."
-  assertCapturedSuccessWithWarnings
+	compile "yarn-semver"
+	assertCaptured "Downloading and installing yarn (~0.28"
+	assertCaptured "Installed yarn 0.28."
+	assertCapturedSuccessWithWarnings
 }
-
 
 testOldYarn() {
-  compile "yarn-old-deprecated-version"
-  assertCaptured "Downloading and installing yarn (~0.16"
-  assertCaptured "Installed yarn 0.16."
-  # yarn's own progress output still lands on stdout via `tee` in the migrated install path
-  assertCaptured "error \`install\` has been replaced with \`add\`"
-  # The migrated failure message is emitted via output::error, which writes to stderr and
-  # bypasses the outer `output` pipe that shapes stdout.
-  assertCapturedStderr "Outdated Yarn version"
-  assertCapturedStderr "Your application is specifying a requirement on an old version of Yarn"
-  assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-yarn-version"
-  assertCapturedError
+	compile "yarn-old-deprecated-version"
+	assertCaptured "Downloading and installing yarn (~0.16"
+	assertCaptured "Installed yarn 0.16."
+	# yarn's own progress output still lands on stdout via `tee` in the migrated install path
+	assertCaptured "error \`install\` has been replaced with \`add\`"
+	# The migrated failure message is emitted via output::error, which writes to stderr and
+	# bypasses the outer `output` pipe that shapes stdout.
+	assertCapturedStderr "Outdated Yarn version"
+	assertCapturedStderr "Your application is specifying a requirement on an old version of Yarn"
+	assertCapturedStderr "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-yarn-version"
+	assertCapturedError
 }
-
 
 testYarnV1Semver() {
-  compile "yarn-v1-semver"
-  assertCaptured "Downloading and installing yarn (1."
-  assertCaptured "Installed yarn 1."
-  assertCapturedSuccessWithWarnings
+	compile "yarn-v1-semver"
+	assertCaptured "Downloading and installing yarn (1."
+	assertCaptured "Installed yarn 1."
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnV1SemverComplex() {
-  compile "yarn-v1-semver-complex"
-  assertCaptured "Downloading and installing yarn (>=1 <2)"
-  assertCaptured "Installed yarn 1."
-  assertCapturedSuccessWithWarnings
+	compile "yarn-v1-semver-complex"
+	assertCaptured "Downloading and installing yarn (>=1 <2)"
+	assertCaptured "Installed yarn 1."
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnV2SemverEdgeCase() {
-  compile "yarn-v2-semver-edge-case"
-  assertCaptured "Downloading and installing yarn (>=2 <3)"
-  assertCaptured "Using yarn 2."
-  assertCapturedSuccessWithWarnings
+	compile "yarn-v2-semver-edge-case"
+	assertCaptured "Downloading and installing yarn (>=2 <3)"
+	assertCaptured "Using yarn 2."
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnInvalid() {
-  compile "yarn-invalid"
-  assertCaptured "Downloading and installing yarn (0.171"
-  assertCaptured "npm error code ETARGET"
-  assertCapturedStderr "Unable to install yarn 0.171"
-  assertCapturedStderr "https://help.heroku.com/8MEL050H"
-  assertCapturedStderr "https://help.heroku.com/0ZIOF3ST"
-  assertCapturedError
+	compile "yarn-invalid"
+	assertCaptured "Downloading and installing yarn (0.171"
+	assertCaptured "npm error code ETARGET"
+	assertCapturedStderr "Unable to install yarn 0.171"
+	assertCapturedStderr "https://help.heroku.com/8MEL050H"
+	assertCapturedStderr "https://help.heroku.com/0ZIOF3ST"
+	assertCapturedError
 }
-
 
 testYarnSemverInvalid() {
-  compile "yarn-invalid-semver"
-  assertCaptured "Downloading and installing yarn (0.17q"
-  assertCaptured "npm error code ETARGET"
-  assertCapturedStderr "Unable to install yarn 0.17q"
-  assertCapturedStderr "https://help.heroku.com/8MEL050H"
-  assertCapturedStderr "https://help.heroku.com/0ZIOF3ST"
-  assertCapturedError
+	compile "yarn-invalid-semver"
+	assertCaptured "Downloading and installing yarn (0.17q"
+	assertCaptured "npm error code ETARGET"
+	assertCapturedStderr "Unable to install yarn 0.17q"
+	assertCapturedStderr "https://help.heroku.com/8MEL050H"
+	assertCapturedStderr "https://help.heroku.com/0ZIOF3ST"
+	assertCapturedError
 }
-
 
 testYarnEngine() {
-  build_dir=$(mktmpdir)
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  compile "yarn-engine" "$cache_dir" "$env_dir" "$build_dir"
-  assertCaptured "installing yarn (1.4.0)"
-  assertFileExists "$build_dir/.heroku/node/bin/yarn"
-  assertCapturedSuccessWithWarnings
+	build_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	compile "yarn-engine" "${cache_dir}" "${env_dir}" "${build_dir}"
+	assertCaptured "installing yarn (1.4.0)"
+	assertFileExists "${build_dir}/.heroku/node/bin/yarn"
+	assertCapturedSuccessWithWarnings
 }
 
-
 testYarnEngineWithMonorepo() {
-  compile "yarn-engine-with-monorepo"
-  assertCaptured "installing yarn (1.4.0)"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-engine-with-monorepo"
+	assertCaptured "installing yarn (1.4.0)"
+	assertCapturedSuccessWithWarnings
 }
 
 # If they specify a version of yarn inside package.json but
@@ -175,181 +161,168 @@ testYarnEngineWithMonorepo() {
 # though we will only install using yarn if a yarn.lock exists
 
 testYarnOnlyEngine() {
-  compile "yarn-only-engine"
-  assertCaptured "installing yarn (1.4.0)"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-only-engine"
+	assertCaptured "installing yarn (1.4.0)"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarnLockfileOutOfDate() {
-  compile "yarn-lockfile-out-of-date"
-  # yarn's own progress output still lands on stdout via `tee` in the migrated install path
-  assertCaptured "Your lockfile needs to be updated"
-  # The migrated failure message is emitted via output::error, which writes to stderr and
-  # bypasses the outer `output` pipe that shapes stdout.
-  assertCapturedStderr "Outdated Yarn lockfile"
-  assertCapturedError
+	compile "yarn-lockfile-out-of-date"
+	# yarn's own progress output still lands on stdout via `tee` in the migrated install path
+	assertCaptured "Your lockfile needs to be updated"
+	# The migrated failure message is emitted via output::error, which writes to stderr and
+	# bypasses the outer `output` pipe that shapes stdout.
+	assertCapturedStderr "Outdated Yarn lockfile"
+	assertCapturedError
 }
 
-
 testDevDependenciesInstalledYarn() {
-  compile "dependencies-yarn"
-  assertCaptured "lodash"
-  assertCaptured "Pruning devDependencies"
-  assertCapturedSuccessWithWarnings
+	compile "dependencies-yarn"
+	assertCaptured "lodash"
+	assertCaptured "Pruning devDependencies"
+	assertCapturedSuccessWithWarnings
 }
 
 # When NPM_CONFIG_PRODUCTION = false we should not prune the devDependencies
 
 testDevDepenenciesWithNoPruningYarn() {
-  env_dir=$(mktmpdir)
-  echo "false" > $env_dir/YARN_PRODUCTION
-  compile "dependencies-yarn" "$(mktmpdir)" $env_dir
-  assertCaptured "lodash"
-  assertCaptured "Skipping because YARN_PRODUCTION is 'false'"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "false" >"${env_dir}"/YARN_PRODUCTION
+	compile "dependencies-yarn" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "lodash"
+	assertCaptured "Skipping because YARN_PRODUCTION is 'false'"
+	assertCapturedSuccessWithWarnings
 
-  env_dir=$(mktmpdir)
-  echo "true" > $env_dir/YARN_PRODUCTION
-  compile "dependencies-yarn" "$(mktmpdir)" $env_dir
-  assertNotCaptured "lodash"
-  assertCaptured "Skipping because YARN_PRODUCTION is 'true'"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}"/YARN_PRODUCTION
+	compile "dependencies-yarn" "$(mktmpdir)" "${env_dir}"
+	assertNotCaptured "lodash"
+	assertCaptured "Skipping because YARN_PRODUCTION is 'true'"
+	assertCapturedSuccessWithWarnings
 }
 
 # When NODE_ENV != production we should not prune the devDependencies
 
 testNodeEnvTestDepenenciesYarn() {
-  env_dir=$(mktmpdir)
-  echo "not-production" > $env_dir/NODE_ENV
-  compile "dependencies-yarn" "$(mktmpdir)" $env_dir
-  assertCaptured "lodash"
-  assertCaptured "Skipping because NODE_ENV is not 'production'"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "not-production" >"${env_dir}"/NODE_ENV
+	compile "dependencies-yarn" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "lodash"
+	assertCaptured "Skipping because NODE_ENV is not 'production'"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testCIDependenciesYarn() {
-  compileTest "ci-dependencies-yarn"
-  assertCaptured "lodash"
-  assertCapturedSuccess
+	compileTest "ci-dependencies-yarn"
+	assertCaptured "lodash"
+	assertCapturedSuccess
 }
-
 
 testYarnBuildMetaData() {
-  cache_dir=$(mktmpdir)
-  compile "yarn" "${cache_dir}"
-  assertMetrics "${cache_dir}" <<-'EOF'
-    select(.build_step == "finished")
-    select(.build_time | type == "number")
-    select(.bundled_npm_version | test("11.\\d+.\\d+"))
-    select(.cache_status == "not-found")
-    select(.has_cached_bower_components == false)
-    select(.has_custom_cache_dirs == false)
-    select(.has_procfile == false)
-    select(.install_dependencies_time | type == "number")
-    select(.install_node_binary_time | type == "number")
-    select(.install_yarn_binary_time | type == "number")
-    select(.node_version | test("v24.\\d+\\.\\d+"))
-    select(.node_version_eol == false)
-    select(.node_version_major == 24)
-    select(.package_manager == "yarn")
-    select(.package_manager_version == "1.22.22")
-    select(.prune_dev_dependencies_time | type == "number")
-    select(.restore_cache_time | type == "number")
-    select(.save_cache_time | type == "number")
-    select(.skipped_prune == false)
-    select(.yarn_version == "1.22.22")
-    select(.yarn_version_request == "1.x")
-EOF
+	cache_dir=$(mktmpdir)
+	compile "yarn" "${cache_dir}"
+	assertMetrics "${cache_dir}" <<-'EOF'
+		    select(.build_step == "finished")
+		    select(.build_time | type == "number")
+		    select(.bundled_npm_version | test("11.\\d+.\\d+"))
+		    select(.cache_status == "not-found")
+		    select(.has_cached_bower_components == false)
+		    select(.has_custom_cache_dirs == false)
+		    select(.has_procfile == false)
+		    select(.install_dependencies_time | type == "number")
+		    select(.install_node_binary_time | type == "number")
+		    select(.install_yarn_binary_time | type == "number")
+		    select(.node_version | test("v24.\\d+\\.\\d+"))
+		    select(.node_version_eol == false)
+		    select(.node_version_major == 24)
+		    select(.package_manager == "yarn")
+		    select(.package_manager_version == "1.22.22")
+		    select(.prune_dev_dependencies_time | type == "number")
+		    select(.restore_cache_time | type == "number")
+		    select(.save_cache_time | type == "number")
+		    select(.skipped_prune == false)
+		    select(.yarn_version == "1.22.22")
+		    select(.yarn_version_request == "1.x")
+	EOF
 }
-
 
 testYarn2() {
-  compile "yarn-2"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
-  assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
+	assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn2WithPackageManager() {
-  compile "yarn-2-package-manager"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
-  assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2-package-manager"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
+	assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn2Engine() {
-  compile "yarn-2-engine"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
-  assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2-engine"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
+	assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn2WithYarn2SkipPruningFalse() {
-  env_dir=$(mktmpdir)
-  echo "false" > $env_dir/YARN2_SKIP_PRUNING
-  compile "yarn-2" "$(mktmpdir)" $env_dir
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
-  assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "false" >"${env_dir}"/YARN2_SKIP_PRUNING
+	compile "yarn-2" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "@types-node-npm-16.11.26-6163d95b7d-478d5c315f.zip appears to be unused - removing"
+	assertCaptured "uuid-npm-9.0.0-46c41e3e43-5a7f936a25.zip appears to be unused - removing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn2WithYarn2SkipPruningTrue() {
-  env_dir=$(mktmpdir)
-  echo "true" > $env_dir/YARN2_SKIP_PRUNING
-  compile "yarn-2" "$(mktmpdir)" $env_dir
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Skipping because YARN2_SKIP_PRUNING is 'true'"
-  assertNotCaptured "Running 'yarn heroku prune'"
-  assertCapturedSuccessWithWarnings
+	env_dir=$(mktmpdir)
+	echo "true" >"${env_dir}"/YARN2_SKIP_PRUNING
+	compile "yarn-2" "$(mktmpdir)" "${env_dir}"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Skipping because YARN2_SKIP_PRUNING is 'true'"
+	assertNotCaptured "Running 'yarn heroku prune'"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn2WithYarnProductionSetCapturesAndReportsError() {
-   env_dir=$(mktmpdir)
-   echo "false" > $env_dir/YARN_PRODUCTION
-   compile "yarn-2" "$(mktmpdir)" $env_dir
-   assertCapturedError "Unsupported Yarn configuration: YARN_PRODUCTION"
-   assertCapturedStderr "YARN2_SKIP_PRUNING=true"
- }
-
+	env_dir=$(mktmpdir)
+	echo "false" >"${env_dir}"/YARN_PRODUCTION
+	compile "yarn-2" "$(mktmpdir)" "${env_dir}"
+	assertCapturedError "Unsupported Yarn configuration: YARN_PRODUCTION"
+	assertCapturedStderr "YARN2_SKIP_PRUNING=true"
+}
 
 testYarn2WithNodeModules() {
-  compile "yarn-2-with-node-modules"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Caching build"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2-with-node-modules"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Caching build"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn2WithoutYarnCache() {
-  compile "yarn-2-without-cache"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2-without-cache"
+	assertCapturedSuccessWithWarnings
 }
 
-
 testYarn2WithoutWorkspaceModule() {
-  compile "yarn-2-without-workspace-plugin"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2-without-workspace-plugin"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCapturedSuccessWithWarnings
 }
 ###
 
@@ -357,16 +330,15 @@ testYarn2WithoutWorkspaceModule() {
 # Yarn 2 warnings
 
 testYarn2WithEngine() {
-  compile "yarn-2-with-engine"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2-with-engine"
+	assertCapturedSuccessWithWarnings
 }
 
-
 testYarn2WithNpmrcAndYarnrc() {
-  compile "yarn-2-with-invalid-rc-files"
-  assertCapturedStderr "There is an existing .npmrc file that will not be used."
-  assertCapturedStderr "There is an existing .yarnrc file that will not be used."
-  assertCapturedSuccessWithWarnings
+	compile "yarn-2-with-invalid-rc-files"
+	assertCapturedStderr "There is an existing .npmrc file that will not be used."
+	assertCapturedStderr "There is an existing .yarnrc file that will not be used."
+	assertCapturedSuccessWithWarnings
 }
 ###
 
@@ -374,23 +346,21 @@ testYarn2WithNpmrcAndYarnrc() {
 # Yarn 2 failures
 
 testYarn2WithoutYarnrcYml() {
-  compile "yarn-2-without-yarnrc-yml"
-  assertCapturedStderr "The 'yarnrc.yml' file is not found"
-  assertCapturedError
+	compile "yarn-2-without-yarnrc-yml"
+	assertCapturedStderr "The 'yarnrc.yml' file is not found"
+	assertCapturedError
 }
-
 
 testYarn2WithoutYarnPath() {
-  compile "yarn-2-without-yarn-path"
-  assertCapturedStderr "The 'yarnPath' could not be read from the 'yarnrc.yml' file"
-  assertCapturedError
+	compile "yarn-2-without-yarn-path"
+	assertCapturedStderr "The 'yarnPath' could not be read from the 'yarnrc.yml' file"
+	assertCapturedError
 }
 
-
 testYarn2WithoutYarnRelease() {
-  compile "yarn-2-without-yarn"
-  assertCapturedStderr "Yarn was not found"
-  assertCapturedError
+	compile "yarn-2-without-yarn"
+	assertCapturedStderr "Yarn was not found"
+	assertCapturedError
 }
 ###
 
@@ -398,142 +368,133 @@ testYarn2WithoutYarnRelease() {
 # Yarn 3 & 4 pruning plugin validation
 
 testYarn3() {
-  compile "yarn-3"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "@types-node-npm-16.11.26-6163d95b7d-57757caaba.zip appears to be unused - removing"
-  assertCaptured "uuid-npm-9.0.0-46c41e3e43-8dd2c83c43.zip appears to be unused - removing"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-3"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "@types-node-npm-16.11.26-6163d95b7d-57757caaba.zip appears to be unused - removing"
+	assertCaptured "uuid-npm-9.0.0-46c41e3e43-8dd2c83c43.zip appears to be unused - removing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn3WithPackageManager() {
-  compile "yarn-3-package-manager"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "@types-node-npm-16.11.26-6163d95b7d-57757caaba.zip appears to be unused - removing"
-  assertCaptured "uuid-npm-9.0.0-46c41e3e43-8dd2c83c43.zip appears to be unused - removing"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-3-package-manager"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "@types-node-npm-16.11.26-6163d95b7d-57757caaba.zip appears to be unused - removing"
+	assertCaptured "uuid-npm-9.0.0-46c41e3e43-8dd2c83c43.zip appears to be unused - removing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn3WithEngine() {
-  compile "yarn-3-engine"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "@types-node-npm-16.11.26-6163d95b7d-57757caaba.zip appears to be unused - removing"
-  assertCaptured "uuid-npm-9.0.0-46c41e3e43-8dd2c83c43.zip appears to be unused - removing"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-3-engine"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "@types-node-npm-16.11.26-6163d95b7d-57757caaba.zip appears to be unused - removing"
+	assertCaptured "uuid-npm-9.0.0-46c41e3e43-8dd2c83c43.zip appears to be unused - removing"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn4() {
-  compile "yarn-4"
-  assertCaptured "engines.yarn (package.json):   unspecified (use default)"
-  assertCaptured "packageManager (package.json): yarn@4.1.1"
-  assertCapturedStderr 'Yarn release script may conflict with "packageManager"'
-  assertCapturedStderr "The package.json file indicates the target version of Yarn to install with:"
-  assertCapturedStderr '- "packageManager": "yarn@4.1.1"'
-  assertCapturedStderr "But the .yarnrc.yml configuration indicates a vendored release of Yarn should be used with:"
-  assertCapturedStderr '- yarnPath: ".yarn/releases/yarn-4.0.0.cjs"'
-  assertCapturedStderr "This will cause the buildpack to install yarn@4.1.1 but, when running Yarn commands, the vendored release"
-  assertCapturedStderr 'at ".yarn/releases/yarn-4.0.0.cjs" will be executed instead.'
-  assertCapturedStderr "To ensure we install the version of Yarn you want, choose only one of the following actions:"
-  assertCapturedStderr '- Remove the "packageManager" field from package.json'
-  assertCapturedStderr '- Remove the "yarnPath" configuration from .yarnrc.yml and delete the vendored release at ".yarn/releases/yarn-4.0.0.cjs"'
-  assertCaptured "Using yarn 4.0.0"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-4"
+	assertCaptured "engines.yarn (package.json):   unspecified (use default)"
+	assertCaptured "packageManager (package.json): yarn@4.1.1"
+	assertCapturedStderr 'Yarn release script may conflict with "packageManager"'
+	assertCapturedStderr "The package.json file indicates the target version of Yarn to install with:"
+	assertCapturedStderr '- "packageManager": "yarn@4.1.1"'
+	assertCapturedStderr "But the .yarnrc.yml configuration indicates a vendored release of Yarn should be used with:"
+	assertCapturedStderr '- yarnPath: ".yarn/releases/yarn-4.0.0.cjs"'
+	assertCapturedStderr "This will cause the buildpack to install yarn@4.1.1 but, when running Yarn commands, the vendored release"
+	assertCapturedStderr 'at ".yarn/releases/yarn-4.0.0.cjs" will be executed instead.'
+	assertCapturedStderr "To ensure we install the version of Yarn you want, choose only one of the following actions:"
+	assertCapturedStderr '- Remove the "packageManager" field from package.json'
+	assertCapturedStderr '- Remove the "yarnPath" configuration from .yarnrc.yml and delete the vendored release at ".yarn/releases/yarn-4.0.0.cjs"'
+	assertCaptured "Using yarn 4.0.0"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn4WithEngine() {
-  compile "yarn-4-engine"
-  assertCaptured "engines.yarn (package.json):   4.1.1"
-  assertCaptured "Downloading and installing yarn (4.1.1)"
-  assertCaptured "Using yarn 4.1.1"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-4-engine"
+	assertCaptured "engines.yarn (package.json):   4.1.1"
+	assertCaptured "Downloading and installing yarn (4.1.1)"
+	assertCaptured "Using yarn 4.1.1"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
+	assertCapturedSuccessWithWarnings
 }
-
 
 testYarn4WithCorepackEnabled() {
-  build_dir=$(mktmpdir)
-  cache_dir=$(mktmpdir)
-  env_dir=$(mktmpdir)
-  compile "yarn-4-with-corepack" "$cache_dir" "$env_dir" "$build_dir"
-  assertCaptured "engines.yarn (package.json):   unspecified (use default)"
-  assertCaptured "packageManager (package.json): yarn@4.1.1"
-  assertCaptured "Downloading and installing yarn (4.1.1)"
-  assertCaptured "Using yarn 4.1.1"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
-  assertCapturedSuccessWithWarnings
-  assertFileExists "$build_dir/.heroku/node/bin/yarn"
+	build_dir=$(mktmpdir)
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	compile "yarn-4-with-corepack" "${cache_dir}" "${env_dir}" "${build_dir}"
+	assertCaptured "engines.yarn (package.json):   unspecified (use default)"
+	assertCaptured "packageManager (package.json): yarn@4.1.1"
+	assertCaptured "Downloading and installing yarn (4.1.1)"
+	assertCaptured "Using yarn 4.1.1"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
+	assertCapturedSuccessWithWarnings
+	assertFileExists "${build_dir}/.heroku/node/bin/yarn"
 }
 
-
 testYarn4WithCorepackAndEngine() {
-  compile "yarn-4-with-corepack-and-engine"
-  assertCaptured "engines.yarn (package.json):   4.1.1"
-  assertCaptured "packageManager (package.json): yarn@4.1.1"
-  assertCapturedStderr "Multiple Yarn versions declared"
-  assertCapturedStderr "The package.json file indicates the target version of Yarn to install in two fields:"
-  assertCapturedStderr '- "packageManager": "yarn@4.1.1"'
-  assertCapturedStderr '- "engines.yarn": "4.1.1"'
-  assertCapturedStderr 'If both fields are present, then "packageManager" will take precedence and "yarn@4.1.1" will be installed.'
-  assertCapturedStderr "To ensure we install the version of Yarn you want, remove one of these fields."
-  assertCaptured "Downloading and installing yarn (4.1.1)"
-  assertCaptured "Using yarn 4.1.1"
-  assertCaptured "Running 'yarn install' with yarn.lock"
-  assertCaptured "Build script check"
-  assertCaptured "Running 'yarn heroku prune'"
-  assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
-  assertCapturedSuccessWithWarnings
+	compile "yarn-4-with-corepack-and-engine"
+	assertCaptured "engines.yarn (package.json):   4.1.1"
+	assertCaptured "packageManager (package.json): yarn@4.1.1"
+	assertCapturedStderr "Multiple Yarn versions declared"
+	assertCapturedStderr "The package.json file indicates the target version of Yarn to install in two fields:"
+	assertCapturedStderr '- "packageManager": "yarn@4.1.1"'
+	assertCapturedStderr '- "engines.yarn": "4.1.1"'
+	assertCapturedStderr 'If both fields are present, then "packageManager" will take precedence and "yarn@4.1.1" will be installed.'
+	assertCapturedStderr "To ensure we install the version of Yarn you want, remove one of these fields."
+	assertCaptured "Downloading and installing yarn (4.1.1)"
+	assertCaptured "Using yarn 4.1.1"
+	assertCaptured "Running 'yarn install' with yarn.lock"
+	assertCaptured "Build script check"
+	assertCaptured "Running 'yarn heroku prune'"
+	assertCaptured "- @types/node@npm:16.11.26, uuid@npm:9.0.0"
+	assertCapturedSuccessWithWarnings
 }
 ###
 
-
 testExecWithYarnAndCorepack() {
-  compileTest "test-yarn-with-corepack"
-  assertCaptured "yarn test run"
-  assertCapturedSuccess
+	compileTest "test-yarn-with-corepack"
+	assertCaptured "yarn test run"
+	assertCapturedSuccess
 }
-
 
 testExecWithYarnAndEngine() {
-  compileTest "test-yarn-with-engine"
-  assertCaptured "yarn test run"
-  assertCapturedSuccess
+	compileTest "test-yarn-with-engine"
+	assertCaptured "yarn test run"
+	assertCapturedSuccess
 }
 
-
 testErrorYarnLockfileOutOfSync() {
-  cache_dir=$(mktmpdir)
-  compile "error-yarn-lockfile-out-of-sync" "${cache_dir}"
-  assertCapturedStderr "Yarn lockfile is not in sync"
-  assertCapturedError
-  assertMetricEqualsString "${cache_dir}" "failure" "yarn-lockfile-out-of-sync"
+	cache_dir=$(mktmpdir)
+	compile "error-yarn-lockfile-out-of-sync" "${cache_dir}"
+	assertCapturedStderr "Yarn lockfile is not in sync"
+	assertCapturedError
+	assertMetricEqualsString "${cache_dir}" "failure" "yarn-lockfile-out-of-sync"
 }
 
 testDetermineYarnPackageNameFailure() {
-  env_dir=$(mktmpdir)
-  # using a bad registry to force `npm info` calls to fail
-  echo "https://registry.invalid" > "$env_dir/NPM_CONFIG_REGISTRY"
-  compile "yarn-registry-failure" "$(mktmpdir)" "$env_dir"
-  assertCapturedStderr "Unable to resolve yarn version '1.22.x' via npm info"
-  assertCapturedError
+	env_dir=$(mktmpdir)
+	# using a bad registry to force `npm info` calls to fail
+	echo "https://registry.invalid" >"${env_dir}/NPM_CONFIG_REGISTRY"
+	compile "yarn-registry-failure" "$(mktmpdir)" "${env_dir}"
+	assertCapturedStderr "Unable to resolve yarn version '1.22.x' via npm info"
+	assertCapturedError
 }
 
 # Node version bounds

--- a/test/unit
+++ b/test/unit
@@ -1,1541 +1,1549 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2312,SC2317,SC2329 # test harness: dynamically-sourced fixtures resolve at runtime; masked command-substitution exits are inherent to a non-error-propagating test runner; test functions are invoked by shunit2 via name reflection, so their bodies look unreachable/uncalled (SC2317/SC2329 false positives)
+# shellcheck disable=SC2030,SC2031,SC2034,SC2046,SC2154,SC2155,SC2310 # deferred: subshell-scope/style/test-fixture nits triaged out of the mechanical migration
 
 testOutputIndent() {
-  local stdout
+	local stdout
 
-  stdout=$(echo '    Indented line' | output::indent)
-  assertEquals 'should preserve leading whitespace' '           Indented line' "${stdout}"
+	stdout=$(echo '    Indented line' | output::indent)
+	assertEquals 'should preserve leading whitespace' '           Indented line' "${stdout}"
 
-  stdout=$(echo 'Foo \ bar' | output::indent)
-  assertEquals 'should preserve unescaped backslashes' '       Foo \ bar' "${stdout}"
+	stdout=$(echo 'Foo \ bar' | output::indent)
+	assertEquals 'should preserve unescaped backslashes' '       Foo \ bar' "${stdout}"
 }
 
 testWebConcurrencyDoesNotOverrideManualValue() {
-  WEB_CONCURRENCY=123
-  unset WEB_CONCURRENCY_SET_BY
+	WEB_CONCURRENCY=123
+	unset WEB_CONCURRENCY_SET_BY
 
-  source "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	source "$(pwd)"/profile/WEB_CONCURRENCY.sh
 
-  assertEquals 123 "$WEB_CONCURRENCY"
-  assertNull "WEB_CONCURRENCY_SET_BY is not null" "$WEB_CONCURRENCY_SET_BY"
+	assertEquals 123 "${WEB_CONCURRENCY}"
+	assertNull "WEB_CONCURRENCY_SET_BY is not null" "${WEB_CONCURRENCY_SET_BY}"
 }
 
 testWebConcurrencySetsAValueWhenUnset() {
-  unset WEB_CONCURRENCY
-  unset WEB_CONCURRENCY_SET_BY
+	unset WEB_CONCURRENCY
+	unset WEB_CONCURRENCY_SET_BY
 
-  source "$(pwd)"/profile/WEB_CONCURRENCY.sh
+	source "$(pwd)"/profile/WEB_CONCURRENCY.sh
 
-  assertNotNull "WEB_CONCURRENCY is null" "$WEB_CONCURRENCY"
-  assertEquals "heroku/nodejs" "$WEB_CONCURRENCY_SET_BY"
+	assertNotNull "WEB_CONCURRENCY is null" "${WEB_CONCURRENCY}"
+	assertEquals "heroku/nodejs" "${WEB_CONCURRENCY_SET_BY}"
 }
 
 testWebConcurrencyProfileScript() {
-  # this was set when we sourced the WEB_CONCURRENCY.sh file
-  unset WEB_MEMORY
-  unset MEMORY_AVAILABLE
-  unset WEB_CONCURRENCY
+	# this was set when we sourced the WEB_CONCURRENCY.sh file
+	unset WEB_MEMORY
+	unset MEMORY_AVAILABLE
+	unset WEB_CONCURRENCY
 
-  # memory in MB of a 2X dyno
-  assertEquals "512" "$(bound_memory 512)"
+	# memory in MB of a 2X dyno
+	assertEquals "512" "$(bound_memory 512)"
 
-  # memory in MB of a 2X dyno
-  assertEquals "1024" "$(bound_memory 1024)"
+	# memory in MB of a 2X dyno
+	assertEquals "1024" "$(bound_memory 1024)"
 
-  # memory in MB of a Peformance-M dyno
-  assertEquals "2560" "$(bound_memory 2560)"
+	# memory in MB of a Peformance-M dyno
+	assertEquals "2560" "$(bound_memory 2560)"
 
-  # memory in MB of a Peformance-L dyno
-  assertEquals "14336" "$(bound_memory 14336)"
+	# memory in MB of a Peformance-L dyno
+	assertEquals "14336" "$(bound_memory 14336)"
 
-  # On non-Heroku systems `detect_memory` can return non-sensically large values
-  # so bound to largest known dyno size
-  assertEquals "129024" "$(bound_memory 129024)"
+	# On non-Heroku systems `detect_memory` can return non-sensically large values
+	# so bound to largest known dyno size
+	assertEquals "129024" "$(bound_memory 129024)"
 
-  # One larger than largest known
-  assertEquals "129024" "$(bound_memory 129025)"
+	# One larger than largest known
+	assertEquals "129024" "$(bound_memory 129025)"
 
-  # test calculate_concurrency
+	# test calculate_concurrency
 
-  # 1x
-  assertEquals "1" "$(calculate_concurrency 512 512)"
-  # 2x
-  assertEquals "2" "$(calculate_concurrency 1024 512)"
-  # Performance-M
-  assertEquals "5" "$(calculate_concurrency 2560 512)"
-  # Performance-L
-  assertEquals "28" "$(calculate_concurrency 14336 512)"
-  # Memory heavy
-  assertEquals "31" "$(calculate_concurrency 63488 2048)"
+	# 1x
+	assertEquals "1" "$(calculate_concurrency 512 512)"
+	# 2x
+	assertEquals "2" "$(calculate_concurrency 1024 512)"
+	# Performance-M
+	assertEquals "5" "$(calculate_concurrency 2560 512)"
+	# Performance-L
+	assertEquals "28" "$(calculate_concurrency 14336 512)"
+	# Memory heavy
+	assertEquals "31" "$(calculate_concurrency 63488 2048)"
 
-  # In case some very large memory available value gets passed in
-  assertEquals "1" "$(validate_concurrency $(calculate_concurrency 103401 512))"
-  # of if web memory is set really low
-  assertEquals "1" "$(validate_concurrency $(calculate_concurrency 512 1))"
+	# In case some very large memory available value gets passed in
+	assertEquals "1" "$(validate_concurrency $(calculate_concurrency 103401 512))"
+	# of if web memory is set really low
+	assertEquals "1" "$(validate_concurrency $(calculate_concurrency 512 1))"
 }
 
 testHasScript() {
-  local file="$(pwd)/test/fixtures/has-script-fixtures/package.json"
-  assertEquals "true" "$(utils::package_json::has_script "$file" "build")"
-  assertEquals "true" "$(utils::package_json::has_script "$file" "heroku-postbuild")"
-  assertEquals "false" "$(utils::package_json::has_script "$file" "postinstall")"
-  assertEquals "true" "$(utils::package_json::has_script "$file" "random-script-name")"
-  assertEquals "false" "$(utils::package_json::has_script "$(pwd)/test/fixtures/does-not-exist.json" "build")"
+	local file="$(pwd)/test/fixtures/has-script-fixtures/package.json"
+	assertEquals "true" "$(utils::package_json::has_script "${file}" "build")"
+	assertEquals "true" "$(utils::package_json::has_script "${file}" "heroku-postbuild")"
+	assertEquals "false" "$(utils::package_json::has_script "${file}" "postinstall")"
+	assertEquals "true" "$(utils::package_json::has_script "${file}" "random-script-name")"
+	assertEquals "false" "$(utils::package_json::has_script "$(pwd)/test/fixtures/does-not-exist.json" "build")"
 }
 
 testHasScriptToleratesUnusualScripts() {
-  # jq's has() errors on a non-object `.scripts` (and on an absent `scripts` key under jq <=1.6).
-  # The helper must still yield "false" and exit 0 so a captured $(...) can't abort the build
-  # under inherit_errexit.
-  local file
-  file="$(mktemp)"
+	# jq's has() errors on a non-object `.scripts` (and on an absent `scripts` key under jq <=1.6).
+	# The helper must still yield "false" and exit 0 so a captured $(...) can't abort the build
+	# under inherit_errexit.
+	local file
+	file="$(mktemp)"
 
-  printf '{"scripts": "not-an-object"}' >"$file"
-  assertEquals "non-object scripts yields false" "false" "$(utils::package_json::has_script "$file" "build" 2>/dev/null)"
-  utils::package_json::has_script "$file" "build" >/dev/null 2>&1
-  assertEquals "non-object scripts must not exit non-zero" 0 "$?"
+	printf '{"scripts": "not-an-object"}' >"${file}"
+	assertEquals "non-object scripts yields false" "false" "$(utils::package_json::has_script "${file}" "build" 2>/dev/null)"
+	utils::package_json::has_script "${file}" "build" >/dev/null 2>&1
+	assertEquals "non-object scripts must not exit non-zero" 0 "$?"
 
-  printf '{}' >"$file"
-  assertEquals "absent scripts key yields false" "false" "$(utils::package_json::has_script "$file" "build" 2>/dev/null)"
-  utils::package_json::has_script "$file" "build" >/dev/null 2>&1
-  assertEquals "absent scripts key must not exit non-zero" 0 "$?"
+	printf '{}' >"${file}"
+	assertEquals "absent scripts key yields false" "false" "$(utils::package_json::has_script "${file}" "build" 2>/dev/null)"
+	utils::package_json::has_script "${file}" "build" >/dev/null 2>&1
+	assertEquals "absent scripts key must not exit non-zero" 0 "$?"
 
-  rm -f "$file"
+	rm -f "${file}"
 }
 
 testReadJson() {
-  local file="$(pwd)/test/fixtures/has-script-fixtures/package.json"
-  assertEquals "10.x" "$(utils::json::read "$file" ".engines.node")"
-  assertEquals "" "$(utils::json::read "$file" ".engines.does_not_exist")"
-  assertEquals "" "$(utils::json::read "$(pwd)/test/fixtures/does-not-exist.json" ".engines.node")"
+	local file="$(pwd)/test/fixtures/has-script-fixtures/package.json"
+	assertEquals "10.x" "$(utils::json::read "${file}" ".engines.node")"
+	assertEquals "" "$(utils::json::read "${file}" ".engines.does_not_exist")"
+	assertEquals "" "$(utils::json::read "$(pwd)/test/fixtures/does-not-exist.json" ".engines.node")"
 }
 
 testReadJsonToleratesWrongType() {
-  # A key that indexes into a value of the wrong type makes jq error (e.g. `.scripts["build"]` when
-  # `.scripts` is a string, exactly as a malformed package.json could present). The reader must still
-  # yield "" and exit 0 so a captured $(...) can't trip the ERR trap and poison the failure marker
-  # under inherit_errexit — this mirrors the has_script/yaml::read tolerance contracts.
-  local file
-  file="$(mktemp)"
-  printf '{"scripts": "not-an-object"}' >"$file"
+	# A key that indexes into a value of the wrong type makes jq error (e.g. `.scripts["build"]` when
+	# `.scripts` is a string, exactly as a malformed package.json could present). The reader must still
+	# yield "" and exit 0 so a captured $(...) can't trip the ERR trap and poison the failure marker
+	# under inherit_errexit — this mirrors the has_script/yaml::read tolerance contracts.
+	local file
+	file="$(mktemp)"
+	printf '{"scripts": "not-an-object"}' >"${file}"
 
-  assertEquals "wrong-type index yields empty string" "" "$(utils::json::read "$file" '.scripts["build"]' 2>/dev/null)"
-  utils::json::read "$file" '.scripts["build"]' >/dev/null 2>&1
-  assertEquals "wrong-type index must not exit non-zero" 0 "$?"
+	assertEquals "wrong-type index yields empty string" "" "$(utils::json::read "${file}" '.scripts["build"]' 2>/dev/null)"
+	utils::json::read "${file}" '.scripts["build"]' >/dev/null 2>&1
+	assertEquals "wrong-type index must not exit non-zero" 0 "$?"
 
-  rm -f "$file"
+	rm -f "${file}"
 }
 
 testReadYaml() {
-  local file
-  file="$(mktemp)"
-  printf 'yarnPath: ".yarn/releases/yarn-4.0.0.cjs"\n' >"$file"
-  assertEquals ".yarn/releases/yarn-4.0.0.cjs" "$(utils::yaml::read "$file" ".yarnPath")"
-  # yq emits the literal "null" for an absent key; callers treat that as absent.
-  assertEquals "null" "$(utils::yaml::read "$file" ".doesNotExist")"
-  rm -f "$file"
+	local file
+	file="$(mktemp)"
+	printf 'yarnPath: ".yarn/releases/yarn-4.0.0.cjs"\n' >"${file}"
+	assertEquals ".yarn/releases/yarn-4.0.0.cjs" "$(utils::yaml::read "${file}" ".yarnPath")"
+	# yq emits the literal "null" for an absent key; callers treat that as absent.
+	assertEquals "null" "$(utils::yaml::read "${file}" ".doesNotExist")"
+	rm -f "${file}"
 
-  # A missing file must yield an empty string and exit 0 (not a fatal non-zero) so a captured
-  # $(...) can't abort the build under inherit_errexit.
-  assertEquals "" "$(utils::yaml::read "$(pwd)/test/fixtures/does-not-exist.yml" ".yarnPath")"
-  utils::yaml::read "$(pwd)/test/fixtures/does-not-exist.yml" ".yarnPath" >/dev/null 2>&1
-  assertEquals "missing file must not exit non-zero" 0 "$?"
+	# A missing file must yield an empty string and exit 0 (not a fatal non-zero) so a captured
+	# $(...) can't abort the build under inherit_errexit.
+	assertEquals "" "$(utils::yaml::read "$(pwd)/test/fixtures/does-not-exist.yml" ".yarnPath")"
+	utils::yaml::read "$(pwd)/test/fixtures/does-not-exist.yml" ".yarnPath" >/dev/null 2>&1
+	assertEquals "missing file must not exit non-zero" 0 "$?"
 
-  # A present-but-corrupt file (unparseable YAML) must degrade the same way — empty string, exit 0 —
-  # so yq's parse error can't abort the build under inherit_errexit.
-  local corrupt
-  corrupt="$(mktemp)"
-  printf 'yarnPath: [\n' >"$corrupt" # unterminated flow sequence: yq exits non-zero
-  assertEquals "corrupt YAML yields empty string" "" "$(utils::yaml::read "$corrupt" ".yarnPath" 2>/dev/null)"
-  utils::yaml::read "$corrupt" ".yarnPath" >/dev/null 2>&1
-  assertEquals "corrupt YAML must not exit non-zero" 0 "$?"
-  rm -f "$corrupt"
+	# A present-but-corrupt file (unparseable YAML) must degrade the same way — empty string, exit 0 —
+	# so yq's parse error can't abort the build under inherit_errexit.
+	local corrupt
+	corrupt="$(mktemp)"
+	printf 'yarnPath: [\n' >"${corrupt}" # unterminated flow sequence: yq exits non-zero
+	assertEquals "corrupt YAML yields empty string" "" "$(utils::yaml::read "${corrupt}" ".yarnPath" 2>/dev/null)"
+	utils::yaml::read "${corrupt}" ".yarnPath" >/dev/null 2>&1
+	assertEquals "corrupt YAML must not exit non-zero" 0 "$?"
+	rm -f "${corrupt}"
 }
 
 testJsonValid() {
-  assertTrue "well-formed JSON is valid" \
-    "utils::json::is_valid '$(pwd)/test/fixtures/has-script-fixtures/package.json'"
-  assertFalse "malformed JSON is invalid" \
-    "utils::json::is_valid '$(pwd)/test/fixtures/bad-json/package.json'"
+	assertTrue "well-formed JSON is valid" \
+		"utils::json::is_valid '$(pwd)/test/fixtures/has-script-fixtures/package.json'"
+	assertFalse "malformed JSON is invalid" \
+		"utils::json::is_valid '$(pwd)/test/fixtures/bad-json/package.json'"
 }
 
 testFailInvalidPackageJsonEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    utils::package_json::_fail_invalid
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		utils::package_json::_fail_invalid
 
-  # The message names package.json and gives concrete syntax-error fix guidance.
-  assertContains "$out" "Error: Unable to parse your package.json."
-  assertContains "$out" "invalid JSON"
-  assertContains "$out" "jq . package.json"
-  # The historical failure id is preserved for metric continuity; app-controlled input.
-  assertContains "$(cat "$capture")" "failure=invalid-package-json"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	# The message names package.json and gives concrete syntax-error fix guidance.
+	assertContains "${out}" "Error: Unable to parse your package.json."
+	assertContains "${out}" "invalid JSON"
+	assertContains "${out}" "jq . package.json"
+	# The historical failure id is preserved for metric continuity; app-controlled input.
+	assertContains "$(cat "${capture}")" "failure=invalid-package-json"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testFailInvalidPackageJsonGuardEmitsOnMalformedJson() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    utils::package_json::fail_invalid "$(pwd)/test/fixtures/bad-json"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		utils::package_json::fail_invalid "$(pwd)/test/fixtures/bad-json"
 
-  assertContains "$out" "Error: Unable to parse your package.json."
-  assertContains "$(cat "$capture")" "failure=invalid-package-json"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Unable to parse your package.json."
+	assertContains "$(cat "${capture}")" "failure=invalid-package-json"
+	rm -f "${capture}"
 }
 
 testFailInvalidPackageJsonGuardDoesNotEmitOnValidJson() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    utils::package_json::fail_invalid "$(pwd)/test/fixtures/has-script-fixtures"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		utils::package_json::fail_invalid "$(pwd)/test/fixtures/has-script-fixtures"
 
-  # Valid JSON: the guard never reaches the emit helper, so nothing is printed or recorded.
-  assertNull "valid package.json should not emit a failure message" "$out"
-  assertEquals "valid package.json should not record a failure" "" "$(cat "$capture")"
-  rm -f "$capture"
+	# Valid JSON: the guard never reaches the emit helper, so nothing is printed or recorded.
+	assertNull "valid package.json should not emit a failure message" "${out}"
+	assertEquals "valid package.json should not record a failure" "" "$(cat "${capture}")"
+	rm -f "${capture}"
 }
 
 testAssertMetricsBasicQueries() {
-  local cache_dir=$(mktemp -d)
-  local metrics_dir="${cache_dir}/build-data"
-  local metrics_file="${metrics_dir}/nodejs.json"
-  
-  # Create the metrics directory and file
-  mkdir -p "$metrics_dir"
-  
-  # Test basic jq queries
-  echo '{"package_manager": "npm", "build_time": 1.234, "cache_status": "not-found"}' > "$metrics_file"
-  assertMetrics "$cache_dir" <<-EOF
-    select(.package_manager == "npm")
-    select(.build_time | type == "number")
-    select(.cache_status == "not-found")
-EOF
-  
-  # Cleanup
-  rm -rf "$cache_dir"
+	local cache_dir=$(mktemp -d)
+	local metrics_dir="${cache_dir}/build-data"
+	local metrics_file="${metrics_dir}/nodejs.json"
+
+	# Create the metrics directory and file
+	mkdir -p "${metrics_dir}"
+
+	# Test basic jq queries
+	echo '{"package_manager": "npm", "build_time": 1.234, "cache_status": "not-found"}' >"${metrics_file}"
+	assertMetrics "${cache_dir}" <<-EOF
+		    select(.package_manager == "npm")
+		    select(.build_time | type == "number")
+		    select(.cache_status == "not-found")
+	EOF
+
+	# Cleanup
+	rm -rf "${cache_dir}"
 }
 
 testAssertMetricsMissingArgument() {
-  local error_output
-  error_output=$(assertMetrics <<-EOF 2>&1 || true
-EOF
-)
-  if ! echo "$error_output" | grep -q "cache_dir argument is required"; then
-    fail "assertMetrics should have failed with appropriate error message for missing argument"
-  fi
+	local error_output
+	error_output=$(
+		assertMetrics <<-EOF 2>&1 || true
+		EOF
+	)
+	if ! echo "${error_output}" | grep -q "cache_dir argument is required"; then
+		fail "assertMetrics should have failed with appropriate error message for missing argument"
+	fi
 }
 
 testAssertMetricsNonExistentFile() {
-  local cache_dir=$(mktemp -d)
-  local error_output
-  error_output=$(assertMetrics "$cache_dir" <<-EOF 2>&1 || true
-    select(.package_manager == "npm")
-EOF
-)
-  if ! echo "$error_output" | grep -q "Metrics file not found"; then
-    fail "assertMetrics should have failed with appropriate error message for non-existent file"
-  fi
-  
-  # Cleanup
-  rm -rf "$cache_dir"
+	local cache_dir=$(mktemp -d)
+	local error_output
+	error_output=$(
+		assertMetrics "${cache_dir}" <<-EOF 2>&1 || true
+			    select(.package_manager == "npm")
+		EOF
+	)
+	if ! echo "${error_output}" | grep -q "Metrics file not found"; then
+		fail "assertMetrics should have failed with appropriate error message for non-existent file"
+	fi
+
+	# Cleanup
+	rm -rf "${cache_dir}"
 }
 
 testAssertMetricsInvalidJqQuery() {
-  local cache_dir=$(mktemp -d)
-  local metrics_dir="${cache_dir}/build-data"
-  local metrics_file="${metrics_dir}/nodejs.json"
-  
-  # Create the metrics directory and file
-  mkdir -p "$metrics_dir"
-  echo '{"package_manager": "npm"}' > "$metrics_file"
-  
-  local error_output
-  error_output=$(assertMetrics "$cache_dir" <<-EOF 2>&1 || true
-    select(.nonexistent == "value")
-EOF
-)
-  if ! echo "$error_output" | grep -q "jq query failed"; then
-    fail "assertMetrics should have failed with appropriate error message for invalid jq query"
-  fi
-  
-  # Cleanup
-  rm -rf "$cache_dir"
+	local cache_dir=$(mktemp -d)
+	local metrics_dir="${cache_dir}/build-data"
+	local metrics_file="${metrics_dir}/nodejs.json"
+
+	# Create the metrics directory and file
+	mkdir -p "${metrics_dir}"
+	echo '{"package_manager": "npm"}' >"${metrics_file}"
+
+	local error_output
+	error_output=$(
+		assertMetrics "${cache_dir}" <<-EOF 2>&1 || true
+			    select(.nonexistent == "value")
+		EOF
+	)
+	if ! echo "${error_output}" | grep -q "jq query failed"; then
+		fail "assertMetrics should have failed with appropriate error message for invalid jq query"
+	fi
+
+	# Cleanup
+	rm -rf "${cache_dir}"
 }
 
 testAssertMetricsUncheckedKeys() {
-  local cache_dir=$(mktemp -d)
-  local metrics_dir="${cache_dir}/build-data"
-  local metrics_file="${metrics_dir}/nodejs.json"
-  
-  # Create the metrics directory and file
-  mkdir -p "$metrics_dir"
-  echo '{"package_manager": "npm", "build_time": 1.234, "cache_status": "not-found"}' > "$metrics_file"
-  
-  local error_output
-  error_output=$(assertMetrics "$cache_dir" <<-EOF 2>&1 || true
-    select(.package_manager == "npm")
-EOF
-)
-  if ! echo "$error_output" | grep -q "keys in the metrics file were not checked: \[build_time,cache_status\]"; then
-    fail "assertMetrics should have failed with appropriate error message for unchecked keys"
-  fi
-  
-  # Cleanup
-  rm -rf "$cache_dir"
+	local cache_dir=$(mktemp -d)
+	local metrics_dir="${cache_dir}/build-data"
+	local metrics_file="${metrics_dir}/nodejs.json"
+
+	# Create the metrics directory and file
+	mkdir -p "${metrics_dir}"
+	echo '{"package_manager": "npm", "build_time": 1.234, "cache_status": "not-found"}' >"${metrics_file}"
+
+	local error_output
+	error_output=$(
+		assertMetrics "${cache_dir}" <<-EOF 2>&1 || true
+			    select(.package_manager == "npm")
+		EOF
+	)
+	if ! echo "${error_output}" | grep -q "keys in the metrics file were not checked: \[build_time,cache_status\]"; then
+		fail "assertMetrics should have failed with appropriate error message for unchecked keys"
+	fi
+
+	# Cleanup
+	rm -rf "${cache_dir}"
 }
 
 testAssertMetricsAllKeysChecked() {
-  local cache_dir=$(mktemp -d)
-  local metrics_dir="${cache_dir}/build-data"
-  local metrics_file="${metrics_dir}/nodejs.json"
-  
-  # Create the metrics directory and file
-  mkdir -p "$metrics_dir"
-  echo '{"package_manager": "npm", "build_time": 1.234, "cache_status": "not-found"}' > "$metrics_file"
-  
-  # Should pass when all keys are checked
-  assertMetrics "$cache_dir" <<-EOF
-    select(.package_manager == "npm")
-    select(.build_time | type == "number")
-    select(.cache_status == "not-found")
-EOF
-  
-  # Cleanup
-  rm -rf "$cache_dir"
+	local cache_dir=$(mktemp -d)
+	local metrics_dir="${cache_dir}/build-data"
+	local metrics_file="${metrics_dir}/nodejs.json"
+
+	# Create the metrics directory and file
+	mkdir -p "${metrics_dir}"
+	echo '{"package_manager": "npm", "build_time": 1.234, "cache_status": "not-found"}' >"${metrics_file}"
+
+	# Should pass when all keys are checked
+	assertMetrics "${cache_dir}" <<-EOF
+		    select(.package_manager == "npm")
+		    select(.build_time | type == "number")
+		    select(.cache_status == "not-found")
+	EOF
+
+	# Cleanup
+	rm -rf "${cache_dir}"
 }
 
 testGetYarnMajorVersionFromPackageManager() {
-  local build_dir=$(mktemp -d)
+	local build_dir=$(mktemp -d)
 
-  # Test Yarn 4 with packageManager
-  echo '{"packageManager": "yarn@4.11.0"}' > "$build_dir/package.json"
-  assertEquals "4" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test Yarn 4 with packageManager
+	echo '{"packageManager": "yarn@4.11.0"}' >"${build_dir}/package.json"
+	assertEquals "4" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Test Yarn 3 with packageManager
-  echo '{"packageManager": "yarn@3.6.3"}' > "$build_dir/package.json"
-  assertEquals "3" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test Yarn 3 with packageManager
+	echo '{"packageManager": "yarn@3.6.3"}' >"${build_dir}/package.json"
+	assertEquals "3" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Test Yarn 2 with packageManager
-  echo '{"packageManager": "yarn@2.0.0"}' > "$build_dir/package.json"
-  assertEquals "2" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test Yarn 2 with packageManager
+	echo '{"packageManager": "yarn@2.0.0"}' >"${build_dir}/package.json"
+	assertEquals "2" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Test Yarn 1 with packageManager
-  echo '{"packageManager": "yarn@1.22.22"}' > "$build_dir/package.json"
-  assertEquals "1" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test Yarn 1 with packageManager
+	echo '{"packageManager": "yarn@1.22.22"}' >"${build_dir}/package.json"
+	assertEquals "1" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Test with hash suffix
-  echo '{"packageManager": "yarn@4.11.0+sha512.abc123"}' > "$build_dir/package.json"
-  assertEquals "4" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test with hash suffix
+	echo '{"packageManager": "yarn@4.11.0+sha512.abc123"}' >"${build_dir}/package.json"
+	assertEquals "4" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Cleanup
-  rm -rf "$build_dir"
+	# Cleanup
+	rm -rf "${build_dir}"
 }
 
 testGetYarnMajorVersionFromEngines() {
-  local build_dir=$(mktemp -d)
+	local build_dir=$(mktemp -d)
 
-  # Test with engines.yarn using caret
-  echo '{"engines": {"yarn": "^4.0.0"}}' > "$build_dir/package.json"
-  assertEquals "4" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test with engines.yarn using caret
+	echo '{"engines": {"yarn": "^4.0.0"}}' >"${build_dir}/package.json"
+	assertEquals "4" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Test with engines.yarn using x notation
-  echo '{"engines": {"yarn": "4.x"}}' > "$build_dir/package.json"
-  assertEquals "4" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test with engines.yarn using x notation
+	echo '{"engines": {"yarn": "4.x"}}' >"${build_dir}/package.json"
+	assertEquals "4" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Test with engines.yarn using >=
-  echo '{"engines": {"yarn": ">=4.5.0"}}' > "$build_dir/package.json"
-  assertEquals "4" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test with engines.yarn using >=
+	echo '{"engines": {"yarn": ">=4.5.0"}}' >"${build_dir}/package.json"
+	assertEquals "4" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Test with engines.yarn using tilde
-  echo '{"engines": {"yarn": "~3.6.0"}}' > "$build_dir/package.json"
-  assertEquals "3" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Test with engines.yarn using tilde
+	echo '{"engines": {"yarn": "~3.6.0"}}' >"${build_dir}/package.json"
+	assertEquals "3" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Cleanup
-  rm -rf "$build_dir"
+	# Cleanup
+	rm -rf "${build_dir}"
 }
 
 testGetYarnMajorVersionPrecedence() {
-  local build_dir=$(mktemp -d)
+	local build_dir=$(mktemp -d)
 
-  # packageManager should take precedence over engines.yarn
-  echo '{"packageManager": "yarn@4.0.0", "engines": {"yarn": "3.x"}}' > "$build_dir/package.json"
-  assertEquals "4" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# packageManager should take precedence over engines.yarn
+	echo '{"packageManager": "yarn@4.0.0", "engines": {"yarn": "3.x"}}' >"${build_dir}/package.json"
+	assertEquals "4" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Cleanup
-  rm -rf "$build_dir"
+	# Cleanup
+	rm -rf "${build_dir}"
 }
 
 testGetYarnMajorVersionNoVersion() {
-  local build_dir=$(mktemp -d)
+	local build_dir=$(mktemp -d)
 
-  # No version specified
-  echo '{}' > "$build_dir/package.json"
-  assertEquals "" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# No version specified
+	echo '{}' >"${build_dir}/package.json"
+	assertEquals "" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Only npm specified
-  echo '{"packageManager": "npm@10.0.0"}' > "$build_dir/package.json"
-  assertEquals "" "$(package_managers::yarn::get_major_version "$build_dir")"
+	# Only npm specified
+	echo '{"packageManager": "npm@10.0.0"}' >"${build_dir}/package.json"
+	assertEquals "" "$(package_managers::yarn::get_major_version "${build_dir}")"
 
-  # Cleanup
-  rm -rf "$build_dir"
+	# Cleanup
+	rm -rf "${build_dir}"
 }
 
 testMultipleLockfilesFixStepsTwoManagers() {
-  local expected
-  expected="$(cat <<-'EOF'
-       If you use npm:
-       $ git rm yarn.lock
-       $ git commit -m "Remove unused lockfiles"
-       $ git push heroku main
+	local expected
+	expected="$(
+		cat <<-'EOF'
+			       If you use npm:
+			       $ git rm yarn.lock
+			       $ git commit -m "Remove unused lockfiles"
+			       $ git push heroku main
 
-       If you use Yarn:
-       $ git rm package-lock.json
-       $ git commit -m "Remove unused lockfiles"
-       $ git push heroku main
+			       If you use Yarn:
+			       $ git rm package-lock.json
+			       $ git commit -m "Remove unused lockfiles"
+			       $ git push heroku main
 
-EOF
-)"
+		EOF
+	)"
 
-  assertEquals "$expected" "$(package_manager::_multiple_lockfiles_fix_steps npm Yarn)"
+	assertEquals "${expected}" "$(package_manager::_multiple_lockfiles_fix_steps npm Yarn)"
 }
 
 testMultipleLockfilesFixStepsThreeManagers() {
-  local expected
-  expected="$(cat <<-'EOF'
-       If you use npm:
-       $ git rm pnpm-lock.yaml yarn.lock
-       $ git commit -m "Remove unused lockfiles"
-       $ git push heroku main
+	local expected
+	expected="$(
+		cat <<-'EOF'
+			       If you use npm:
+			       $ git rm pnpm-lock.yaml yarn.lock
+			       $ git commit -m "Remove unused lockfiles"
+			       $ git push heroku main
 
-       If you use pnpm:
-       $ git rm package-lock.json yarn.lock
-       $ git commit -m "Remove unused lockfiles"
-       $ git push heroku main
+			       If you use pnpm:
+			       $ git rm package-lock.json yarn.lock
+			       $ git commit -m "Remove unused lockfiles"
+			       $ git push heroku main
 
-       If you use Yarn:
-       $ git rm package-lock.json pnpm-lock.yaml
-       $ git commit -m "Remove unused lockfiles"
-       $ git push heroku main
+			       If you use Yarn:
+			       $ git rm package-lock.json pnpm-lock.yaml
+			       $ git commit -m "Remove unused lockfiles"
+			       $ git push heroku main
 
-EOF
-)"
+		EOF
+	)"
 
-  assertEquals "$expected" "$(package_manager::_multiple_lockfiles_fix_steps npm pnpm Yarn)"
+	assertEquals "${expected}" "$(package_manager::_multiple_lockfiles_fix_steps npm pnpm Yarn)"
 }
 
 testFailMultipleLockfilesEmitsDetailedMessage() {
-  # The pre-flight guard detects two modern lockfiles on disk and emits the multiple-lock-files
-  # failure with the per-manager `git rm` fix steps and the .gitignore advice.
-  local build_dir out capture
-  build_dir=$(mktemp -d)
-  capture=$(mktemp)
-  : > "$build_dir/package-lock.json"
-  : > "$build_dir/yarn.lock"
+	# The pre-flight guard detects two modern lockfiles on disk and emits the multiple-lock-files
+	# failure with the per-manager `git rm` fix steps and the .gitignore advice.
+	local build_dir out capture
+	build_dir=$(mktemp -d)
+	capture=$(mktemp)
+	: >"${build_dir}/package-lock.json"
+	: >"${build_dir}/yarn.lock"
 
-  _capture_node_fail out "$capture" \
-    package_manager::fail_multiple_lockfiles "$build_dir"
+	_capture_node_fail out "${capture}" \
+		package_manager::fail_multiple_lockfiles "${build_dir}"
 
-  assertContains "$out" "Error: Multiple lockfiles found."
-  # Reported list is sorted case-insensitively (npm before Yarn).
-  assertContains "$out" "Multiple package managers (npm,Yarn)"
-  # Per-manager git rm fix steps interpolated from the detected lockfiles.
-  assertContains "$out" "If you use npm:"
-  assertContains "$out" "\$ git rm yarn.lock"
-  assertContains "$out" "If you use Yarn:"
-  assertContains "$out" "\$ git rm package-lock.json"
-  assertContains "$out" "add them to your .gitignore file."
-  assertContains "$(cat "$capture")" "failure=multiple-lock-files"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  # The colliding managers are recorded (sorted) for observability.
-  assertContains "$(cat "$capture")" "failure_detail=npm,Yarn"
-  rm -rf "$build_dir"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Multiple lockfiles found."
+	# Reported list is sorted case-insensitively (npm before Yarn).
+	assertContains "${out}" "Multiple package managers (npm,Yarn)"
+	# Per-manager git rm fix steps interpolated from the detected lockfiles.
+	assertContains "${out}" "If you use npm:"
+	assertContains "${out}" "\$ git rm yarn.lock"
+	assertContains "${out}" "If you use Yarn:"
+	assertContains "${out}" "\$ git rm package-lock.json"
+	assertContains "${out}" "add them to your .gitignore file."
+	assertContains "$(cat "${capture}")" "failure=multiple-lock-files"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	# The colliding managers are recorded (sorted) for observability.
+	assertContains "$(cat "${capture}")" "failure_detail=npm,Yarn"
+	rm -rf "${build_dir}"
+	rm -f "${capture}"
 }
 
 testFailShrinkwrapConflictEmitsDetailedMessage() {
-  # A single modern lockfile alongside npm-shrinkwrap.json trips the shrinkwrap branch, which
-  # emits the shrinkwrap-lock-file-conflict failure with the 4-file list and .gitignore advice.
-  local build_dir out capture
-  build_dir=$(mktemp -d)
-  capture=$(mktemp)
-  : > "$build_dir/yarn.lock"
-  : > "$build_dir/npm-shrinkwrap.json"
+	# A single modern lockfile alongside npm-shrinkwrap.json trips the shrinkwrap branch, which
+	# emits the shrinkwrap-lock-file-conflict failure with the 4-file list and .gitignore advice.
+	local build_dir out capture
+	build_dir=$(mktemp -d)
+	capture=$(mktemp)
+	: >"${build_dir}/yarn.lock"
+	: >"${build_dir}/npm-shrinkwrap.json"
 
-  _capture_node_fail out "$capture" \
-    package_manager::fail_multiple_lockfiles "$build_dir"
+	_capture_node_fail out "${capture}" \
+		package_manager::fail_multiple_lockfiles "${build_dir}"
 
-  assertContains "$out" "Error: Multiple lockfiles conflicting with npm-shrinkwrap.json."
-  # The full 4-file conflict list is preserved.
-  assertContains "$out" "- yarn.lock"
-  assertContains "$out" "- pnpm-lock.yaml"
-  assertContains "$out" "- package-lock.json"
-  assertContains "$out" "- npm-shrinkwrap.json"
-  assertContains "$out" "add them to your .gitignore file."
-  assertContains "$(cat "$capture")" "failure=shrinkwrap-lock-file-conflict"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  # The modern lockfile conflicting with npm-shrinkwrap.json is recorded for observability.
-  assertContains "$(cat "$capture")" "failure_detail=Yarn"
-  rm -rf "$build_dir"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Multiple lockfiles conflicting with npm-shrinkwrap.json."
+	# The full 4-file conflict list is preserved.
+	assertContains "${out}" "- yarn.lock"
+	assertContains "${out}" "- pnpm-lock.yaml"
+	assertContains "${out}" "- package-lock.json"
+	assertContains "${out}" "- npm-shrinkwrap.json"
+	assertContains "${out}" "add them to your .gitignore file."
+	assertContains "$(cat "${capture}")" "failure=shrinkwrap-lock-file-conflict"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	# The modern lockfile conflicting with npm-shrinkwrap.json is recorded for observability.
+	assertContains "$(cat "${capture}")" "failure_detail=Yarn"
+	rm -rf "${build_dir}"
+	rm -f "${capture}"
 }
 
 testFailMultipleLockfilesPassesCleanForValidLayouts() {
-  # The common, valid layouts must NOT emit a failure: zero lockfiles, exactly one modern
-  # lockfile, or npm-shrinkwrap.json on its own. Guards against a future regression in the
-  # `>1` threshold or the has_modern_lockfile default silently failing normal builds.
-  local build_dir out capture layout
-  for layout in "none" "package-lock.json" "yarn.lock" "pnpm-lock.yaml" "npm-shrinkwrap.json"; do
-    build_dir=$(mktemp -d)
-    capture=$(mktemp)
-    [ "$layout" = "none" ] || : > "$build_dir/$layout"
+	# The common, valid layouts must NOT emit a failure: zero lockfiles, exactly one modern
+	# lockfile, or npm-shrinkwrap.json on its own. Guards against a future regression in the
+	# `>1` threshold or the has_modern_lockfile default silently failing normal builds.
+	local build_dir out capture layout
+	for layout in "none" "package-lock.json" "yarn.lock" "pnpm-lock.yaml" "npm-shrinkwrap.json"; do
+		build_dir=$(mktemp -d)
+		capture=$(mktemp)
+		[[ "${layout}" = "none" ]] || : >"${build_dir}/${layout}"
 
-    _capture_node_fail out "$capture" \
-      package_manager::fail_multiple_lockfiles "$build_dir"
+		_capture_node_fail out "${capture}" \
+			package_manager::fail_multiple_lockfiles "${build_dir}"
 
-    # No message emitted and no failure recorded in build data.
-    assertEquals "layout '$layout' should not emit a failure message" "" "$out"
-    assertEquals "layout '$layout' should not record a failure" "" "$(cat "$capture")"
-    rm -rf "$build_dir"
-    rm -f "$capture"
-  done
+		# No message emitted and no failure recorded in build data.
+		assertEquals "layout '${layout}' should not emit a failure message" "" "${out}"
+		assertEquals "layout '${layout}' should not record a failure" "" "$(cat "${capture}")"
+		rm -rf "${build_dir}"
+		rm -f "${capture}"
+	done
 }
 
 testFailureEmitRendersAndRecords() {
-  local out
-  # Run in a subshell with stubs so `fail` doesn't kill the test runner and build_data
-  # writes are captured to a temp file instead of the real store.
-  local capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    declare -A failure
-    failure[id]="install-dependencies::npm"
-    failure[detail]="EBADPLATFORM"
-    failure[classification]="user"
-    failure[message]="Error: Unable to install dependencies using npm."
-    failure::emit failure 2>&1 || true
-  )
+	local out
+	# Run in a subshell with stubs so `fail` doesn't kill the test runner and build_data
+	# writes are captured to a temp file instead of the real store.
+	local capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		declare -A failure
+		failure[id]="install-dependencies::npm"
+		failure[detail]="EBADPLATFORM"
+		failure[classification]="user"
+		failure[message]="Error: Unable to install dependencies using npm."
+		failure::emit failure 2>&1 || true
+	)
 
-  assertContains "$out" "Error: Unable to install dependencies using npm."
-  assertContains "$(cat "$capture")" "failure=install-dependencies::npm"
-  assertContains "$(cat "$capture")" "failure_detail=EBADPLATFORM"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Unable to install dependencies using npm."
+	assertContains "$(cat "${capture}")" "failure=install-dependencies::npm"
+	assertContains "$(cat "${capture}")" "failure_detail=EBADPLATFORM"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testFailureEmitOmitsOptionalFields() {
-  # detail and classification are optional; emit must not write those build_data keys when
-  # they are unset.
-  local capture
-  capture=$(mktemp)
-  (
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    declare -A failure
-    failure[id]="install-dependencies::npm"
-    failure[message]="An error."
-    failure::emit failure >/dev/null 2>&1 || true
-  )
+	# detail and classification are optional; emit must not write those build_data keys when
+	# they are unset.
+	local capture
+	capture=$(mktemp)
+	(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		declare -A failure
+		failure[id]="install-dependencies::npm"
+		failure[message]="An error."
+		failure::emit failure >/dev/null 2>&1 || true
+	)
 
-  assertContains "$(cat "$capture")" "failure=install-dependencies::npm"
-  assertNotContains "$(cat "$capture")" "failure_detail="
-  assertNotContains "$(cat "$capture")" "failure_classification="
-  rm -f "$capture"
+	assertContains "$(cat "${capture}")" "failure=install-dependencies::npm"
+	assertNotContains "$(cat "${capture}")" "failure_detail="
+	assertNotContains "$(cat "${capture}")" "failure_classification="
+	rm -f "${capture}"
 }
 
 testFailureEmitWritesMarkerWhenSet() {
-  # When FAILURE_EMITTED_MARKER is set, emit must create the marker file so the legacy ERR
-  # trap in bin/compile knows this failure is already handled and skips its own matchers.
-  local marker
-  marker=$(mktemp)
-  rm -f "$marker"
-  (
-    fail() { exit 1; }
-    build_data::set_string() { :; }
-    export FAILURE_EMITTED_MARKER="$marker"
-    declare -A failure
-    failure[id]="install-dependencies::npm"
-    failure[message]="An error."
-    failure::emit failure >/dev/null 2>&1 || true
-  )
+	# When FAILURE_EMITTED_MARKER is set, emit must create the marker file so the legacy ERR
+	# trap in bin/compile knows this failure is already handled and skips its own matchers.
+	local marker
+	marker=$(mktemp)
+	rm -f "${marker}"
+	(
+		fail() { exit 1; }
+		build_data::set_string() { :; }
+		export FAILURE_EMITTED_MARKER="${marker}"
+		declare -A failure
+		failure[id]="install-dependencies::npm"
+		failure[message]="An error."
+		failure::emit failure >/dev/null 2>&1 || true
+	)
 
-  assertTrue "emit should create the marker file when FAILURE_EMITTED_MARKER is set" "[ -e '$marker' ]"
-  rm -f "$marker"
+	assertTrue "emit should create the marker file when FAILURE_EMITTED_MARKER is set" "[ -e '${marker}' ]"
+	rm -f "${marker}"
 }
 
 testFailureHandleUncaughtRendersAndRecords() {
-  # After an unclassified command fails, the generic ERR-trap handler renders the internal-error
-  # message and records failure=internal-error. With errtrace enabled, BASH_COMMAND/caller point at
-  # the real failure site, so the handler includes a "Failing command"/"Stack trace" block and
-  # records the failing command as failure_detail. Run in a subshell with stubs so `fail` doesn't
-  # kill the test runner and build_data writes are captured. (Called directly rather than via a real
-  # ERR trap here, so we assert the blocks are present, not their exact contents.)
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    unset FAILURE_EMITTED_MARKER
-    false || true
-    failure::handle_uncaught 2>&1 || true
-  )
+	# After an unclassified command fails, the generic ERR-trap handler renders the internal-error
+	# message and records failure=internal-error. With errtrace enabled, BASH_COMMAND/caller point at
+	# the real failure site, so the handler includes a "Failing command"/"Stack trace" block and
+	# records the failing command as failure_detail. Run in a subshell with stubs so `fail` doesn't
+	# kill the test runner and build_data writes are captured. (Called directly rather than via a real
+	# ERR trap here, so we assert the blocks are present, not their exact contents.)
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		unset FAILURE_EMITTED_MARKER
+		false || true
+		failure::handle_uncaught 2>&1 || true
+	)
 
-  assertContains "$out" "An unexpected error occurred"
-  assertContains "should render a Failing command block" "$out" "Failing command:"
-  assertContains "should render a Stack trace block" "$out" "Stack trace:"
-  assertContains "$(cat "$capture")" "failure=internal-error"
-  assertContains "should record failure_detail for observability" "$(cat "$capture")" "failure_detail="
-  rm -f "$capture"
+	assertContains "${out}" "An unexpected error occurred"
+	assertContains "should render a Failing command block" "${out}" "Failing command:"
+	assertContains "should render a Stack trace block" "${out}" "Stack trace:"
+	assertContains "$(cat "${capture}")" "failure=internal-error"
+	assertContains "should record failure_detail for observability" "$(cat "${capture}")" "failure_detail="
+	rm -f "${capture}"
 }
 
 testFailureHandleUncaughtSkipsWhenMarkerPresent() {
-  # When the marker file exists a migrated path already reported the failure, so the generic
-  # handler must stay quiet: print nothing and record no build data.
-  local out capture marker
-  capture=$(mktemp)
-  marker=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    export FAILURE_EMITTED_MARKER="$marker"
-    false || true
-    failure::handle_uncaught 2>&1 || true
-  )
+	# When the marker file exists a migrated path already reported the failure, so the generic
+	# handler must stay quiet: print nothing and record no build data.
+	local out capture marker
+	capture=$(mktemp)
+	marker=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		export FAILURE_EMITTED_MARKER="${marker}"
+		false || true
+		failure::handle_uncaught 2>&1 || true
+	)
 
-  assertEquals "handler must print nothing when the marker exists" "" "$out"
-  assertEquals "handler must record no build data when the marker exists" "" "$(cat "$capture")"
-  rm -f "$capture" "$marker"
+	assertEquals "handler must print nothing when the marker exists" "" "${out}"
+	assertEquals "handler must record no build data when the marker exists" "" "$(cat "${capture}")"
+	rm -f "${capture}" "${marker}"
 }
 
 testErrTrapNotPoisonedByGuardedVersionSub() {
-  # Regression for the marker-poisoning hazard behind the `|| true` guards on every
-  # argument-position `$(<tool> --version)` in bin/compile/cache.sh. Under the real strict mode
-  # (`errtrace` + `inherit_errexit` + an armed `failure::handle_uncaught` trap), a failing tool
-  # inside an *unguarded* argument-position substitution fires the ERR trap inside the
-  # command-substitution subshell — creating the marker and recording failure=internal-error even
-  # though the parent shell keeps going. That poisons a later real failure (the marker makes the
-  # trap stay quiet) and records a bogus internal error. The `|| true` guard must prevent it.
-  #
-  # Both branches run the same failing tool through the same live trap; only the guard differs.
-  # Each scenario runs in a BACKGROUNDED subshell so its `set -e` stays genuinely active: guarding
-  # the subshell inline (`( … ) || true`, `if ( … )`) would instead place it in a condition context
-  # and suppress errexit throughout — making these assertions pass vacuously. `wait … || true`
-  # collects the exit code without aborting the test runner.
-  local unguarded_capture unguarded_marker guarded_capture guarded_marker
-  unguarded_capture="$(mktemp)"
-  guarded_capture="$(mktemp)"
-  unguarded_marker="$(mktemp)" && rm -f "$unguarded_marker"
-  guarded_marker="$(mktemp)" && rm -f "$guarded_marker"
+	# Regression for the marker-poisoning hazard behind the `|| true` guards on every
+	# argument-position `$(<tool> --version)` in bin/compile/cache.sh. Under the real strict mode
+	# (`errtrace` + `inherit_errexit` + an armed `failure::handle_uncaught` trap), a failing tool
+	# inside an *unguarded* argument-position substitution fires the ERR trap inside the
+	# command-substitution subshell — creating the marker and recording failure=internal-error even
+	# though the parent shell keeps going. That poisons a later real failure (the marker makes the
+	# trap stay quiet) and records a bogus internal error. The `|| true` guard must prevent it.
+	#
+	# Both branches run the same failing tool through the same live trap; only the guard differs.
+	# Each scenario runs in a BACKGROUNDED subshell so its `set -e` stays genuinely active: guarding
+	# the subshell inline (`( … ) || true`, `if ( … )`) would instead place it in a condition context
+	# and suppress errexit throughout — making these assertions pass vacuously. `wait … || true`
+	# collects the exit code without aborting the test runner.
+	local unguarded_capture unguarded_marker guarded_capture guarded_marker
+	unguarded_capture="$(mktemp)"
+	guarded_capture="$(mktemp)"
+	unguarded_marker="$(mktemp)" && rm -f "${unguarded_marker}"
+	guarded_marker="$(mktemp)" && rm -f "${guarded_marker}"
 
-  # Baseline: UNGUARDED sub must poison — proves the trap machinery actually fires here, so the
-  # guarded assertion below is meaningful and not passing vacuously.
-  (
-    build_data::set_string() { echo "$1=$2" >>"$unguarded_capture"; }
-    build_data::set_duration() { :; }
-    build_start_time=0
-    broken_tool() { return 3; }
-    export FAILURE_EMITTED_MARKER="$unguarded_marker"
-    set -euo pipefail -o errtrace
-    shopt -s inherit_errexit
-    trap 'failure::handle_uncaught' ERR
-    build_data::set_string "package_manager_version" "$(broken_tool)"
-  ) >/dev/null 2>&1 &
-  wait "$!" || true
-  assertTrue "unguarded failing version sub should poison the marker (baseline)" "[ -e '$unguarded_marker' ]"
-  assertContains "unguarded failing version sub should record a bogus failure (baseline)" \
-    "$(cat "$unguarded_capture")" "failure=internal-error"
+	# Baseline: UNGUARDED sub must poison — proves the trap machinery actually fires here, so the
+	# guarded assertion below is meaningful and not passing vacuously.
+	(
+		build_data::set_string() { echo "$1=$2" >>"${unguarded_capture}"; }
+		build_data::set_duration() { :; }
+		build_start_time=0
+		broken_tool() { return 3; }
+		export FAILURE_EMITTED_MARKER="${unguarded_marker}"
+		set -euo pipefail -o errtrace
+		shopt -s inherit_errexit
+		trap 'failure::handle_uncaught' ERR
+		build_data::set_string "package_manager_version" "$(broken_tool)"
+	) >/dev/null 2>&1 &
+	wait "$!" || true
+	assertTrue "unguarded failing version sub should poison the marker (baseline)" "[ -e '${unguarded_marker}' ]"
+	assertContains "unguarded failing version sub should record a bogus failure (baseline)" \
+		"$(cat "${unguarded_capture}")" "failure=internal-error"
 
-  # The fix: the SAME failing tool guarded with `|| true` must not fire the trap at all.
-  (
-    build_data::set_string() { echo "$1=$2" >>"$guarded_capture"; }
-    build_data::set_duration() { :; }
-    build_start_time=0
-    broken_tool() { return 3; }
-    export FAILURE_EMITTED_MARKER="$guarded_marker"
-    set -euo pipefail -o errtrace
-    shopt -s inherit_errexit
-    trap 'failure::handle_uncaught' ERR
-    build_data::set_string "package_manager_version" "$(broken_tool || true)"
-  ) >/dev/null 2>&1 &
-  wait "$!" || true
-  assertFalse "guarded failing version sub must not create the marker" "[ -e '$guarded_marker' ]"
-  assertEquals "guarded failing version sub must not record a failure" "" \
-    "$(grep '^failure=' "$guarded_capture" || true)"
+	# The fix: the SAME failing tool guarded with `|| true` must not fire the trap at all.
+	(
+		build_data::set_string() { echo "$1=$2" >>"${guarded_capture}"; }
+		build_data::set_duration() { :; }
+		build_start_time=0
+		broken_tool() { return 3; }
+		export FAILURE_EMITTED_MARKER="${guarded_marker}"
+		set -euo pipefail -o errtrace
+		shopt -s inherit_errexit
+		trap 'failure::handle_uncaught' ERR
+		build_data::set_string "package_manager_version" "$(broken_tool || true)"
+	) >/dev/null 2>&1 &
+	wait "$!" || true
+	assertFalse "guarded failing version sub must not create the marker" "[ -e '${guarded_marker}' ]"
+	assertEquals "guarded failing version sub must not record a failure" "" \
+		"$(grep '^failure=' "${guarded_capture}" || true)"
 
-  rm -f "$unguarded_capture" "$guarded_capture" "$unguarded_marker" "$guarded_marker"
+	rm -f "${unguarded_capture}" "${guarded_capture}" "${unguarded_marker}" "${guarded_marker}"
 }
 
 testErrTrapReportsAndTerminatesOnUncaughtParentFailure() {
-  # A genuinely-uncaught failure at the top level of the build must fire the armed ERR trap,
-  # render the internal-error message, record failure=internal-error (plus the failing command as
-  # failure_detail), write the marker, and TERMINATE — the shell must not run past the failure.
-  # This is the run-past-failure / build-hang guard for the handler; it complements
-  # testErrTrapNotPoisonedByGuardedVersionSub (a *guarded* sub that must NOT fire the trap).
-  # Runs in a BACKGROUNDED subshell so `set -e` stays genuinely active (an inline `( … ) || true`
-  # or `if ( … )` would put it in a condition context and suppress errexit vacuously); `wait …
-  # || true` collects the exit code without aborting the runner. A regression that broke
-  # termination (or the caller stack-trace loop) would surface as "UNREACHABLE" in the output.
-  local out capture out_file marker
-  capture="$(mktemp)"
-  out_file="$(mktemp)"
-  marker="$(mktemp)" && rm -f "$marker"
-  (
-    build_data::set_string() { echo "$1=$2" >>"$capture"; }
-    build_data::set_duration() { :; }
-    build_start_time=0
-    export FAILURE_EMITTED_MARKER="$marker"
-    set -euo pipefail -o errtrace
-    shopt -s inherit_errexit
-    trap 'failure::handle_uncaught' ERR
-    heroku_broken_tool_zzz # bare, top-level, unclassified: must fire the trap and terminate
-    echo "UNREACHABLE"     # the handler must exit the build before this line runs
-  ) >"$out_file" 2>&1 &
-  wait "$!" || true
-  out="$(cat "$out_file")"
+	# A genuinely-uncaught failure at the top level of the build must fire the armed ERR trap,
+	# render the internal-error message, record failure=internal-error (plus the failing command as
+	# failure_detail), write the marker, and TERMINATE — the shell must not run past the failure.
+	# This is the run-past-failure / build-hang guard for the handler; it complements
+	# testErrTrapNotPoisonedByGuardedVersionSub (a *guarded* sub that must NOT fire the trap).
+	# Runs in a BACKGROUNDED subshell so `set -e` stays genuinely active (an inline `( … ) || true`
+	# or `if ( … )` would put it in a condition context and suppress errexit vacuously); `wait …
+	# || true` collects the exit code without aborting the runner. A regression that broke
+	# termination (or the caller stack-trace loop) would surface as "UNREACHABLE" in the output.
+	local out capture out_file marker
+	capture="$(mktemp)"
+	out_file="$(mktemp)"
+	marker="$(mktemp)" && rm -f "${marker}"
+	(
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		build_data::set_duration() { :; }
+		build_start_time=0
+		export FAILURE_EMITTED_MARKER="${marker}"
+		set -euo pipefail -o errtrace
+		shopt -s inherit_errexit
+		trap 'failure::handle_uncaught' ERR
+		heroku_broken_tool_zzz # bare, top-level, unclassified: must fire the trap and terminate
+		echo "UNREACHABLE"     # the handler must exit the build before this line runs
+	) >"${out_file}" 2>&1 &
+	wait "$!" || true
+	out="$(cat "${out_file}")"
 
-  assertContains "should render the internal-error message" "$out" "An unexpected error occurred"
-  assertContains "should name the failing command in the output" "$out" "heroku_broken_tool_zzz"
-  assertNotContains "must terminate the build before running past the failure" "$out" "UNREACHABLE"
-  assertContains "should record failure=internal-error" "$(cat "$capture")" "failure=internal-error"
-  assertContains "should record the failing command as failure_detail" \
-    "$(cat "$capture")" "failure_detail=heroku_broken_tool_zzz"
-  assertTrue "should write the marker so a re-fire would be deduped" "[ -e '$marker' ]"
-  rm -f "$capture" "$out_file" "$marker"
+	assertContains "should render the internal-error message" "${out}" "An unexpected error occurred"
+	assertContains "should name the failing command in the output" "${out}" "heroku_broken_tool_zzz"
+	assertNotContains "must terminate the build before running past the failure" "${out}" "UNREACHABLE"
+	assertContains "should record failure=internal-error" "$(cat "${capture}")" "failure=internal-error"
+	assertContains "should record the failing command as failure_detail" \
+		"$(cat "${capture}")" "failure_detail=heroku_broken_tool_zzz"
+	assertTrue "should write the marker so a re-fire would be deduped" "[ -e '${marker}' ]"
+	rm -f "${capture}" "${out_file}" "${marker}"
 }
 
 testFailureEmitDisarmsTrapOnEntry() {
-  # emit disarms the ERR trap on its first line so a hiccup *inside* emit (here: the build_data
-  # write fails) can't re-enter failure::handle_uncaught and overwrite the real classification with
-  # a generic internal-error. Runs under the real strict mode with the live trap armed, in a
-  # BACKGROUNDED subshell so `set -e` stays active (see testErrTrapNotPoisonedByGuardedVersionSub).
-  # If the disarm regressed, set_string's failure would fire the trap and the capture would also
-  # contain failure=internal-error.
-  local capture marker
-  capture="$(mktemp)"
-  marker="$(mktemp)" && rm -f "$marker"
-  (
-    # set_string fails on every call, simulating a hiccup mid-emit.
-    build_data::set_string() {
-      echo "$1=$2" >>"$capture"
-      return 1
-    }
-    build_data::set_duration() { :; }
-    build_start_time=0
-    export FAILURE_EMITTED_MARKER="$marker"
-    declare -A failure
-    failure[id]="install-dependencies::npm"
-    failure[message]="Error: Unable to install dependencies using npm."
-    set -euo pipefail -o errtrace
-    shopt -s inherit_errexit
-    trap 'failure::handle_uncaught' ERR
-    failure::emit failure
-  ) >/dev/null 2>&1 &
-  wait "$!" || true
+	# emit disarms the ERR trap on its first line so a hiccup *inside* emit (here: the build_data
+	# write fails) can't re-enter failure::handle_uncaught and overwrite the real classification with
+	# a generic internal-error. Runs under the real strict mode with the live trap armed, in a
+	# BACKGROUNDED subshell so `set -e` stays active (see testErrTrapNotPoisonedByGuardedVersionSub).
+	# If the disarm regressed, set_string's failure would fire the trap and the capture would also
+	# contain failure=internal-error.
+	local capture marker
+	capture="$(mktemp)"
+	marker="$(mktemp)" && rm -f "${marker}"
+	(
+		# set_string fails on every call, simulating a hiccup mid-emit.
+		build_data::set_string() {
+			echo "$1=$2" >>"${capture}"
+			return 1
+		}
+		build_data::set_duration() { :; }
+		build_start_time=0
+		export FAILURE_EMITTED_MARKER="${marker}"
+		declare -A failure
+		failure[id]="install-dependencies::npm"
+		failure[message]="Error: Unable to install dependencies using npm."
+		set -euo pipefail -o errtrace
+		shopt -s inherit_errexit
+		trap 'failure::handle_uncaught' ERR
+		failure::emit failure
+	) >/dev/null 2>&1 &
+	wait "$!" || true
 
-  assertContains "should record the classified failure id" \
-    "$(cat "$capture")" "failure=install-dependencies::npm"
-  assertEquals "disarm must keep the trap from overwriting the classification with internal-error" "" \
-    "$(grep '^failure=internal-error' "$capture" || true)"
-  rm -f "$capture" "$marker"
+	assertContains "should record the classified failure id" \
+		"$(cat "${capture}")" "failure=install-dependencies::npm"
+	assertEquals "disarm must keep the trap from overwriting the classification with internal-error" "" \
+		"$(grep '^failure=internal-error' "${capture}" || true)"
+	rm -f "${capture}" "${marker}"
 }
 
 testFailureHandleUncaughtRendersStackFrames() {
-  # The handler records a `caller` stack for observability. Drive it through a nested call chain so
-  # the trace has multiple frames, and assert each named frame appears — this exercises the
-  # `while read … < <(caller …)` loop past its first iteration and proves it terminates (a
-  # regression that broke the loop guards would hang instead of returning this output). Called
-  # directly (not via a real trap) so we can assert the exact frame names.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >>"$capture"; }
-    unset FAILURE_EMITTED_MARKER
-    _uncaught_frame_c() { failure::handle_uncaught; }
-    _uncaught_frame_b() { _uncaught_frame_c; }
-    _uncaught_frame_a() { _uncaught_frame_b; }
-    _uncaught_frame_a 2>&1 || true
-  )
+	# The handler records a `caller` stack for observability. Drive it through a nested call chain so
+	# the trace has multiple frames, and assert each named frame appears — this exercises the
+	# `while read … < <(caller …)` loop past its first iteration and proves it terminates (a
+	# regression that broke the loop guards would hang instead of returning this output). Called
+	# directly (not via a real trap) so we can assert the exact frame names.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		unset FAILURE_EMITTED_MARKER
+		_uncaught_frame_c() { failure::handle_uncaught; }
+		_uncaught_frame_b() { _uncaught_frame_c; }
+		_uncaught_frame_a() { _uncaught_frame_b; }
+		_uncaught_frame_a 2>&1 || true
+	)
 
-  assertContains "stack trace should name the innermost frame" "$out" "_uncaught_frame_c @"
-  assertContains "stack trace should name the middle frame" "$out" "_uncaught_frame_b @"
-  assertContains "stack trace should name the outermost frame" "$out" "_uncaught_frame_a @"
-  rm -f "$capture"
+	assertContains "stack trace should name the innermost frame" "${out}" "_uncaught_frame_c @"
+	assertContains "stack trace should name the middle frame" "${out}" "_uncaught_frame_b @"
+	assertContains "stack trace should name the outermost frame" "${out}" "_uncaught_frame_a @"
+	rm -f "${capture}"
 }
 
 testFailureHandlePipefail() {
-  # The generic pipefail helper hard-codes classification=buildpack and encodes the
-  # PIPESTATUS array into failure_detail for observability. Callers pass the id and message.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    failure::handle_pipefail "some-tool-pipefail" "0 1" "Error: log capture failed." 2>&1 || true
-  )
+	# The generic pipefail helper hard-codes classification=buildpack and encodes the
+	# PIPESTATUS array into failure_detail for observability. Callers pass the id and message.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		failure::handle_pipefail "some-tool-pipefail" "0 1" "Error: log capture failed." 2>&1 || true
+	)
 
-  assertContains "$out" "Error: log capture failed."
-  assertContains "$(cat "$capture")" "failure=some-tool-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	assertContains "${out}" "Error: log capture failed."
+	assertContains "$(cat "${capture}")" "failure=some-tool-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 testHandleGitAuthFailure() {
-  local -A result
-  failure::handle_git_auth_failure "$(pwd)/test/unit-fixtures/git-auth-failures/host-key-verification-failed.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug verbatim so downstream observability stays continuous.
-  assertEquals "private-git-dependency-without-auth" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  # Assert the exact stripped detail (not a substring) so a regression in
-  # failure::_extract_git_auth_detail's prefix stripping is caught — an unstripped
-  # `npm error Host key verification failed.` would still satisfy a contains check.
-  assertEquals "Host key verification failed." "${result[detail]}"
-  assertContains "${result[message]}" "git dependency over SSH"
+	local -A result
+	failure::handle_git_auth_failure "$(pwd)/test/unit-fixtures/git-auth-failures/host-key-verification-failed.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug verbatim so downstream observability stays continuous.
+	assertEquals "private-git-dependency-without-auth" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	# Assert the exact stripped detail (not a substring) so a regression in
+	# failure::_extract_git_auth_detail's prefix stripping is caught — an unstripped
+	# `npm error Host key verification failed.` would still satisfy a contains check.
+	assertEquals "Host key verification failed." "${result[detail]}"
+	assertContains "${result[message]}" "git dependency over SSH"
 }
 
 testHandleGitAuthNoMatchReturnsNonZero() {
-  local -A result
-  # `clean.log` is a successful install with no host-key line; the classifier should not match
-  # and should leave the array empty. Guard the call so set -e (if active) doesn't abort on the
-  # expected non-zero.
-  if failure::handle_git_auth_failure "$(pwd)/test/unit-fixtures/git-auth-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# `clean.log` is a successful install with no host-key line; the classifier should not match
+	# and should leave the array empty. Guard the call so set -e (if active) doesn't abort on the
+	# expected non-zero.
+	if failure::handle_git_auth_failure "$(pwd)/test/unit-fixtures/git-auth-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleEconnreset() {
-  local -A result
-  failure::handle_econnreset "$(pwd)/test/unit-fixtures/econnreset-failures/econnreset.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug verbatim so downstream observability stays continuous.
-  assertEquals "econnreset" "${result[id]}"
-  assertEquals "upstream" "${result[classification]}"
-  assertContains "${result[message]}" "ECONNRESET"
+	local -A result
+	failure::handle_econnreset "$(pwd)/test/unit-fixtures/econnreset-failures/econnreset.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug verbatim so downstream observability stays continuous.
+	assertEquals "econnreset" "${result[id]}"
+	assertEquals "upstream" "${result[classification]}"
+	assertContains "${result[message]}" "ECONNRESET"
 }
 
 testHandleEconnresetNoMatchReturnsNonZero() {
-  local -A result
-  # `clean.log` is a successful install with no ECONNRESET line; the classifier should not
-  # match and should leave the array empty. Guard the call so set -e (if active) doesn't abort
-  # on the expected non-zero.
-  if failure::handle_econnreset "$(pwd)/test/unit-fixtures/econnreset-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# `clean.log` is a successful install with no ECONNRESET line; the classifier should not
+	# match and should leave the array empty. Guard the call so set -e (if active) doesn't abort
+	# on the expected non-zero.
+	if failure::handle_econnreset "$(pwd)/test/unit-fixtures/econnreset-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleLibc6Incompatibility() {
-  local -A result
-  failure::handle_libc6_incompatibility "$(pwd)/test/unit-fixtures/libc6-failures/glibc-not-found.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug verbatim so downstream observability stays continuous.
-  assertEquals "libc6-incompatibility" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[message]}" "This Node.js version is not compatible with the current stack."
-  assertContains "${result[message]}" "https://help.heroku.com/R7DTSTD0"
+	local -A result
+	failure::handle_libc6_incompatibility "$(pwd)/test/unit-fixtures/libc6-failures/glibc-not-found.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug verbatim so downstream observability stays continuous.
+	assertEquals "libc6-incompatibility" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[message]}" "This Node.js version is not compatible with the current stack."
+	assertContains "${result[message]}" "https://help.heroku.com/R7DTSTD0"
 }
 
 testHandleLibc6IncompatibilityNoMatchReturnsNonZero() {
-  local -A result
-  # `clean.log` is a successful install with no GLIBC line; the classifier should not match and
-  # should leave the array empty. Guard the call so set -e (if active) doesn't abort on the
-  # expected non-zero.
-  if failure::handle_libc6_incompatibility "$(pwd)/test/unit-fixtures/libc6-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# `clean.log` is a successful install with no GLIBC line; the classifier should not match and
+	# should leave the array empty. Guard the call so set -e (if active) doesn't abort on the
+	# expected non-zero.
+	if failure::handle_libc6_incompatibility "$(pwd)/test/unit-fixtures/libc6-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleBuildScriptFailureOpensslUnsupportedAlgorithm() {
-  local -A result
-  package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug verbatim so downstream observability stays continuous.
-  assertEquals "openssl-unsupported-algorithm" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[message]}" "Unsupported cryptographic algorithm used"
-  assertContains "${result[message]}" "update any dependencies that may be causing the issue"
-  assertContains "${result[message]}" "NODE_OPTIONS=--openssl-legacy-provider"
-  if [[ "${result[message]}" == *"webpack"* ]]; then
-    fail "base OSSL message should not mention Webpack"
-  fi
+	local -A result
+	package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug verbatim so downstream observability stays continuous.
+	assertEquals "openssl-unsupported-algorithm" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[message]}" "Unsupported cryptographic algorithm used"
+	assertContains "${result[message]}" "update any dependencies that may be causing the issue"
+	assertContains "${result[message]}" "NODE_OPTIONS=--openssl-legacy-provider"
+	if [[ "${result[message]}" == *"webpack"* ]]; then
+		fail "base OSSL message should not mention Webpack"
+	fi
 }
 
 testHandleBuildScriptFailureOpensslUnsupportedAlgorithmWebpack() {
-  local -A result
-  package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm-webpack.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug verbatim so downstream observability stays continuous.
-  assertEquals "openssl-unsupported-algorithm-webpack" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[message]}" "Unsupported cryptographic algorithm used"
-  assertContains "${result[message]}" "output.hashFunction"
-  assertContains "${result[message]}" "https://webpack.js.org/configuration/output/#outputhashfunction"
+	local -A result
+	package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm-webpack.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug verbatim so downstream observability stays continuous.
+	assertEquals "openssl-unsupported-algorithm-webpack" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[message]}" "Unsupported cryptographic algorithm used"
+	assertContains "${result[message]}" "output.hashFunction"
+	assertContains "${result[message]}" "https://webpack.js.org/configuration/output/#outputhashfunction"
 }
 
 testHandleBuildScriptFailureNodeOutOfMemory() {
-  local -A result
-  package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/node-out-of-memory.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug verbatim so downstream observability stays continuous.
-  assertEquals "node-out-of-memory" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[message]}" "Node.js Out-Of-Memory (OOM)"
-  assertContains "${result[message]}" "NODE_OPTIONS=\"--max-old-space-size=VALUE_IN_MB\""
+	local -A result
+	package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/node-out-of-memory.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug verbatim so downstream observability stays continuous.
+	assertEquals "node-out-of-memory" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[message]}" "Node.js Out-Of-Memory (OOM)"
+	assertContains "${result[message]}" "NODE_OPTIONS=\"--max-old-space-size=VALUE_IN_MB\""
 }
 
 testHandleBuildScriptFailureNoMatchReturnsNonZero() {
-  local -A result
-  # `clean.log` is a successful build with no OSSL error; the classifier should not match and
-  # should leave the array empty. Guard the call so set -e (if active) doesn't abort on the
-  # expected non-zero.
-  if package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# `clean.log` is a successful build with no OSSL error; the classifier should not match and
+	# should leave the array empty. Guard the call so set -e (if active) doesn't abort on the
+	# expected non-zero.
+	if package_manager::_handle_build_script_failure "$(pwd)/test/unit-fixtures/build-script-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testFailuresLibDoesNotLeakShellOptions() {
-  # Source the lib in a fresh subshell that does NOT have nounset enabled, and confirm
-  # nounset is still off afterwards (i.e. the lib restored our options instead of leaving
-  # `set -u` on). `set -o` prints the active options; nounset should read "off".
-  local nounset_after
-  nounset_after=$(
-    set +u
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/failures.sh"
-    set -o | awk '$1 == "nounset" { print $2 }'
-  )
-  assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
+	# Source the lib in a fresh subshell that does NOT have nounset enabled, and confirm
+	# nounset is still off afterwards (i.e. the lib restored our options instead of leaving
+	# `set -u` on). `set -o` prints the active options; nounset should read "off".
+	local nounset_after
+	nounset_after=$(
+		set +u
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/failures.sh"
+		set -o | awk '$1 == "nounset" { print $2 }'
+	)
+	assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
 }
 
 testFailuresLibDoesNotLeakErrexit() {
-  # Regression guard: bin/compile runs under `set -e`. If the lib captures the caller's
-  # options with `$(set +o)`, bash forces errexit off inside that command-substitution
-  # subshell, so the epilogue would wrongly restore errexit as DISABLED — silencing real
-  # build failures. Source the lib in a subshell that has errexit ON and confirm `$-` still
-  # carries `e` afterwards. `$-` is read directly (not via another `$(...)`, which would
-  # itself drop errexit and mask the result).
-  local errexit_after
-  errexit_after=$(
-    set -e
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/failures.sh"
-    case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
-  )
-  assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
+	# Regression guard: bin/compile runs under `set -e`. If the lib captures the caller's
+	# options with `$(set +o)`, bash forces errexit off inside that command-substitution
+	# subshell, so the epilogue would wrongly restore errexit as DISABLED — silencing real
+	# build failures. Source the lib in a subshell that has errexit ON and confirm `$-` still
+	# carries `e` afterwards. `$-` is read directly (not via another `$(...)`, which would
+	# itself drop errexit and mask the result).
+	local errexit_after
+	errexit_after=$(
+		set -e
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/failures.sh"
+		case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
+	)
+	assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
 }
 
 testPackageManagerLibDoesNotLeakShellOptions() {
-  # Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated package_manager lib:
-  # sourcing it must restore the caller's nounset rather than leaving `set -u` on.
-  local nounset_after
-  nounset_after=$(
-    set +u
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/package_manager.sh"
-    set -o | awk '$1 == "nounset" { print $2 }'
-  )
-  assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
+	# Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated package_manager lib:
+	# sourcing it must restore the caller's nounset rather than leaving `set -u` on.
+	local nounset_after
+	nounset_after=$(
+		set +u
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/package_manager.sh"
+		set -o | awk '$1 == "nounset" { print $2 }'
+	)
+	assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
 }
 
 testPackageManagerLibDoesNotLeakErrexit() {
-  # Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the package_manager lib.
-  local errexit_after
-  errexit_after=$(
-    set -e
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/package_manager.sh"
-    case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
-  )
-  assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
+	# Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the package_manager lib.
+	local errexit_after
+	errexit_after=$(
+		set -e
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/package_manager.sh"
+		case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
+	)
+	assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
 }
 
 testYarnLibDoesNotLeakShellOptions() {
-  # Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated yarn lib: sourcing
-  # it must restore the caller's nounset rather than leaving `set -u` on.
-  local nounset_after
-  nounset_after=$(
-    set +u
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/package_managers/yarn.sh"
-    set -o | awk '$1 == "nounset" { print $2 }'
-  )
-  assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
+	# Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated yarn lib: sourcing
+	# it must restore the caller's nounset rather than leaving `set -u` on.
+	local nounset_after
+	nounset_after=$(
+		set +u
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/package_managers/yarn.sh"
+		set -o | awk '$1 == "nounset" { print $2 }'
+	)
+	assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
 }
 
 testYarnLibDoesNotLeakErrexit() {
-  # Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the yarn lib.
-  local errexit_after
-  errexit_after=$(
-    set -e
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/package_managers/yarn.sh"
-    case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
-  )
-  assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
+	# Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the yarn lib.
+	local errexit_after
+	errexit_after=$(
+		set -e
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/package_managers/yarn.sh"
+		case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
+	)
+	assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
 }
 
 testPnpmLibDoesNotLeakShellOptions() {
-  # Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated pnpm lib: sourcing
-  # it must restore the caller's nounset rather than leaving `set -u` on.
-  local nounset_after
-  nounset_after=$(
-    set +u
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/package_managers/pnpm.sh"
-    set -o | awk '$1 == "nounset" { print $2 }'
-  )
-  assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
+	# Same guard as testFailuresLibDoesNotLeakShellOptions, for the migrated pnpm lib: sourcing
+	# it must restore the caller's nounset rather than leaving `set -u` on.
+	local nounset_after
+	nounset_after=$(
+		set +u
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/package_managers/pnpm.sh"
+		set -o | awk '$1 == "nounset" { print $2 }'
+	)
+	assertEquals "nounset should be restored to off after sourcing" "off" "${nounset_after}"
 }
 
 testPnpmLibDoesNotLeakErrexit() {
-  # Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the pnpm lib.
-  local errexit_after
-  errexit_after=$(
-    set -e
-    # shellcheck source=/dev/null
-    source "$(pwd)/lib/package_managers/pnpm.sh"
-    case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
-  )
-  assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
+	# Same errexit-restoration guard as testFailuresLibDoesNotLeakErrexit, for the pnpm lib.
+	local errexit_after
+	errexit_after=$(
+		set -e
+		# shellcheck source=/dev/null
+		source "$(pwd)/lib/package_managers/pnpm.sh"
+		case "$-" in *e*) echo "on" ;; *) echo "off" ;; esac
+	)
+	assertEquals "errexit should remain on after sourcing" "on" "${errexit_after}"
 }
 
 testHandleNpmInstallEbadplatform() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "npm-ebadplatform" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  # Detail carries the npm code plus the first descriptive error line.
-  assertContains "${result[detail]}" "EBADPLATFORM:"
-  assertContains "${result[detail]}" "Unsupported platform"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "npm-ebadplatform" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	# Detail carries the npm code plus the first descriptive error line.
+	assertContains "${result[detail]}" "EBADPLATFORM:"
+	assertContains "${result[detail]}" "Unsupported platform"
 }
 
 testHandleNpmInstallInvalidName() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/einvalidpackagename.log" result
-  assertEquals "npm-package-name-typo" "${result[id]}"
-  assertContains "${result[detail]}" "EINVALIDPACKAGENAME:"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/einvalidpackagename.log" result
+	assertEquals "npm-package-name-typo" "${result[id]}"
+	assertContains "${result[detail]}" "EINVALIDPACKAGENAME:"
 }
 
 testHandleNpmInstall404() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/e404.log" result
-  assertEquals "module-404" "${result[id]}"
-  assertContains "${result[detail]}" "E404:"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/e404.log" result
+	assertEquals "module-404" "${result[id]}"
+	assertContains "${result[detail]}" "E404:"
 }
 
 testHandleNpmInstallFlatmapStream() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/flatmap-stream.log" result
-  assertEquals "flatmap-stream-404" "${result[id]}"
-  assertContains "${result[message]}" "flatmap-stream module has been removed"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/flatmap-stream.log" result
+	assertEquals "flatmap-stream-404" "${result[id]}"
+	assertContains "${result[message]}" "flatmap-stream module has been removed"
 }
 
 testHandleNpmInstallStrictAllowScripts() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/estrictallowscripts.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "npm-strict-allow-scripts" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "ESTRICTALLOWSCRIPTS:"
-  assertContains "${result[message]}" "npm approve-scripts"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/estrictallowscripts.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "npm-strict-allow-scripts" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "ESTRICTALLOWSCRIPTS:"
+	assertContains "${result[message]}" "npm approve-scripts"
 }
 
 testHandleNpmInstallAllowGitBlocked() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowgit.log" result
-  assertEquals "npm-allow-git-blocked" "${result[id]}"
-  assertContains "${result[detail]}" "EALLOWGIT:"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[message]}" "git repository"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowgit.log" result
+	assertEquals "npm-allow-git-blocked" "${result[id]}"
+	assertContains "${result[detail]}" "EALLOWGIT:"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[message]}" "git repository"
 }
 
 testHandleNpmInstallAllowRemoteBlocked() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowremote.log" result
-  assertEquals "npm-allow-remote-blocked" "${result[id]}"
-  assertContains "${result[detail]}" "EALLOWREMOTE:"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[message]}" "remote URL"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eallowremote.log" result
+	assertEquals "npm-allow-remote-blocked" "${result[id]}"
+	assertContains "${result[detail]}" "EALLOWREMOTE:"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[message]}" "remote URL"
 }
 
 testHandleNpmInstallEresolve() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eresolve.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # The legacy failure id is preserved verbatim so the `failure` build-data key stays continuous
-  # for downstream metrics.
-  assertEquals "npm-peer-dependency-conflict" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "ERESOLVE:"
-  assertContains "${result[detail]}" "could not resolve"
-  # The migrated message still surfaces the legacy_peer_deps workaround verbatim.
-  assertContains "${result[message]}" "npm_config_legacy_peer_deps=true"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eresolve.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# The legacy failure id is preserved verbatim so the `failure` build-data key stays continuous
+	# for downstream metrics.
+	assertEquals "npm-peer-dependency-conflict" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "ERESOLVE:"
+	assertContains "${result[detail]}" "could not resolve"
+	# The migrated message still surfaces the legacy_peer_deps workaround verbatim.
+	assertContains "${result[message]}" "npm_config_legacy_peer_deps=true"
 }
 
 testHandleNpmInstallLockfileOutOfSync() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eusage.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
-  assertEquals "npm-lockfile-out-of-sync" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "EUSAGE:"
-  assertContains "${result[detail]}" "package.json and package-lock.json are in sync"
-  assertContains "${result[message]}" "npm lockfile is not in sync"
-  assertContains "${result[message]}" "npm install"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/eusage.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so Honeycomb dashboards keep working.
+	assertEquals "npm-lockfile-out-of-sync" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "EUSAGE:"
+	assertContains "${result[detail]}" "package.json and package-lock.json are in sync"
+	assertContains "${result[message]}" "npm lockfile is not in sync"
+	assertContains "${result[message]}" "npm install"
 }
 
 testHandleNpmInstallBadVersion() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/notarget.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so downstream metrics stay continuous.
-  assertEquals "bad-version-for-dependency" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "ETARGET:"
-  assertContains "${result[detail]}" "No matching version found"
-  assertContains "${result[message]}" "does not exist"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/notarget.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so downstream metrics stay continuous.
+	assertEquals "bad-version-for-dependency" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "ETARGET:"
+	assertContains "${result[detail]}" "No matching version found"
+	assertContains "${result[message]}" "does not exist"
 }
 
 testHandleNpmInstallDependencyFailedToBuild() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/dependency-failed-to-build.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # The legacy failure id is preserved verbatim so the `failure` build-data key stays continuous.
-  assertEquals "dependency-failed-to-build" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "ELIFECYCLE:"
-  assertContains "${result[message]}" "install script for one of your dependencies failed"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/dependency-failed-to-build.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# The legacy failure id is preserved verbatim so the `failure` build-data key stays continuous.
+	assertEquals "dependency-failed-to-build" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "ELIFECYCLE:"
+	assertContains "${result[message]}" "install script for one of your dependencies failed"
 }
 
 testHandleNpmInstallBcryptMatchesGenericDependencyFailedToBuild() {
-  local -A result
-  # bcrypt install-script failures have no error code or user text of their own beyond the
-  # generic ELIFECYCLE "Failed at the <pkg> install script" signal, so they are not migrated as
-  # a distinct matcher — they classify under the same generic dependency-failed-to-build id as
-  # any other native-addon build failure.
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/bcrypt-install-script.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "dependency-failed-to-build" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
+	local -A result
+	# bcrypt install-script failures have no error code or user text of their own beyond the
+	# generic ELIFECYCLE "Failed at the <pkg> install script" signal, so they are not migrated as
+	# a distinct matcher — they classify under the same generic dependency-failed-to-build id as
+	# any other native-addon build failure.
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/bcrypt-install-script.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "dependency-failed-to-build" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
 }
 
 testHandleNpmInstallEnoent() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/enoent.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so downstream metrics stay continuous.
-  assertEquals "npm-enoent" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "ENOENT:"
-  assertContains "${result[detail]}" "syscall open"
-  assertContains "${result[message]}" "npm could not find a file or directory"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/enoent.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so downstream metrics stay continuous.
+	assertEquals "npm-enoent" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "ENOENT:"
+	assertContains "${result[detail]}" "syscall open"
+	assertContains "${result[message]}" "npm could not find a file or directory"
 }
 
 testHandleNpmInstallGitDependency() {
-  local -A result
-  package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/git-dependency.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so Honeycomb/build-data metrics stay continuous.
-  assertEquals "npm-install-git-dependency" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "128:"
-  assertContains "${result[message]}" "npm Git dependency error (code 128)"
+	local -A result
+	package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/git-dependency.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so Honeycomb/build-data metrics stay continuous.
+	assertEquals "npm-install-git-dependency" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "128:"
+	assertContains "${result[message]}" "npm Git dependency error (code 128)"
 }
 
 testHandleNpmInstallGitDependencyHostKeyGuardIsNoOp() {
-  # A missing-auth failure ("Host key verification failed") is also a GitUnknownError with git
-  # exit 128, so this matcher excludes it defensively — but in practice the exclusion never
-  # matters: at every call site, failure::handle_git_auth_failure runs first (elif, before the
-  # npm-specific classifier) and claims host-key failures before this matcher is ever reached.
-  # This test bypasses that call-site ordering by invoking the npm classifier directly, so the
-  # exclusion is exercised here even though it is a no-op in the real control flow.
-  local -A result
-  if package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/git-dependency-host-key.log" result; then
-    fail "expected classifier to return non-zero for a host-key (missing-auth) git failure"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	# A missing-auth failure ("Host key verification failed") is also a GitUnknownError with git
+	# exit 128, so this matcher excludes it defensively — but in practice the exclusion never
+	# matters: at every call site, failure::handle_git_auth_failure runs first (elif, before the
+	# npm-specific classifier) and claims host-key failures before this matcher is ever reached.
+	# This test bypasses that call-site ordering by invoking the npm classifier directly, so the
+	# exclusion is exercised here even though it is a no-op in the real control flow.
+	local -A result
+	if package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/git-dependency-host-key.log" result; then
+		fail "expected classifier to return non-zero for a host-key (missing-auth) git failure"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleInstallPipefail() {
-  # The npm-specific pipefail wrapper owns the failure id and the user-facing message;
-  # verify both plus the buildpack classification and PIPESTATUS detail inherited from
-  # failure::handle_pipefail. Shared by install_dependencies and rebuild_dependencies.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::npm::_handle_install_pipefail "0 1" 2>&1 || true
-  )
+	# The npm-specific pipefail wrapper owns the failure id and the user-facing message;
+	# verify both plus the buildpack classification and PIPESTATUS detail inherited from
+	# failure::handle_pipefail. Shared by install_dependencies and rebuild_dependencies.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::npm::_handle_install_pipefail "0 1" 2>&1 || true
+	)
 
-  assertContains "$out" "Unable to capture the npm install log output"
-  assertContains "$out" "ran out of disk space"
-  assertContains "$(cat "$capture")" "failure=npm-install-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	assertContains "${out}" "Unable to capture the npm install log output"
+	assertContains "${out}" "ran out of disk space"
+	assertContains "$(cat "${capture}")" "failure=npm-install-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 testHandlePrunePipefail() {
-  # The npm-specific prune pipefail wrapper owns the failure id and the user-facing message;
-  # verify both plus the buildpack classification and PIPESTATUS detail inherited from
-  # failure::handle_pipefail.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::npm::_handle_prune_pipefail "0 1" 2>&1 || true
-  )
+	# The npm-specific prune pipefail wrapper owns the failure id and the user-facing message;
+	# verify both plus the buildpack classification and PIPESTATUS detail inherited from
+	# failure::handle_pipefail.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::npm::_handle_prune_pipefail "0 1" 2>&1 || true
+	)
 
-  assertContains "$out" "Unable to capture the npm prune log output"
-  assertContains "$out" "ran out of disk space"
-  assertContains "$(cat "$capture")" "failure=npm-prune-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	assertContains "${out}" "Unable to capture the npm prune log output"
+	assertContains "${out}" "ran out of disk space"
+	assertContains "$(cat "${capture}")" "failure=npm-prune-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 testHandleNpmInstallNoMatchReturnsNonZero() {
-  local -A result
-  # `clean.log` is a successful install; the classifier should not match and should leave the
-  # array empty. Guard the call so set -e (if active) doesn't abort on the expected non-zero.
-  if package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# `clean.log` is a successful install; the classifier should not match and should leave the
+	# array empty. Guard the call so set -e (if active) doesn't abort on the expected non-zero.
+	if package_managers::npm::_handle_npm_install_failure "$(pwd)/test/unit-fixtures/npm-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleYarnInstallLockfileNeedsUpdate() {
-  local -A result
-  package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/lockfile-needs-update.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
-  assertEquals "outdated-yarn-lockfile" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "Your lockfile needs to be updated"
-  assertContains "${result[message]}" "Outdated Yarn lockfile"
-  assertContains "${result[message]}" "yarn install"
+	local -A result
+	package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/lockfile-needs-update.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so Honeycomb dashboards keep working.
+	assertEquals "outdated-yarn-lockfile" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "Your lockfile needs to be updated"
+	assertContains "${result[message]}" "Outdated Yarn lockfile"
+	assertContains "${result[message]}" "yarn install"
 }
 
 testHandleYarnInstallOutdatedYarn() {
-  local -A result
-  package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/outdated-yarn.log" result "0.16.1"
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
-  assertEquals "outdated-yarn" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "install"
-  assertContains "${result[detail]}" "has been replaced with"
-  assertContains "${result[message]}" "Outdated Yarn version"
-  assertContains "${result[message]}" "does not support the --frozen-lockfile option"
-  assertContains "${result[message]}" "at least 0.19"
-  # The caller-supplied version is interpolated into the message (title + parenthetical).
-  assertContains "${result[message]}" "Outdated Yarn version: 0.16.1"
-  assertContains "${result[message]}" "Yarn (0.16.1)"
+	local -A result
+	package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/outdated-yarn.log" result "0.16.1"
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so Honeycomb dashboards keep working.
+	assertEquals "outdated-yarn" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "install"
+	assertContains "${result[detail]}" "has been replaced with"
+	assertContains "${result[message]}" "Outdated Yarn version"
+	assertContains "${result[message]}" "does not support the --frozen-lockfile option"
+	assertContains "${result[message]}" "at least 0.19"
+	# The caller-supplied version is interpolated into the message (title + parenthetical).
+	assertContains "${result[message]}" "Outdated Yarn version: 0.16.1"
+	assertContains "${result[message]}" "Yarn (0.16.1)"
 }
 
 testHandleYarnInstallBadVersion() {
-  local -A result
-  package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/no-matching-version.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so downstream metrics stay continuous.
-  assertEquals "bad-version-for-dependency" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "Couldn't find any versions for"
-  assertContains "${result[message]}" "does not exist"
+	local -A result
+	package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/no-matching-version.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so downstream metrics stay continuous.
+	assertEquals "bad-version-for-dependency" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "Couldn't find any versions for"
+	assertContains "${result[message]}" "does not exist"
 }
 
 testHandleYarnInstallNoMatchReturnsNonZero() {
-  local -A result
-  if package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	if package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testMatchClassicRegistry404() {
-  local -A result
-  package_managers::yarn::_match_classic_registry_404 "$(pwd)/test/unit-fixtures/yarn-failures/e404.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Reuses npm's E404 id/classification (package_managers::npm::_handle_npm_install_failure) so
-  # the metric is unified across tools regardless of which one hit the 404.
-  assertEquals "module-404" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "Request failed"
-  assertContains "${result[message]}" "Unable to install dependencies using Yarn"
+	local -A result
+	package_managers::yarn::_match_classic_registry_404 "$(pwd)/test/unit-fixtures/yarn-failures/e404.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Reuses npm's E404 id/classification (package_managers::npm::_handle_npm_install_failure) so
+	# the metric is unified across tools regardless of which one hit the 404.
+	assertEquals "module-404" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "Request failed"
+	assertContains "${result[message]}" "Unable to install dependencies using Yarn"
 }
 
 testMatchClassicRegistry404FlatmapStream() {
-  local -A result
-  package_managers::yarn::_match_classic_registry_404 "$(pwd)/test/unit-fixtures/yarn-failures/flatmap-stream.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "flatmap-stream-404" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  assertContains "${result[detail]}" "Request failed"
-  assertContains "${result[message]}" "flatmap-stream module has been removed"
+	local -A result
+	package_managers::yarn::_match_classic_registry_404 "$(pwd)/test/unit-fixtures/yarn-failures/flatmap-stream.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "flatmap-stream-404" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	assertContains "${result[detail]}" "Request failed"
+	assertContains "${result[message]}" "flatmap-stream module has been removed"
 }
 
 testMatchClassicRegistry404NoMatchReturnsNonZero() {
-  local -A result
-  if package_managers::yarn::_match_classic_registry_404 "$(pwd)/test/unit-fixtures/yarn-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	if package_managers::yarn::_match_classic_registry_404 "$(pwd)/test/unit-fixtures/yarn-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleYarnInstall404() {
-  local -A result
-  # Verifies the shared registry-404 matcher is wired into the classic install classifier.
-  package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/e404.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "module-404" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
+	local -A result
+	# Verifies the shared registry-404 matcher is wired into the classic install classifier.
+	package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/e404.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "module-404" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
 }
 
 testHandleYarnInstallFlatmapStream() {
-  local -A result
-  package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/flatmap-stream.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "flatmap-stream-404" "${result[id]}"
+	local -A result
+	package_managers::yarn::_handle_yarn_classic_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/flatmap-stream.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "flatmap-stream-404" "${result[id]}"
 }
 
 testHandleYarnBerryInstallLockfileOutOfSync() {
-  local -A result
-  package_managers::yarn::_handle_yarn_berry_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/berry-lockfile-out-of-sync.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
-  assertEquals "yarn-lockfile-out-of-sync" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  # Detail carries the Berry code plus the framed error line's descriptive text.
-  assertContains "${result[detail]}" "YN0028:"
-  assertContains "${result[detail]}" "The lockfile would have been modified"
-  assertContains "${result[message]}" "Yarn lockfile is not in sync"
-  assertContains "${result[message]}" "--immutable"
-  assertContains "${result[message]}" "yarn install"
+	local -A result
+	package_managers::yarn::_handle_yarn_berry_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/berry-lockfile-out-of-sync.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	# Preserve the legacy failure slug so Honeycomb dashboards keep working.
+	assertEquals "yarn-lockfile-out-of-sync" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	# Detail carries the Berry code plus the framed error line's descriptive text.
+	assertContains "${result[detail]}" "YN0028:"
+	assertContains "${result[detail]}" "The lockfile would have been modified"
+	assertContains "${result[message]}" "Yarn lockfile is not in sync"
+	assertContains "${result[message]}" "--immutable"
+	assertContains "${result[message]}" "yarn install"
 }
 
 testHandleYarnBerryInstallNoMatchReturnsNonZero() {
-  local -A result
-  # The yarn 1.x clean fixture has no YN codes at all, which is enough to exercise the
-  # no-match path for the Berry classifier.
-  if package_managers::yarn::_handle_yarn_berry_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# The yarn 1.x clean fixture has no YN codes at all, which is enough to exercise the
+	# no-match path for the Berry classifier.
+	if package_managers::yarn::_handle_yarn_berry_install_failure "$(pwd)/test/unit-fixtures/yarn-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleYarnInstallPipefail() {
-  # The yarn-specific pipefail wrapper owns the failure id and the user-facing message;
-  # verify both plus the buildpack classification and PIPESTATUS detail inherited from
-  # failure::handle_pipefail.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::yarn::_handle_install_pipefail "0 1" 2>&1 || true
-  )
+	# The yarn-specific pipefail wrapper owns the failure id and the user-facing message;
+	# verify both plus the buildpack classification and PIPESTATUS detail inherited from
+	# failure::handle_pipefail.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::_handle_install_pipefail "0 1" 2>&1 || true
+	)
 
-  assertContains "$out" "Unable to capture the yarn install log output"
-  assertContains "$out" "ran out of disk space"
-  assertContains "$(cat "$capture")" "failure=yarn-install-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	assertContains "${out}" "Unable to capture the yarn install log output"
+	assertContains "${out}" "ran out of disk space"
+	assertContains "$(cat "${capture}")" "failure=yarn-install-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 testFailProductionEnvSetPrunesWhenProductionTrue() {
-  # YARN_PRODUCTION=true meant "production install" under yarn 1.x, so the migration guidance keeps
-  # pruning by recommending YARN2_SKIP_PRUNING=false.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >>"$capture"; }
-    package_managers::yarn::fail_if_yarn_production_env_set_on_berry "true" 2>&1 || true
-  )
+	# YARN_PRODUCTION=true meant "production install" under yarn 1.x, so the migration guidance keeps
+	# pruning by recommending YARN2_SKIP_PRUNING=false.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::fail_if_yarn_production_env_set_on_berry "true" 2>&1 || true
+	)
 
-  assertContains "$out" "Unsupported Yarn configuration: YARN_PRODUCTION"
-  assertContains "$out" "heroku config:unset YARN_PRODUCTION"
-  assertContains "$out" "heroku config:set YARN2_SKIP_PRUNING=false"
-  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
-  assertContains "$(cat "$capture")" "failure=yarn2-with-yarn-production-env-set"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	assertContains "${out}" "Unsupported Yarn configuration: YARN_PRODUCTION"
+	assertContains "${out}" "heroku config:unset YARN_PRODUCTION"
+	assertContains "${out}" "heroku config:set YARN2_SKIP_PRUNING=false"
+	# Preserve the legacy failure slug so Honeycomb dashboards keep working.
+	assertContains "$(cat "${capture}")" "failure=yarn2-with-yarn-production-env-set"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testFailProductionEnvSetSkipsPruneForOtherValues() {
-  # Any non-"true" value meant "keep devDependencies", so the guidance skips pruning
-  # (YARN2_SKIP_PRUNING=true).
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >>"$capture"; }
-    package_managers::yarn::fail_if_yarn_production_env_set_on_berry "false" 2>&1 || true
-  )
+	# Any non-"true" value meant "keep devDependencies", so the guidance skips pruning
+	# (YARN2_SKIP_PRUNING=true).
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::fail_if_yarn_production_env_set_on_berry "false" 2>&1 || true
+	)
 
-  assertContains "$out" "heroku config:set YARN2_SKIP_PRUNING=true"
-  assertContains "$(cat "$capture")" "failure=yarn2-with-yarn-production-env-set"
-  rm -f "$capture"
+	assertContains "${out}" "heroku config:set YARN2_SKIP_PRUNING=true"
+	assertContains "$(cat "${capture}")" "failure=yarn2-with-yarn-production-env-set"
+	rm -f "${capture}"
 }
 
 testFailProductionEnvSetIsNoOpWhenUnset() {
-  # The guard is invoked unconditionally from bin/compile, so an unset YARN_PRODUCTION must not
-  # emit or fail — it returns 0 with no output and no build-data writes.
-  local out capture rc
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >>"$capture"; }
-    package_managers::yarn::fail_if_yarn_production_env_set_on_berry "" 2>&1
-  ) && rc=0 || rc=$?
+	# The guard is invoked unconditionally from bin/compile, so an unset YARN_PRODUCTION must not
+	# emit or fail — it returns 0 with no output and no build-data writes.
+	local out capture rc
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::fail_if_yarn_production_env_set_on_berry "" 2>&1
+	) && rc=0 || rc=$?
 
-  assertEquals "guard should return 0 when YARN_PRODUCTION is unset" "0" "${rc}"
-  assertEquals "guard should emit nothing when YARN_PRODUCTION is unset" "" "$out"
-  assertEquals "guard should not write build data when YARN_PRODUCTION is unset" "" "$(cat "$capture")"
-  rm -f "$capture"
+	assertEquals "guard should return 0 when YARN_PRODUCTION is unset" "0" "${rc}"
+	assertEquals "guard should emit nothing when YARN_PRODUCTION is unset" "" "${out}"
+	assertEquals "guard should not write build data when YARN_PRODUCTION is unset" "" "$(cat "${capture}")"
+	rm -f "${capture}"
 }
 
 testHandlePnpmInstallLockfileOutOfSync() {
-  local -A result
-  package_managers::pnpm::_handle_install_failure "$(pwd)/test/unit-fixtures/pnpm-failures/outdated-lockfile.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "pnpm-lockfile-out-of-sync" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
-  # Detail carries the pnpm code plus the first descriptive error line.
-  assertContains "${result[detail]}" "ERR_PNPM_OUTDATED_LOCKFILE:"
-  assertContains "${result[detail]}" "is not up to date"
-  assertContains "${result[message]}" "pnpm lockfile is not in sync"
-  assertContains "${result[message]}" "pnpm install"
+	local -A result
+	package_managers::pnpm::_handle_install_failure "$(pwd)/test/unit-fixtures/pnpm-failures/outdated-lockfile.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "pnpm-lockfile-out-of-sync" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
+	# Detail carries the pnpm code plus the first descriptive error line.
+	assertContains "${result[detail]}" "ERR_PNPM_OUTDATED_LOCKFILE:"
+	assertContains "${result[detail]}" "is not up to date"
+	assertContains "${result[message]}" "pnpm lockfile is not in sync"
+	assertContains "${result[message]}" "pnpm install"
 }
 
 testHandlePnpmInstallNoMatchReturnsNonZero() {
-  local -A result
-  # `clean.log` is a successful install; the classifier should not match and should leave the
-  # array empty. Guard the call so set -e (if active) doesn't abort on the expected non-zero.
-  if package_managers::pnpm::_handle_install_failure "$(pwd)/test/unit-fixtures/pnpm-failures/clean.log" result; then
-    fail "expected classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# `clean.log` is a successful install; the classifier should not match and should leave the
+	# array empty. Guard the call so set -e (if active) doesn't abort on the expected non-zero.
+	if package_managers::pnpm::_handle_install_failure "$(pwd)/test/unit-fixtures/pnpm-failures/clean.log" result; then
+		fail "expected classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandlePnpmInstallPipefail() {
-  # The pnpm-specific pipefail wrapper owns the failure id and the user-facing message;
-  # verify both plus the buildpack classification and PIPESTATUS detail inherited from
-  # failure::handle_pipefail.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::pnpm::_handle_install_pipefail "0 1" 2>&1 || true
-  )
+	# The pnpm-specific pipefail wrapper owns the failure id and the user-facing message;
+	# verify both plus the buildpack classification and PIPESTATUS detail inherited from
+	# failure::handle_pipefail.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::pnpm::_handle_install_pipefail "0 1" 2>&1 || true
+	)
 
-  assertContains "$out" "Unable to capture the pnpm install log output"
-  assertContains "$out" "ran out of disk space"
-  assertContains "$(cat "$capture")" "failure=pnpm-install-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	assertContains "${out}" "Unable to capture the pnpm install log output"
+	assertContains "${out}" "ran out of disk space"
+	assertContains "$(cat "${capture}")" "failure=pnpm-install-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 testHandlePnpmPrunePipefail() {
-  # The pnpm-prune pipefail wrapper owns the failure id and the user-facing message; verify
-  # both plus the buildpack classification and PIPESTATUS detail inherited from
-  # failure::handle_pipefail. Both prune paths share this wrapper.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::pnpm::_handle_prune_pipefail "0 1" 2>&1 || true
-  )
+	# The pnpm-prune pipefail wrapper owns the failure id and the user-facing message; verify
+	# both plus the buildpack classification and PIPESTATUS detail inherited from
+	# failure::handle_pipefail. Both prune paths share this wrapper.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::pnpm::_handle_prune_pipefail "0 1" 2>&1 || true
+	)
 
-  assertContains "$out" "Unable to capture the pnpm prune log output"
-  assertContains "$out" "ran out of disk space"
-  assertContains "$(cat "$capture")" "failure=pnpm-prune-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	assertContains "${out}" "Unable to capture the pnpm prune log output"
+	assertContains "${out}" "ran out of disk space"
+	assertContains "$(cat "${capture}")" "failure=pnpm-prune-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 testPnpmExtractErrorDetailReturnsFirstDescriptiveLine() {
-  # Strips the leading `[ERR_PNPM_<CODE>] ` bracket prefix from the rendered summary line.
-  local detail
-  detail=$(package_managers::pnpm::_extract_error_detail "$(pwd)/test/unit-fixtures/pnpm-failures/outdated-lockfile.log")
-  assertEquals "Cannot install with \"frozen-lockfile\" because pnpm-lock.yaml is not up to date with <ROOT>/package.json" "$detail"
+	# Strips the leading `[ERR_PNPM_<CODE>] ` bracket prefix from the rendered summary line.
+	local detail
+	detail=$(package_managers::pnpm::_extract_error_detail "$(pwd)/test/unit-fixtures/pnpm-failures/outdated-lockfile.log")
+	assertEquals "Cannot install with \"frozen-lockfile\" because pnpm-lock.yaml is not up to date with <ROOT>/package.json" "${detail}"
 }
 
 testPnpmExtractErrorDetailEmptyWhenNoDescriptiveLine() {
-  # A log with no `[ERR_PNPM_...]` summary line yields empty detail without erroring.
-  local detail
-  detail=$(package_managers::pnpm::_extract_error_detail "$(pwd)/test/unit-fixtures/pnpm-failures/clean.log")
-  assertEquals "" "$detail"
+	# A log with no `[ERR_PNPM_...]` summary line yields empty detail without erroring.
+	local detail
+	detail=$(package_managers::pnpm::_extract_error_detail "$(pwd)/test/unit-fixtures/pnpm-failures/clean.log")
+	assertEquals "" "${detail}"
 }
 
 testHandleYarnClassicPrune404() {
-  local -A result
-  # Verifies the shared registry-404 matcher is also wired into the classic prune classifier, so
-  # a re-fetch during `yarn install --frozen-lockfile` (prune's reinstall) is caught the same way
-  # as a fresh install.
-  package_managers::yarn::_handle_yarn_classic_prune_failure "$(pwd)/test/unit-fixtures/yarn-failures/e404.log" result
-  assertEquals "classifier should return 0 on a match" "0" "$?"
-  assertEquals "module-404" "${result[id]}"
-  assertEquals "user" "${result[classification]}"
+	local -A result
+	# Verifies the shared registry-404 matcher is also wired into the classic prune classifier, so
+	# a re-fetch during `yarn install --frozen-lockfile` (prune's reinstall) is caught the same way
+	# as a fresh install.
+	package_managers::yarn::_handle_yarn_classic_prune_failure "$(pwd)/test/unit-fixtures/yarn-failures/e404.log" result
+	assertEquals "classifier should return 0 on a match" "0" "$?"
+	assertEquals "module-404" "${result[id]}"
+	assertEquals "user" "${result[classification]}"
 }
 
 testHandleYarnClassicPruneNoMatchReturnsNonZero() {
-  local -A result
-  # The clean fixture matches none of the classifier's failure modes (including the shared
-  # registry-404 matcher), so the classifier must return non-zero and leave the array empty.
-  if package_managers::yarn::_handle_yarn_classic_prune_failure "$(pwd)/test/unit-fixtures/yarn-prune-devdependencies-failures/clean.log" result; then
-    fail "expected classic prune classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# The clean fixture matches none of the classifier's failure modes (including the shared
+	# registry-404 matcher), so the classifier must return non-zero and leave the array empty.
+	if package_managers::yarn::_handle_yarn_classic_prune_failure "$(pwd)/test/unit-fixtures/yarn-prune-devdependencies-failures/clean.log" result; then
+		fail "expected classic prune classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleYarnBerryPruneNoMatchReturnsNonZero() {
-  local -A result
-  # No Berry prune failure mode is classified today; the classifier must always return non-zero
-  # (so the caller bubbles the raw exit code to the legacy trap) and leave the array empty. The
-  # clean fixture stands in for any unrecognised prune output.
-  if package_managers::yarn::_handle_yarn_berry_prune_failure "$(pwd)/test/unit-fixtures/yarn-prune-devdependencies-failures/clean.log" result; then
-    fail "expected berry prune classifier to return non-zero for an unrecognised log"
-  fi
-  assertEquals "array should be left empty on no match" "" "${result[id]:-}"
+	local -A result
+	# No Berry prune failure mode is classified today; the classifier must always return non-zero
+	# (so the caller bubbles the raw exit code to the legacy trap) and leave the array empty. The
+	# clean fixture stands in for any unrecognised prune output.
+	if package_managers::yarn::_handle_yarn_berry_prune_failure "$(pwd)/test/unit-fixtures/yarn-prune-devdependencies-failures/clean.log" result; then
+		fail "expected berry prune classifier to return non-zero for an unrecognised log"
+	fi
+	assertEquals "array should be left empty on no match" "" "${result[id]:-}"
 }
 
 testHandleYarnPrunePipefail() {
-  # The yarn-prune pipefail wrapper owns the failure id and the user-facing message; verify both
-  # plus the buildpack classification and PIPESTATUS detail inherited from
-  # failure::handle_pipefail. Shared by the Berry and classic prune call sites.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::yarn::_handle_prune_pipefail "0 1" 2>&1 || true
-  )
+	# The yarn-prune pipefail wrapper owns the failure id and the user-facing message; verify both
+	# plus the buildpack classification and PIPESTATUS detail inherited from
+	# failure::handle_pipefail. Shared by the Berry and classic prune call sites.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::_handle_prune_pipefail "0 1" 2>&1 || true
+	)
 
-  assertContains "$out" "Unable to capture the yarn prune log output"
-  assertContains "$out" "ran out of disk space"
-  assertContains "$(cat "$capture")" "failure=yarn-prune-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	assertContains "${out}" "Unable to capture the yarn prune log output"
+	assertContains "${out}" "ran out of disk space"
+	assertContains "$(cat "${capture}")" "failure=yarn-prune-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 # The Yarn 2+ (Berry) vendoring pre-flight checks emit their classified failure directly at the
@@ -1546,175 +1554,175 @@ testHandleYarnPrunePipefail() {
 # path stubs `fail`/`build_data::set_string` in a subshell and asserts nothing was emitted.
 
 testFailMissingYarnrcYmlEmitsMessageWhenAbsent() {
-  local out capture build_dir
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  _capture_node_fail out "$capture" \
-    package_managers::yarn::fail_missing_yarnrc_yml "$build_dir"
+	local out capture build_dir
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	_capture_node_fail out "${capture}" \
+		package_managers::yarn::fail_missing_yarnrc_yml "${build_dir}"
 
-  assertContains "$out" "The 'yarnrc.yml' file is not found"
-  assertContains "$out" "yarn set version berry"
-  assertContains "$out" "https://yarnpkg.com/getting-started/install#per-project-install"
-  # The legacy warn() helper appended this default docs URL on its own line; preserve it.
-  assertContains "$out" "https://devcenter.heroku.com/articles/nodejs-support"
-  # Preserve the legacy failure slug so Honeycomb dashboards keep working.
-  assertContains "$(cat "$capture")" "failure=missing-yarnrc-yml"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -rf "$capture" "$build_dir"
+	assertContains "${out}" "The 'yarnrc.yml' file is not found"
+	assertContains "${out}" "yarn set version berry"
+	assertContains "${out}" "https://yarnpkg.com/getting-started/install#per-project-install"
+	# The legacy warn() helper appended this default docs URL on its own line; preserve it.
+	assertContains "${out}" "https://devcenter.heroku.com/articles/nodejs-support"
+	# Preserve the legacy failure slug so Honeycomb dashboards keep working.
+	assertContains "$(cat "${capture}")" "failure=missing-yarnrc-yml"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -rf "${capture}" "${build_dir}"
 }
 
 testFailMissingYarnrcYmlNoEmitWhenPresent() {
-  local capture build_dir out
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  touch "$build_dir/.yarnrc.yml"
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::yarn::fail_missing_yarnrc_yml "$build_dir" 2>&1
-    echo "returned:$?"
-  )
-  assertContains "the guard should pass and the function should return cleanly" "$out" "returned:0"
-  assertEquals "nothing should be written to build data" "" "$(cat "$capture")"
-  rm -rf "$capture" "$build_dir"
+	local capture build_dir out
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	touch "${build_dir}/.yarnrc.yml"
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::fail_missing_yarnrc_yml "${build_dir}" 2>&1
+		echo "returned:$?"
+	)
+	assertContains "the guard should pass and the function should return cleanly" "${out}" "returned:0"
+	assertEquals "nothing should be written to build data" "" "$(cat "${capture}")"
+	rm -rf "${capture}" "${build_dir}"
 }
 
 testFailMissingYarnPathEmitsMessageWhenEmpty() {
-  local out capture build_dir
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  _capture_node_fail out "$capture" \
-    package_managers::yarn::fail_missing_yarn_path "$build_dir" ""
+	local out capture build_dir
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	_capture_node_fail out "${capture}" \
+		package_managers::yarn::fail_missing_yarn_path "${build_dir}" ""
 
-  assertContains "$out" "The 'yarnPath' could not be read from the 'yarnrc.yml' file"
-  assertContains "$out" "yarn set version berry"
-  assertContains "$out" "https://yarnpkg.com/getting-started/install#per-project-install"
-  # The legacy warn() helper appended this default docs URL on its own line; preserve it.
-  assertContains "$out" "https://devcenter.heroku.com/articles/nodejs-support"
-  assertContains "$(cat "$capture")" "failure=missing-yarn-path"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -rf "$capture" "$build_dir"
+	assertContains "${out}" "The 'yarnPath' could not be read from the 'yarnrc.yml' file"
+	assertContains "${out}" "yarn set version berry"
+	assertContains "${out}" "https://yarnpkg.com/getting-started/install#per-project-install"
+	# The legacy warn() helper appended this default docs URL on its own line; preserve it.
+	assertContains "${out}" "https://devcenter.heroku.com/articles/nodejs-support"
+	assertContains "$(cat "${capture}")" "failure=missing-yarn-path"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -rf "${capture}" "${build_dir}"
 }
 
 testFailMissingYarnPathNoEmitWhenSet() {
-  local capture build_dir out
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::yarn::fail_missing_yarn_path "$build_dir" ".yarn/releases/yarn-4.0.0.cjs" 2>&1
-    echo "returned:$?"
-  )
-  assertContains "a non-empty yarn_path should pass the guard" "$out" "returned:0"
-  assertEquals "nothing should be written to build data" "" "$(cat "$capture")"
-  rm -rf "$capture" "$build_dir"
+	local capture build_dir out
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::fail_missing_yarn_path "${build_dir}" ".yarn/releases/yarn-4.0.0.cjs" 2>&1
+		echo "returned:$?"
+	)
+	assertContains "a non-empty yarn_path should pass the guard" "${out}" "returned:0"
+	assertEquals "nothing should be written to build data" "" "$(cat "${capture}")"
+	rm -rf "${capture}" "${build_dir}"
 }
 
 testFailMissingYarnVendorEmitsMessageWhenAbsent() {
-  local out capture build_dir
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  _capture_node_fail out "$capture" \
-    package_managers::yarn::fail_missing_yarn_vendor "$build_dir" ".yarn/releases/yarn-4.0.0.cjs"
+	local out capture build_dir
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	_capture_node_fail out "${capture}" \
+		package_managers::yarn::fail_missing_yarn_vendor "${build_dir}" ".yarn/releases/yarn-4.0.0.cjs"
 
-  assertContains "$out" "Yarn was not found"
-  assertContains "$out" ".yarn/releases/yarn-4.0.0.cjs"
-  assertContains "$out" "https://yarnpkg.com/getting-started/install#per-project-install"
-  # The legacy warn() helper appended this default docs URL on its own line; preserve it.
-  assertContains "$out" "https://devcenter.heroku.com/articles/nodejs-support"
-  assertContains "$(cat "$capture")" "failure=missing-yarn-vendor"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  # The offending vendored path is recorded in detail for observability.
-  assertContains "$(cat "$capture")" "failure_detail=.yarn/releases/yarn-4.0.0.cjs"
-  rm -rf "$capture" "$build_dir"
+	assertContains "${out}" "Yarn was not found"
+	assertContains "${out}" ".yarn/releases/yarn-4.0.0.cjs"
+	assertContains "${out}" "https://yarnpkg.com/getting-started/install#per-project-install"
+	# The legacy warn() helper appended this default docs URL on its own line; preserve it.
+	assertContains "${out}" "https://devcenter.heroku.com/articles/nodejs-support"
+	assertContains "$(cat "${capture}")" "failure=missing-yarn-vendor"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	# The offending vendored path is recorded in detail for observability.
+	assertContains "$(cat "${capture}")" "failure_detail=.yarn/releases/yarn-4.0.0.cjs"
+	rm -rf "${capture}" "${build_dir}"
 }
 
 testFailMissingYarnVendorNoEmitWhenPresent() {
-  local capture build_dir out
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  mkdir -p "$build_dir/.yarn/releases"
-  touch "$build_dir/.yarn/releases/yarn-4.0.0.cjs"
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_managers::yarn::fail_missing_yarn_vendor "$build_dir" ".yarn/releases/yarn-4.0.0.cjs" 2>&1
-    echo "returned:$?"
-  )
-  assertContains "a vendored release that exists should pass the guard" "$out" "returned:0"
-  assertEquals "nothing should be written to build data" "" "$(cat "$capture")"
-  rm -rf "$capture" "$build_dir"
+	local capture build_dir out
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	mkdir -p "${build_dir}/.yarn/releases"
+	touch "${build_dir}/.yarn/releases/yarn-4.0.0.cjs"
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_managers::yarn::fail_missing_yarn_vendor "${build_dir}" ".yarn/releases/yarn-4.0.0.cjs" 2>&1
+		echo "returned:$?"
+	)
+	assertContains "a vendored release that exists should pass the guard" "${out}" "returned:0"
+	assertEquals "nothing should be written to build data" "" "$(cat "${capture}")"
+	rm -rf "${capture}" "${build_dir}"
 }
 
 # npm 12 removed --unsafe-perm; the gate helper decides whether callers may pass it. Stub `npm`
 # in a subshell so `version_major` reads a controlled version without a real npm install.
 testSupportsUnsafePermForNpm11() {
-  local rc
-  (
-    npm() { echo "11.16.0"; }
-    package_managers::npm::supports_unsafe_perm
-  ) && rc=0 || rc=$?
-  assertEquals "npm 11 should still support --unsafe-perm" "0" "${rc}"
+	local rc
+	(
+		npm() { echo "11.16.0"; }
+		package_managers::npm::supports_unsafe_perm
+	) && rc=0 || rc=$?
+	assertEquals "npm 11 should still support --unsafe-perm" "0" "${rc}"
 }
 
 testSupportsUnsafePermForNpm12() {
-  local rc
-  (
-    npm() { echo "12.0.0"; }
-    package_managers::npm::supports_unsafe_perm
-  ) && rc=0 || rc=$?
-  assertEquals "npm 12 should not support --unsafe-perm" "1" "${rc}"
+	local rc
+	(
+		npm() { echo "12.0.0"; }
+		package_managers::npm::supports_unsafe_perm
+	) && rc=0 || rc=$?
+	assertEquals "npm 12 should not support --unsafe-perm" "1" "${rc}"
 }
 
 testFailNoVersionResolvedEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_no_version_resolved "0.11.333" "24"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_no_version_resolved "0.11.333" "24"
 
-  # The reworded message recommends a major range using the resolver-supplied LTS major.
-  assertContains "$out" "Error: No published Node.js version matches the requested range."
-  assertContains "$out" "package.json (0.11.333)"
-  assertContains "$out" '"node": "24.x"'
-  assertContains "$out" "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
-  # The historical failure id is preserved for metric continuity.
-  assertContains "$(cat "$capture")" "failure=invalid-node-version"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  assertContains "$(cat "$capture")" "failure_detail=0.11.333"
-  rm -f "$capture"
+	# The reworded message recommends a major range using the resolver-supplied LTS major.
+	assertContains "${out}" "Error: No published Node.js version matches the requested range."
+	assertContains "${out}" "package.json (0.11.333)"
+	assertContains "${out}" '"node": "24.x"'
+	assertContains "${out}" "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
+	# The historical failure id is preserved for metric continuity.
+	assertContains "$(cat "${capture}")" "failure=invalid-node-version"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	assertContains "$(cat "${capture}")" "failure_detail=0.11.333"
+	rm -f "${capture}"
 }
 
 testFailInvalidSemverRequirementEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_invalid_semver_requirement "stable" "24"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_invalid_semver_requirement "stable" "24"
 
-  assertContains "$out" "Error: Invalid Node.js version requirement."
-  assertContains "$out" "package.json (stable)"
-  assertContains "$out" '"node": "24.x"'
-  assertContains "$out" "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
-  assertContains "$(cat "$capture")" "failure=invalid-semver-requirement"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  assertContains "$(cat "$capture")" "failure_detail=stable"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Invalid Node.js version requirement."
+	assertContains "${out}" "package.json (stable)"
+	assertContains "${out}" '"node": "24.x"'
+	assertContains "${out}" "https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version"
+	assertContains "$(cat "${capture}")" "failure=invalid-semver-requirement"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	assertContains "$(cat "${capture}")" "failure_detail=stable"
+	rm -f "${capture}"
 }
 
 testFailResolveEmitsCatchAllMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_resolve "20.0.0" "internal-error" "Error reading '/app/inventory/node.toml': No such file or directory"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_resolve "20.0.0" "internal-error" "Error reading '/app/inventory/node.toml': No such file or directory"
 
-  assertContains "$out" "Error: Unable to resolve a Node.js version to install."
-  assertContains "$out" "(20.0.0)"
-  assertContains "$out" "Error reading '/app/inventory/node.toml': No such file or directory"
-  # Catch-all is classified as buildpack-side and records the resolver status + error in detail.
-  assertContains "$(cat "$capture")" "failure=node-version-resolution-failed"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=internal-error: Error reading '/app/inventory/node.toml': No such file or directory"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Unable to resolve a Node.js version to install."
+	assertContains "${out}" "(20.0.0)"
+	assertContains "${out}" "Error reading '/app/inventory/node.toml': No such file or directory"
+	# Catch-all is classified as buildpack-side and records the resolver status + error in detail.
+	assertContains "$(cat "${capture}")" "failure=node-version-resolution-failed"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=internal-error: Error reading '/app/inventory/node.toml': No such file or directory"
+	rm -f "${capture}"
 }
 
 # Captures build_data writes and emitted message for one of the runtimes::nodejs::_fail_*
@@ -1722,14 +1730,14 @@ testFailResolveEmitsCatchAllMessage() {
 # in a subshell with `fail`/`build_data::set_string` stubbed so emit doesn't kill the runner.
 # Usage: _capture_node_fail <out_var> <capture_file> <fn> [args...]
 _capture_node_fail() {
-  local out_var="$1"
-  local capture="$2"
-  shift 2
-  printf -v "$out_var" '%s' "$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    "$@" 2>&1 || true
-  )"
+	local out_var="$1"
+	local capture="$2"
+	shift 2
+	printf -v "${out_var}" '%s' "$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		"$@" 2>&1 || true
+	)"
 }
 
 # Drives runtimes::nodejs::_install through its resolver-JSON dispatch by stubbing `RESOLVE` to
@@ -1739,234 +1747,234 @@ _capture_node_fail() {
 # statuses exit via the stubbed `fail` before any download; a non-JSON payload `return 1`s early.
 # Usage: _capture_node_install <out_var> <capture_file> <rc_var> <resolver_json>
 _capture_node_install() {
-  local out_var="$1"
-  local capture="$2"
-  local rc_var="$3"
-  local resolver_json="$4"
-  # Internal locals are prefixed `_ci_` so they never collide with the caller-supplied variable
-  # names (`printf -v` uses dynamic scoping, so a local named `out` would shadow the caller's).
-  local _ci_out _ci_rc _ci_dir
-  _ci_dir=$(mktemp -d)
-  # Run in a subshell so the stubs don't leak. Use the `if` form to capture the subshell's exit
-  # code without tripping the runner's errexit (a bare assignment from a failing subshell would
-  # abort this function before the code is read). Capture stdout+stderr together.
-  if _ci_out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    build_data::set_raw() { echo "$1=$2" >> "$capture"; }
-    _stub_resolve() { printf '%s' "${resolver_json}"; }
-    RESOLVE=_stub_resolve
-    runtimes::nodejs::_install "some-requested-version" "${_ci_dir}" 2>&1
-  ); then
-    _ci_rc=0
-  else
-    _ci_rc=$?
-  fi
-  rm -rf "${_ci_dir}"
-  printf -v "$out_var" '%s' "$_ci_out"
-  printf -v "$rc_var" '%s' "$_ci_rc"
+	local out_var="$1"
+	local capture="$2"
+	local rc_var="$3"
+	local resolver_json="$4"
+	# Internal locals are prefixed `_ci_` so they never collide with the caller-supplied variable
+	# names (`printf -v` uses dynamic scoping, so a local named `out` would shadow the caller's).
+	local _ci_out _ci_rc _ci_dir
+	_ci_dir=$(mktemp -d)
+	# Run in a subshell so the stubs don't leak. Use the `if` form to capture the subshell's exit
+	# code without tripping the runner's errexit (a bare assignment from a failing subshell would
+	# abort this function before the code is read). Capture stdout+stderr together.
+	if _ci_out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		build_data::set_raw() { echo "$1=$2" >>"${capture}"; }
+		_stub_resolve() { printf '%s' "${resolver_json}"; }
+		RESOLVE=_stub_resolve
+		runtimes::nodejs::_install "some-requested-version" "${_ci_dir}" 2>&1
+	); then
+		_ci_rc=0
+	else
+		_ci_rc=$?
+	fi
+	rm -rf "${_ci_dir}"
+	printf -v "${out_var}" '%s' "${_ci_out}"
+	printf -v "${rc_var}" '%s' "${_ci_rc}"
 }
 
 testInstallDispatchesNoVersionResolvedStatus() {
-  local out capture rc
-  capture=$(mktemp)
-  _capture_node_install out "$capture" rc \
-    '{"status":"no-version-resolved","error":"no match for 0.11.333","lts_major":24}'
+	local out capture rc
+	capture=$(mktemp)
+	_capture_node_install out "${capture}" rc \
+		'{"status":"no-version-resolved","error":"no match for 0.11.333","lts_major":24}'
 
-  # The `case` routed the status to _fail_no_version_resolved, which reworded the message and
-  # interpolated the resolver-supplied lts_major into the recommended range.
-  assertContains "$out" "Error: No published Node.js version matches the requested range."
-  assertContains "$out" '"node": "24.x"'
-  assertContains "$(cat "$capture")" "failure=invalid-node-version"
-  rm -f "$capture"
+	# The `case` routed the status to _fail_no_version_resolved, which reworded the message and
+	# interpolated the resolver-supplied lts_major into the recommended range.
+	assertContains "${out}" "Error: No published Node.js version matches the requested range."
+	assertContains "${out}" '"node": "24.x"'
+	assertContains "$(cat "${capture}")" "failure=invalid-node-version"
+	rm -f "${capture}"
 }
 
 testInstallDispatchesInvalidSemverStatus() {
-  local out capture rc
-  capture=$(mktemp)
-  _capture_node_install out "$capture" rc \
-    '{"status":"invalid-semver-requirement","error":"bad semver","lts_major":24}'
+	local out capture rc
+	capture=$(mktemp)
+	_capture_node_install out "${capture}" rc \
+		'{"status":"invalid-semver-requirement","error":"bad semver","lts_major":24}'
 
-  assertContains "$out" "Error: Invalid Node.js version requirement."
-  assertContains "$out" '"node": "24.x"'
-  assertContains "$(cat "$capture")" "failure=invalid-semver-requirement"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Invalid Node.js version requirement."
+	assertContains "${out}" '"node": "24.x"'
+	assertContains "$(cat "${capture}")" "failure=invalid-semver-requirement"
+	rm -f "${capture}"
 }
 
 testInstallDispatchesInternalErrorToCatchAll() {
-  local out capture rc
-  capture=$(mktemp)
-  # `internal-error` carries no lts_major; the `(.lts_major // "")` fallback keeps @tsv from
-  # dropping a field, and the catch-all routes to _fail_resolve carrying the resolver's error.
-  _capture_node_install out "$capture" rc \
-    '{"status":"internal-error","error":"Error reading node.toml: nope"}'
+	local out capture rc
+	capture=$(mktemp)
+	# `internal-error` carries no lts_major; the `(.lts_major // "")` fallback keeps @tsv from
+	# dropping a field, and the catch-all routes to _fail_resolve carrying the resolver's error.
+	_capture_node_install out "${capture}" rc \
+		'{"status":"internal-error","error":"Error reading node.toml: nope"}'
 
-  assertContains "$out" "Error: Unable to resolve a Node.js version to install."
-  assertContains "$out" "Error reading node.toml: nope"
-  assertContains "$(cat "$capture")" "failure=node-version-resolution-failed"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=internal-error: Error reading node.toml: nope"
-  rm -f "$capture"
+	assertContains "${out}" "Error: Unable to resolve a Node.js version to install."
+	assertContains "${out}" "Error reading node.toml: nope"
+	assertContains "$(cat "${capture}")" "failure=node-version-resolution-failed"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=internal-error: Error reading node.toml: nope"
+	rm -f "${capture}"
 }
 
 testInstallBubblesNonJsonResolverOutput() {
-  local out capture rc
-  capture=$(mktemp)
-  # A crashed/garbled binary produces no parseable JSON: the `jq -e` guard fails, so _install
-  # returns non-zero without emitting a classified failure, leaving the global ERR trap to report.
-  _capture_node_install out "$capture" rc "Segmentation fault"
+	local out capture rc
+	capture=$(mktemp)
+	# A crashed/garbled binary produces no parseable JSON: the `jq -e` guard fails, so _install
+	# returns non-zero without emitting a classified failure, leaving the global ERR trap to report.
+	_capture_node_install out "${capture}" rc "Segmentation fault"
 
-  assertEquals "non-JSON output should bubble up via a non-zero return" "1" "$rc"
-  assertEquals "no classified failure should be recorded" "" "$(cat "$capture")"
-  rm -f "$capture"
+	assertEquals "non-JSON output should bubble up via a non-zero return" "1" "${rc}"
+	assertEquals "no classified failure should be recorded" "" "$(cat "${capture}")"
+	rm -f "${capture}"
 }
 
 testFailNodeDownloadEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_node_download "https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_node_download "https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
 
-  # The detailed, verbatim message reaches the user via failure::emit.
-  assertContains "$out" "Error: Unable to download Node.js."
-  assertContains "$out" "https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
-  assertContains "$out" "https://status.nodejs.org/"
-  # Classification + detail are recorded as build data.
-  assertContains "$(cat "$capture")" "failure=node-download-failed"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
-  rm -f "$capture"
+	# The detailed, verbatim message reaches the user via failure::emit.
+	assertContains "${out}" "Error: Unable to download Node.js."
+	assertContains "${out}" "https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
+	assertContains "${out}" "https://status.nodejs.org/"
+	# Classification + detail are recorded as build data.
+	assertContains "$(cat "${capture}")" "failure=node-download-failed"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"
+	rm -f "${capture}"
 }
 
 testFailChecksumValidationEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_checksum_validation "20.0.0" "sha256" "abc123" "def456"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_checksum_validation "20.0.0" "sha256" "abc123" "def456"
 
-  assertContains "$out" "Checksum validation failed for Node.js 20.0.0 - sha256:abc123"
-  assertContains "$(cat "$capture")" "failure=checksum-validation-failed"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  # Detail records both the expected and the actual (mismatched) checksum for observability.
-  assertContains "$(cat "$capture")" "failure_detail=sha256 expected:abc123 actual:def456"
-  rm -f "$capture"
+	assertContains "${out}" "Checksum validation failed for Node.js 20.0.0 - sha256:abc123"
+	assertContains "$(cat "${capture}")" "failure=checksum-validation-failed"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	# Detail records both the expected and the actual (mismatched) checksum for observability.
+	assertContains "$(cat "${capture}")" "failure_detail=sha256 expected:abc123 actual:def456"
+	rm -f "${capture}"
 }
 
 testFailUnsupportedChecksumEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_unsupported_checksum "20.0.0" "sha512" "abc123"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_unsupported_checksum "20.0.0" "sha512" "abc123"
 
-  assertContains "$out" "Unsupported checksum for Node.js 20.0.0 - sha512:abc123"
-  assertContains "$(cat "$capture")" "failure=unsupported-checksum"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=sha512:abc123"
-  rm -f "$capture"
+	assertContains "${out}" "Unsupported checksum for Node.js 20.0.0 - sha512:abc123"
+	assertContains "$(cat "${capture}")" "failure=unsupported-checksum"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=sha512:abc123"
+	rm -f "${capture}"
 }
 
 testFailDotHerokuEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_dot_heroku ".heroku" "dot-heroku"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_dot_heroku ".heroku" "dot-heroku"
 
-  assertContains "$out" "Error: The directory .heroku could not be created."
-  assertContains "$out" "a .heroku file is checked into this project"
-  # The historical failure id is preserved for metric continuity.
-  assertContains "$(cat "$capture")" "failure=dot-heroku"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	assertContains "${out}" "Error: The directory .heroku could not be created."
+	assertContains "${out}" "a .heroku file is checked into this project"
+	# The historical failure id is preserved for metric continuity.
+	assertContains "$(cat "${capture}")" "failure=dot-heroku"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testFailDotHerokuNodeEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_dot_heroku ".heroku/node" "dot-heroku-node"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_dot_heroku ".heroku/node" "dot-heroku-node"
 
-  assertContains "$out" "Error: The directory .heroku/node could not be created."
-  assertContains "$out" "a .heroku file is checked into this project"
-  assertContains "$(cat "$capture")" "failure=dot-heroku-node"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	assertContains "${out}" "Error: The directory .heroku/node could not be created."
+	assertContains "${out}" "a .heroku file is checked into this project"
+	assertContains "$(cat "${capture}")" "failure=dot-heroku-node"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testGuardDotHerokuEmitsWhenFilePresent() {
-  local out capture build_dir
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  touch "$build_dir/.heroku"
+	local out capture build_dir
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	touch "${build_dir}/.heroku"
 
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::fail_dot_heroku "$build_dir"
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::fail_dot_heroku "${build_dir}"
 
-  assertContains "$out" "Error: The directory .heroku could not be created."
-  assertContains "$(cat "$capture")" "failure=dot-heroku"
-  rm -rf "$build_dir"
-  rm -f "$capture"
+	assertContains "${out}" "Error: The directory .heroku could not be created."
+	assertContains "$(cat "${capture}")" "failure=dot-heroku"
+	rm -rf "${build_dir}"
+	rm -f "${capture}"
 }
 
 testGuardDotHerokuNoopWhenFileAbsent() {
-  local out capture build_dir
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
+	local out capture build_dir
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
 
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::fail_dot_heroku "$build_dir"
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::fail_dot_heroku "${build_dir}"
 
-  assertEquals "no message should be emitted when .heroku is absent" "" "$out"
-  assertEquals "no classified failure should be recorded" "" "$(cat "$capture")"
-  rm -rf "$build_dir"
-  rm -f "$capture"
+	assertEquals "no message should be emitted when .heroku is absent" "" "${out}"
+	assertEquals "no classified failure should be recorded" "" "$(cat "${capture}")"
+	rm -rf "${build_dir}"
+	rm -f "${capture}"
 }
 
 testGuardDotHerokuNodeEmitsWhenFilePresent() {
-  local out capture build_dir
-  capture=$(mktemp)
-  build_dir=$(mktemp -d)
-  mkdir -p "$build_dir/.heroku"
-  touch "$build_dir/.heroku/node"
+	local out capture build_dir
+	capture=$(mktemp)
+	build_dir=$(mktemp -d)
+	mkdir -p "${build_dir}/.heroku"
+	touch "${build_dir}/.heroku/node"
 
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::fail_dot_heroku "$build_dir"
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::fail_dot_heroku "${build_dir}"
 
-  assertContains "$out" "Error: The directory .heroku/node could not be created."
-  assertContains "$(cat "$capture")" "failure=dot-heroku-node"
-  rm -rf "$build_dir"
-  rm -f "$capture"
+	assertContains "${out}" "Error: The directory .heroku/node could not be created."
+	assertContains "$(cat "${capture}")" "failure=dot-heroku-node"
+	rm -rf "${build_dir}"
+	rm -f "${capture}"
 }
 
 testFailIojsUnsupportedEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    runtimes::nodejs::_fail_iojs_unsupported "3.3.1"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		runtimes::nodejs::_fail_iojs_unsupported "3.3.1"
 
-  # The message names io.js, echoes the requested version, and gives the fix instruction.
-  assertContains "$out" "Error: io.js is no longer supported."
-  assertContains "$out" '"iojs": "3.3.1"'
-  assertContains "$out" 'remove the "iojs" entry under "engines" in your package.json'
-  # The historical failure id is preserved for metric continuity; app-controlled input.
-  assertContains "$(cat "$capture")" "failure=iojs-unsupported"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  assertContains "$(cat "$capture")" "failure_detail=3.3.1"
-  rm -f "$capture"
+	# The message names io.js, echoes the requested version, and gives the fix instruction.
+	assertContains "${out}" "Error: io.js is no longer supported."
+	assertContains "${out}" '"iojs": "3.3.1"'
+	assertContains "${out}" 'remove the "iojs" entry under "engines" in your package.json'
+	# The historical failure id is preserved for metric continuity; app-controlled input.
+	assertContains "$(cat "${capture}")" "failure=iojs-unsupported"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	assertContains "$(cat "${capture}")" "failure_detail=3.3.1"
+	rm -f "${capture}"
 }
 
 testExtractErrorDetailReturnsFirstDescriptiveLine() {
-  # Skips the bare `code <CODE>` line and the "complete log" noise, strips the
-  # `npm error `/`npm ERR! ` prefix (but keeps any keyword like `notsup` that follows).
-  local detail
-  detail=$(package_managers::npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log")
-  assertEquals "notsup Unsupported platform for fsevents@2.3.3: wanted {\"os\":\"darwin\",\"arch\":\"any\"} (current: {\"os\":\"linux\",\"arch\":\"x64\"})" "$detail"
+	# Skips the bare `code <CODE>` line and the "complete log" noise, strips the
+	# `npm error `/`npm ERR! ` prefix (but keeps any keyword like `notsup` that follows).
+	local detail
+	detail=$(package_managers::npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/ebadplatform.log")
+	assertEquals "notsup Unsupported platform for fsevents@2.3.3: wanted {\"os\":\"darwin\",\"arch\":\"any\"} (current: {\"os\":\"linux\",\"arch\":\"x64\"})" "${detail}"
 }
 
 testExtractErrorDetailEmptyWhenNoDescriptiveLine() {
-  # A log with no `npm error`/`npm ERR!` line at all yields empty detail without erroring.
-  local detail
-  detail=$(package_managers::npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/clean.log")
-  assertEquals "" "$detail"
+	# A log with no `npm error`/`npm ERR!` line at all yields empty detail without erroring.
+	local detail
+	detail=$(package_managers::npm::_extract_error_detail "$(pwd)/test/unit-fixtures/npm-failures/clean.log")
+	assertEquals "" "${detail}"
 }
 
 # Each PM module spells its own `run <script>` command; stub the tool binary as a function that
@@ -1974,407 +1982,407 @@ testExtractErrorDetailEmptyWhenNoDescriptiveLine() {
 # command is streamed through the shared `package_manager::run_script_command` runner.
 
 testNpmRunScript() {
-  local out
-  out=$(
-    npm() { echo "TOOL: npm $*"; }
-    package_managers::npm::run_script "build" 2>&1
-  )
-  assertContains "$out" "Running build"
-  assertContains "$out" "TOOL: npm run build --if-present"
+	local out
+	out=$(
+		npm() { echo "TOOL: npm $*"; }
+		package_managers::npm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "Running build"
+	assertContains "${out}" "TOOL: npm run build --if-present"
 }
 
 testNpmRunScriptWithBuildFlags() {
-  # npm forwards NODE_BUILD_FLAGS after a `--` separator.
-  local out
-  out=$(
-    npm() { echo "TOOL: npm $*"; }
-    package_managers::npm::run_script "build" "--prod --optimize" 2>&1
-  )
-  assertContains "$out" "Running with --prod --optimize flags"
-  assertContains "$out" "TOOL: npm run build --if-present -- --prod --optimize"
+	# npm forwards NODE_BUILD_FLAGS after a `--` separator.
+	local out
+	out=$(
+		npm() { echo "TOOL: npm $*"; }
+		package_managers::npm::run_script "build" "--prod --optimize" 2>&1
+	)
+	assertContains "${out}" "Running with --prod --optimize flags"
+	assertContains "${out}" "TOOL: npm run build --if-present -- --prod --optimize"
 }
 
 testPnpmRunScript() {
-  local out
-  out=$(
-    pnpm() { echo "TOOL: pnpm $*"; }
-    package_managers::pnpm::run_script "build" 2>&1
-  )
-  assertContains "$out" "Running build"
-  assertContains "$out" "TOOL: pnpm run --if-present build"
+	local out
+	out=$(
+		pnpm() { echo "TOOL: pnpm $*"; }
+		package_managers::pnpm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "Running build"
+	assertContains "${out}" "TOOL: pnpm run --if-present build"
 }
 
 testPnpmRunScriptWithBuildFlags() {
-  # pnpm forwards NODE_BUILD_FLAGS after a `--` separator.
-  local out
-  out=$(
-    pnpm() { echo "TOOL: pnpm $*"; }
-    package_managers::pnpm::run_script "build" "--prod" 2>&1
-  )
-  assertContains "$out" "Running with --prod flags"
-  assertContains "$out" "TOOL: pnpm run --if-present build -- --prod"
+	# pnpm forwards NODE_BUILD_FLAGS after a `--` separator.
+	local out
+	out=$(
+		pnpm() { echo "TOOL: pnpm $*"; }
+		package_managers::pnpm::run_script "build" "--prod" 2>&1
+	)
+	assertContains "${out}" "Running with --prod flags"
+	assertContains "${out}" "TOOL: pnpm run --if-present build -- --prod"
 }
 
 testYarnRunScript() {
-  local build_dir out
-  build_dir=$(mktemp -d)
-  echo '{"scripts":{"build":"webpack"}}' > "$build_dir/package.json"
-  out=$(
-    yarn() { echo "TOOL: yarn $*"; }
-    package_managers::yarn::run_script "$build_dir" "build" 2>&1
-  )
-  assertContains "$out" "Running build (yarn)"
-  assertContains "$out" "TOOL: yarn run build"
-  rm -rf "$build_dir"
+	local build_dir out
+	build_dir=$(mktemp -d)
+	echo '{"scripts":{"build":"webpack"}}' >"${build_dir}/package.json"
+	out=$(
+		yarn() { echo "TOOL: yarn $*"; }
+		package_managers::yarn::run_script "${build_dir}" "build" 2>&1
+	)
+	assertContains "${out}" "Running build (yarn)"
+	assertContains "${out}" "TOOL: yarn run build"
+	rm -rf "${build_dir}"
 }
 
 testYarnRunScriptWithBuildFlags() {
-  # yarn takes NODE_BUILD_FLAGS as a trailing argument (no `--` separator).
-  local build_dir out
-  build_dir=$(mktemp -d)
-  echo '{"scripts":{"build":"webpack"}}' > "$build_dir/package.json"
-  out=$(
-    yarn() { echo "TOOL: yarn $*"; }
-    package_managers::yarn::run_script "$build_dir" "build" "--prod --optimize" 2>&1
-  )
-  assertContains "$out" "Running with --prod --optimize flags"
-  assertContains "$out" "TOOL: yarn run build --prod --optimize"
-  rm -rf "$build_dir"
+	# yarn takes NODE_BUILD_FLAGS as a trailing argument (no `--` separator).
+	local build_dir out
+	build_dir=$(mktemp -d)
+	echo '{"scripts":{"build":"webpack"}}' >"${build_dir}/package.json"
+	out=$(
+		yarn() { echo "TOOL: yarn $*"; }
+		package_managers::yarn::run_script "${build_dir}" "build" "--prod --optimize" 2>&1
+	)
+	assertContains "${out}" "Running with --prod --optimize flags"
+	assertContains "${out}" "TOOL: yarn run build --prod --optimize"
+	rm -rf "${build_dir}"
 }
 
 testYarnRunScriptSkipsEmptyScript() {
-  # yarn errors on an empty script body, so an empty script is announced but never run.
-  local build_dir out
-  build_dir=$(mktemp -d)
-  echo '{"scripts":{"build":""}}' > "$build_dir/package.json"
-  out=$(
-    yarn() { echo "TOOL: yarn $*"; }
-    package_managers::yarn::run_script "$build_dir" "build" 2>&1
-  )
-  assertContains "$out" "Running build (yarn)"
-  if [[ "$out" == *"TOOL: yarn"* ]]; then
-    fail "yarn should not be invoked for an empty script body"
-  fi
-  rm -rf "$build_dir"
+	# yarn errors on an empty script body, so an empty script is announced but never run.
+	local build_dir out
+	build_dir=$(mktemp -d)
+	echo '{"scripts":{"build":""}}' >"${build_dir}/package.json"
+	out=$(
+		yarn() { echo "TOOL: yarn $*"; }
+		package_managers::yarn::run_script "${build_dir}" "build" 2>&1
+	)
+	assertContains "${out}" "Running build (yarn)"
+	if [[ "${out}" == *"TOOL: yarn"* ]]; then
+		fail "yarn should not be invoked for an empty script body"
+	fi
+	rm -rf "${build_dir}"
 }
 
 testHandleScriptPipefail() {
-  # The build-script pipefail handler owns the failure id and user-facing message, plus the
-  # buildpack classification and PIPESTATUS detail inherited from failure::handle_pipefail. It
-  # fires when the script exits 0 but a downstream pipe stage (tee) fails.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    package_manager::_handle_script_pipefail "0 1" 2>&1 || true
-  )
-  assertContains "$out" "Unable to capture the build script log output"
-  assertContains "$out" "ran out of disk space"
-  assertContains "$(cat "$capture")" "failure=build-script-pipefail"
-  assertContains "$(cat "$capture")" "failure_classification=buildpack"
-  assertContains "$(cat "$capture")" "failure_detail=PIPESTATUS=[0 1]"
-  rm -f "$capture"
+	# The build-script pipefail handler owns the failure id and user-facing message, plus the
+	# buildpack classification and PIPESTATUS detail inherited from failure::handle_pipefail. It
+	# fires when the script exits 0 but a downstream pipe stage (tee) fails.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		package_manager::_handle_script_pipefail "0 1" 2>&1 || true
+	)
+	assertContains "${out}" "Unable to capture the build script log output"
+	assertContains "${out}" "ran out of disk space"
+	assertContains "$(cat "${capture}")" "failure=build-script-pipefail"
+	assertContains "$(cat "${capture}")" "failure_classification=buildpack"
+	assertContains "$(cat "${capture}")" "failure_detail=PIPESTATUS=[0 1]"
+	rm -f "${capture}"
 }
 
 testRunScriptCommandClassifiesGitAuthFailure() {
-  # A heroku-prebuild/build/heroku-postbuild/heroku-cleanup script can shell out to git for a
-  # git+ssh:// dependency and hit the same SSH host-key failure as the main install. Drive the
-  # failure through the real dispatch path (package_managers::npm::run_script ->
-  # package_manager::run_script_command), not the classifier directly, so a reintroduced nameref
-  # collision between the two would be caught.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    # run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
-    # survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
-    # which sets it globally for the whole build.
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    npm() {
-      cat "$(pwd)/test/unit-fixtures/git-auth-failures/host-key-verification-failed.log"
-      return 1
-    }
-    package_managers::npm::run_script "build" 2>&1
-  )
-  assertContains "$out" "Unable to install a git dependency over SSH"
-  assertContains "$(cat "$capture")" "failure=private-git-dependency-without-auth"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	# A heroku-prebuild/build/heroku-postbuild/heroku-cleanup script can shell out to git for a
+	# git+ssh:// dependency and hit the same SSH host-key failure as the main install. Drive the
+	# failure through the real dispatch path (package_managers::npm::run_script ->
+	# package_manager::run_script_command), not the classifier directly, so a reintroduced nameref
+	# collision between the two would be caught.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		# run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
+		# survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
+		# which sets it globally for the whole build.
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			cat "$(pwd)/test/unit-fixtures/git-auth-failures/host-key-verification-failed.log"
+			return 1
+		}
+		package_managers::npm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "Unable to install a git dependency over SSH"
+	assertContains "$(cat "${capture}")" "failure=private-git-dependency-without-auth"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testRunScriptCommandClassifiesEconnreset() {
-  # A build-script lifecycle hook can hit an ECONNRESET the same way a fresh install can. Drive
-  # the failure through the real dispatch path (package_managers::npm::run_script ->
-  # package_manager::run_script_command), not the classifier directly, so a reintroduced
-  # nameref collision between the two would be caught.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    # run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
-    # survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
-    # which sets it globally for the whole build.
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    npm() {
-      cat "$(pwd)/test/unit-fixtures/econnreset-failures/econnreset.log"
-      return 1
-    }
-    package_managers::npm::run_script "build" 2>&1
-  )
-  assertContains "$out" "ECONNRESET"
-  assertContains "$(cat "$capture")" "failure=econnreset"
-  assertContains "$(cat "$capture")" "failure_classification=upstream"
-  rm -f "$capture"
+	# A build-script lifecycle hook can hit an ECONNRESET the same way a fresh install can. Drive
+	# the failure through the real dispatch path (package_managers::npm::run_script ->
+	# package_manager::run_script_command), not the classifier directly, so a reintroduced
+	# nameref collision between the two would be caught.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		# run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
+		# survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
+		# which sets it globally for the whole build.
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			cat "$(pwd)/test/unit-fixtures/econnreset-failures/econnreset.log"
+			return 1
+		}
+		package_managers::npm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "ECONNRESET"
+	assertContains "$(cat "${capture}")" "failure=econnreset"
+	assertContains "$(cat "${capture}")" "failure_classification=upstream"
+	rm -f "${capture}"
 }
 
 testInstallDependenciesEconnresetRetryNoiseDoesNotMaskNpmSpecificFailure() {
-  # A build that retries past a transient ECONNRESET and then fails for an unrelated, permanent
-  # reason (npm EBADPLATFORM) must surface the specific npm failure, not "just retry" — the
-  # econnreset classifier is checked last, as a fallback, specifically so retry noise like this
-  # can't shadow a real, permanent failure. Drive it through the real call site
-  # (package_managers::npm::install_dependencies), not the classifier directly, so a
-  # reintroduced ordering regression at this call site would be caught.
-  local fixture build_dir out capture
-  fixture="$(pwd)/test/unit-fixtures/econnreset-failures/retry-noise-with-ebadplatform.log"
-  build_dir=$(mktemp -d)
-  echo '{}' >"${build_dir}/package.json"
-  capture=$(mktemp)
-  out=$(
-    # install_dependencies classifies from PIPESTATUS[0] (npm's exit code), which only survives
-    # the `npm | tee` pipeline under pipefail; enable it here to match bin/compile, which sets
-    # it globally for the whole build.
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_raw() { :; }
-    build_data::set_duration() { :; }
-    build_data::current_unix_realtime() { echo 0; }
-    build_data::set_string() { echo "$1=$2" >>"${capture}"; }
-    npm() {
-      if [[ "$1" == "--version" ]]; then
-        echo "10.0.0"
-        return 0
-      fi
-      cat "${fixture}"
-      return 1
-    }
-    package_managers::npm::install_dependencies "${build_dir}" 2>&1
-  )
-  assertContains "$out" "Unable to install dependencies using npm"
-  assertContains "$(cat "$capture")" "failure=npm-ebadplatform"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  if [[ "$(cat "$capture")" == *"failure=econnreset"* ]]; then
-    fail "transient ECONNRESET retry noise should not shadow the permanent npm-specific failure"
-  fi
-  rm -rf "${build_dir}"
-  rm -f "$capture"
+	# A build that retries past a transient ECONNRESET and then fails for an unrelated, permanent
+	# reason (npm EBADPLATFORM) must surface the specific npm failure, not "just retry" — the
+	# econnreset classifier is checked last, as a fallback, specifically so retry noise like this
+	# can't shadow a real, permanent failure. Drive it through the real call site
+	# (package_managers::npm::install_dependencies), not the classifier directly, so a
+	# reintroduced ordering regression at this call site would be caught.
+	local fixture build_dir out capture
+	fixture="$(pwd)/test/unit-fixtures/econnreset-failures/retry-noise-with-ebadplatform.log"
+	build_dir=$(mktemp -d)
+	echo '{}' >"${build_dir}/package.json"
+	capture=$(mktemp)
+	out=$(
+		# install_dependencies classifies from PIPESTATUS[0] (npm's exit code), which only survives
+		# the `npm | tee` pipeline under pipefail; enable it here to match bin/compile, which sets
+		# it globally for the whole build.
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_raw() { :; }
+		build_data::set_duration() { :; }
+		build_data::current_unix_realtime() { echo 0; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			if [[ "$1" == "--version" ]]; then
+				echo "10.0.0"
+				return 0
+			fi
+			cat "${fixture}"
+			return 1
+		}
+		package_managers::npm::install_dependencies "${build_dir}" 2>&1
+	)
+	assertContains "${out}" "Unable to install dependencies using npm"
+	assertContains "$(cat "${capture}")" "failure=npm-ebadplatform"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	if [[ "$(cat "${capture}")" == *"failure=econnreset"* ]]; then
+		fail "transient ECONNRESET retry noise should not shadow the permanent npm-specific failure"
+	fi
+	rm -rf "${build_dir}"
+	rm -f "${capture}"
 }
 
 testInstallDependenciesClassifiesTerminalEconnreset() {
-  # A terminal ECONNRESET (retries exhausted, no other error code present) must still be
-  # classified as econnreset even though it is now checked last, as a fallback, after the
-  # npm-specific matcher. Drive it through the real call site
-  # (package_managers::npm::install_dependencies), not the classifier directly; complements
-  # testHandleEconnreset, which stays green as the direct-classifier check.
-  local fixture build_dir out capture
-  fixture="$(pwd)/test/unit-fixtures/econnreset-failures/econnreset.log"
-  build_dir=$(mktemp -d)
-  echo '{}' >"${build_dir}/package.json"
-  capture=$(mktemp)
-  out=$(
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_raw() { :; }
-    build_data::set_duration() { :; }
-    build_data::current_unix_realtime() { echo 0; }
-    build_data::set_string() { echo "$1=$2" >>"${capture}"; }
-    npm() {
-      if [[ "$1" == "--version" ]]; then
-        echo "10.0.0"
-        return 0
-      fi
-      cat "${fixture}"
-      return 1
-    }
-    package_managers::npm::install_dependencies "${build_dir}" 2>&1
-  )
-  assertContains "$out" "ECONNRESET"
-  assertContains "$(cat "$capture")" "failure=econnreset"
-  assertContains "$(cat "$capture")" "failure_classification=upstream"
-  rm -rf "${build_dir}"
-  rm -f "$capture"
+	# A terminal ECONNRESET (retries exhausted, no other error code present) must still be
+	# classified as econnreset even though it is now checked last, as a fallback, after the
+	# npm-specific matcher. Drive it through the real call site
+	# (package_managers::npm::install_dependencies), not the classifier directly; complements
+	# testHandleEconnreset, which stays green as the direct-classifier check.
+	local fixture build_dir out capture
+	fixture="$(pwd)/test/unit-fixtures/econnreset-failures/econnreset.log"
+	build_dir=$(mktemp -d)
+	echo '{}' >"${build_dir}/package.json"
+	capture=$(mktemp)
+	out=$(
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_raw() { :; }
+		build_data::set_duration() { :; }
+		build_data::current_unix_realtime() { echo 0; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			if [[ "$1" == "--version" ]]; then
+				echo "10.0.0"
+				return 0
+			fi
+			cat "${fixture}"
+			return 1
+		}
+		package_managers::npm::install_dependencies "${build_dir}" 2>&1
+	)
+	assertContains "${out}" "ECONNRESET"
+	assertContains "$(cat "${capture}")" "failure=econnreset"
+	assertContains "$(cat "${capture}")" "failure_classification=upstream"
+	rm -rf "${build_dir}"
+	rm -f "${capture}"
 }
 
 testRunScriptCommandClassifiesLibc6Incompatibility() {
-  # A build-script lifecycle hook invokes the Node.js binary itself (e.g. `node ./some-script`
-  # via a package.json script), so it can hit the same glibc incompatibility as the main
-  # install. Drive the failure through the real dispatch path (package_managers::npm::run_script
-  # -> package_manager::run_script_command), not the classifier directly, so a reintroduced
-  # nameref collision between the two would be caught.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    # run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
-    # survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
-    # which sets it globally for the whole build.
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    npm() {
-      cat "$(pwd)/test/unit-fixtures/libc6-failures/glibc-not-found.log"
-      return 1
-    }
-    package_managers::npm::run_script "build" 2>&1
-  )
-  assertContains "$out" "This Node.js version is not compatible with the current stack."
-  assertContains "$(cat "$capture")" "failure=libc6-incompatibility"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	# A build-script lifecycle hook invokes the Node.js binary itself (e.g. `node ./some-script`
+	# via a package.json script), so it can hit the same glibc incompatibility as the main
+	# install. Drive the failure through the real dispatch path (package_managers::npm::run_script
+	# -> package_manager::run_script_command), not the classifier directly, so a reintroduced
+	# nameref collision between the two would be caught.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		# run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
+		# survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
+		# which sets it globally for the whole build.
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			cat "$(pwd)/test/unit-fixtures/libc6-failures/glibc-not-found.log"
+			return 1
+		}
+		package_managers::npm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "This Node.js version is not compatible with the current stack."
+	assertContains "$(cat "${capture}")" "failure=libc6-incompatibility"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testRunScriptCommandClassifiesOpensslUnsupportedAlgorithm() {
-  # The build script (e.g. `node build.js`) can hit OpenSSL 3's dropped support for an
-  # algorithm/digest. Drive the failure through the real dispatch path
-  # (package_managers::npm::run_script -> package_manager::run_script_command), not the
-  # classifier directly, so a reintroduced nameref collision between the two would be caught.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    # run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
-    # survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
-    # which sets it globally for the whole build.
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    npm() {
-      cat "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm.log"
-      return 1
-    }
-    package_managers::npm::run_script "build" 2>&1
-  )
-  assertContains "$out" "Unsupported cryptographic algorithm used"
-  assertContains "$(cat "$capture")" "failure=openssl-unsupported-algorithm"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	# The build script (e.g. `node build.js`) can hit OpenSSL 3's dropped support for an
+	# algorithm/digest. Drive the failure through the real dispatch path
+	# (package_managers::npm::run_script -> package_manager::run_script_command), not the
+	# classifier directly, so a reintroduced nameref collision between the two would be caught.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		# run_script_command classifies from PIPESTATUS[0] (the tool's exit code), which only
+		# survives the `tool | tee` pipeline under pipefail; enable it here to match bin/compile,
+		# which sets it globally for the whole build.
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			cat "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm.log"
+			return 1
+		}
+		package_managers::npm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "Unsupported cryptographic algorithm used"
+	assertContains "$(cat "${capture}")" "failure=openssl-unsupported-algorithm"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testRunScriptCommandClassifiesOpensslUnsupportedAlgorithmWebpack() {
-  # The webpack-cli sub-case gets a more specific id and fix instructions.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    npm() {
-      cat "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm-webpack.log"
-      return 1
-    }
-    package_managers::npm::run_script "build" 2>&1
-  )
-  assertContains "$out" "output.hashFunction"
-  assertContains "$(cat "$capture")" "failure=openssl-unsupported-algorithm-webpack"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	# The webpack-cli sub-case gets a more specific id and fix instructions.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			cat "$(pwd)/test/unit-fixtures/build-script-failures/openssl-unsupported-algorithm-webpack.log"
+			return 1
+		}
+		package_managers::npm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "output.hashFunction"
+	assertContains "$(cat "${capture}")" "failure=openssl-unsupported-algorithm-webpack"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testRunScriptCommandClassifiesNodeOutOfMemory() {
-  # The build script (e.g. asset bundling via Webpack/Vite/Rollup) can exhaust the Node.js heap.
-  # Drive the failure through the real dispatch path (package_managers::npm::run_script ->
-  # package_manager::run_script_command), not the classifier directly, so a reintroduced
-  # nameref collision between the two would be caught.
-  local out capture
-  capture=$(mktemp)
-  out=$(
-    set -o pipefail
-    fail() { exit 1; }
-    build_data::set_string() { echo "$1=$2" >> "$capture"; }
-    npm() {
-      cat "$(pwd)/test/unit-fixtures/build-script-failures/node-out-of-memory.log"
-      return 1
-    }
-    package_managers::npm::run_script "build" 2>&1
-  )
-  assertContains "$out" "Node.js Out-Of-Memory (OOM)"
-  assertContains "$(cat "$capture")" "failure=node-out-of-memory"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	# The build script (e.g. asset bundling via Webpack/Vite/Rollup) can exhaust the Node.js heap.
+	# Drive the failure through the real dispatch path (package_managers::npm::run_script ->
+	# package_manager::run_script_command), not the classifier directly, so a reintroduced
+	# nameref collision between the two would be caught.
+	local out capture
+	capture=$(mktemp)
+	out=$(
+		set -o pipefail
+		fail() { exit 1; }
+		build_data::set_string() { echo "$1=$2" >>"${capture}"; }
+		npm() {
+			cat "$(pwd)/test/unit-fixtures/build-script-failures/node-out-of-memory.log"
+			return 1
+		}
+		package_managers::npm::run_script "build" 2>&1
+	)
+	assertContains "${out}" "Node.js Out-Of-Memory (OOM)"
+	assertContains "$(cat "${capture}")" "failure=node-out-of-memory"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testFailConflictingMetadataEmitsDetailedMessage() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    package_manager::_fail_conflicting_metadata \
-    "npm version detected in engines.npm (10.x)" \
-    "pnpm version declared in packageManager (pnpm@9.9.0)"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		package_manager::_fail_conflicting_metadata \
+		"npm version detected in engines.npm (10.x)" \
+		"pnpm version declared in packageManager (pnpm@9.9.0)"
 
-  # The message preserves the existing wording and lists each detected declaration.
-  assertContains "$out" "Multiple package managers declared in package.json"
-  assertContains "$out" "Only one of the following fields should be used, all others should be removed"
-  assertContains "$out" "- npm version detected in engines.npm (10.x)"
-  assertContains "$out" "- pnpm version declared in packageManager (pnpm@9.9.0)"
-  # The historical failure id is preserved for metric continuity; app-controlled input.
-  assertContains "$(cat "$capture")" "failure=multiple-package-managers"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  # Detail records the conflicting fields detected.
-  assertContains "$(cat "$capture")" "failure_detail=npm version detected in engines.npm (10.x)"
-  assertContains "$(cat "$capture")" "pnpm version declared in packageManager (pnpm@9.9.0)"
-  rm -f "$capture"
+	# The message preserves the existing wording and lists each detected declaration.
+	assertContains "${out}" "Multiple package managers declared in package.json"
+	assertContains "${out}" "Only one of the following fields should be used, all others should be removed"
+	assertContains "${out}" "- npm version detected in engines.npm (10.x)"
+	assertContains "${out}" "- pnpm version declared in packageManager (pnpm@9.9.0)"
+	# The historical failure id is preserved for metric continuity; app-controlled input.
+	assertContains "$(cat "${capture}")" "failure=multiple-package-managers"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	# Detail records the conflicting fields detected.
+	assertContains "$(cat "${capture}")" "failure_detail=npm version detected in engines.npm (10.x)"
+	assertContains "$(cat "${capture}")" "pnpm version declared in packageManager (pnpm@9.9.0)"
+	rm -f "${capture}"
 }
 
 testFailConflictingMetadataGuardEmitsWhenMultipleDeclared() {
-  local out capture
-  capture=$(mktemp)
-  _capture_node_fail out "$capture" \
-    package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/conflicting-package-manager-metadata"
+	local out capture
+	capture=$(mktemp)
+	_capture_node_fail out "${capture}" \
+		package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/conflicting-package-manager-metadata"
 
-  assertContains "$out" "Multiple package managers declared in package.json"
-  assertContains "$(cat "$capture")" "failure=multiple-package-managers"
-  assertContains "$(cat "$capture")" "failure_classification=user"
-  rm -f "$capture"
+	assertContains "${out}" "Multiple package managers declared in package.json"
+	assertContains "$(cat "${capture}")" "failure=multiple-package-managers"
+	assertContains "$(cat "${capture}")" "failure_classification=user"
+	rm -f "${capture}"
 }
 
 testFailConflictingMetadataGuardDoesNotEmitWhenSingleDeclared() {
-  local out capture
-  capture=$(mktemp)
-  # error-prune declares only engines.npm — a single package manager, so the guard never
-  # reaches the emit helper and nothing is printed or recorded.
-  _capture_node_fail out "$capture" \
-    package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/error-prune"
+	local out capture
+	capture=$(mktemp)
+	# error-prune declares only engines.npm — a single package manager, so the guard never
+	# reaches the emit helper and nothing is printed or recorded.
+	_capture_node_fail out "${capture}" \
+		package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/error-prune"
 
-  assertNull "single package manager should not emit a failure message" "$out"
-  assertEquals "single package manager should not record a failure" "" "$(cat "$capture")"
-  rm -f "$capture"
+	assertNull "single package manager should not emit a failure message" "${out}"
+	assertEquals "single package manager should not record a failure" "" "$(cat "${capture}")"
+	rm -f "${capture}"
 }
 
 testFailConflictingMetadataGuardDoesNotEmitWhenNoneDeclared() {
-  local out capture
-  capture=$(mktemp)
-  # has-script-fixtures declares only engines.node (no npm/yarn/pnpm and no packageManager), so
-  # no package manager is detected and the guard never reaches the emit helper.
-  _capture_node_fail out "$capture" \
-    package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/has-script-fixtures"
+	local out capture
+	capture=$(mktemp)
+	# has-script-fixtures declares only engines.node (no npm/yarn/pnpm and no packageManager), so
+	# no package manager is detected and the guard never reaches the emit helper.
+	_capture_node_fail out "${capture}" \
+		package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/has-script-fixtures"
 
-  assertNull "no package manager declared should not emit a failure message" "$out"
-  assertEquals "no package manager declared should not record a failure" "" "$(cat "$capture")"
-  rm -f "$capture"
+	assertNull "no package manager declared should not emit a failure message" "${out}"
+	assertEquals "no package manager declared should not record a failure" "" "$(cat "${capture}")"
+	rm -f "${capture}"
 }
 
 testFailConflictingMetadataGuardDoesNotEmitWhenSameManagerDeclaredTwice() {
-  local out capture
-  capture=$(mktemp)
-  # pnpm-with-corepack-and-engine declares pnpm in BOTH engines.pnpm and packageManager. These
-  # name the same package manager, so they dedupe to a single key and the guard must not emit —
-  # guards the packageManager-field detection branch against a false conflict.
-  _capture_node_fail out "$capture" \
-    package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/pnpm-with-corepack-and-engine"
+	local out capture
+	capture=$(mktemp)
+	# pnpm-with-corepack-and-engine declares pnpm in BOTH engines.pnpm and packageManager. These
+	# name the same package manager, so they dedupe to a single key and the guard must not emit —
+	# guards the packageManager-field detection branch against a false conflict.
+	_capture_node_fail out "${capture}" \
+		package_manager::fail_conflicting_metadata "$(pwd)/test/fixtures/pnpm-with-corepack-and-engine"
 
-  assertNull "same package manager declared twice should not emit a failure message" "$out"
-  assertEquals "same package manager declared twice should not record a failure" "" "$(cat "$capture")"
-  rm -f "$capture"
+	assertNull "same package manager declared twice should not emit a failure message" "${out}"
+	assertEquals "same package manager declared twice should not record a failure" "" "$(cat "${capture}")"
+	rm -f "${capture}"
 }
 
 BP_DIR="$(pwd)"

--- a/test/utils
+++ b/test/utils
@@ -1,237 +1,214 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# shellcheck disable=SC2312 # test harness: masked command-substitution exits are inherent to a non-error-propagating test runner
+# shellcheck disable=SC2034,SC2076,SC2124,SC2154,SC2181,SC2199,SC2249,SC2310,SC2335 # deferred: style/test-fixture nits (incl. command-existence checks in conditions) triaged out of the mechanical migration
 
 # taken from
 # https://github.com/ryanbrainard/heroku-buildpack-testrunner/blob/master/lib/test_utils.sh
 
-oneTimeSetUp()
-{
-   TEST_SUITE_CACHE="$(mktemp -d ${SHUNIT_TMPDIR}/test_suite_cache.XXXX)"
+oneTimeSetUp() {
+	TEST_SUITE_CACHE="$(mktemp -d "${SHUNIT_TMPDIR}"/test_suite_cache.XXXX)"
 }
 
-oneTimeTearDown()
-{
-  rm -rf ${TEST_SUITE_CACHE}
+oneTimeTearDown() {
+	rm -rf "${TEST_SUITE_CACHE}"
 }
 
-setUp()
-{
-  OUTPUT_DIR="$(mktemp -d ${SHUNIT_TMPDIR}/output.XXXX)"
-  STD_OUT="${OUTPUT_DIR}/stdout"
-  STD_ERR="${OUTPUT_DIR}/stderr"
-  BUILD_DIR="${OUTPUT_DIR}/build"
-  CACHE_DIR="${OUTPUT_DIR}/cache"
-  mkdir -p ${OUTPUT_DIR}
-  mkdir -p ${BUILD_DIR}
-  mkdir -p ${CACHE_DIR}
+setUp() {
+	OUTPUT_DIR="$(mktemp -d "${SHUNIT_TMPDIR}"/output.XXXX)"
+	STD_OUT="${OUTPUT_DIR}/stdout"
+	STD_ERR="${OUTPUT_DIR}/stderr"
+	BUILD_DIR="${OUTPUT_DIR}/build"
+	CACHE_DIR="${OUTPUT_DIR}/cache"
+	mkdir -p "${OUTPUT_DIR}"
+	mkdir -p "${BUILD_DIR}"
+	mkdir -p "${CACHE_DIR}"
 }
 
-tearDown()
-{
-  rm -rf ${OUTPUT_DIR}
+tearDown() {
+	rm -rf "${OUTPUT_DIR}"
 }
 
-capture()
-{
-  resetCapture
+capture() {
+	resetCapture
 
-  LAST_COMMAND="$@"
+	LAST_COMMAND="$@"
 
-  "$@" >${STD_OUT} 2>${STD_ERR}
-  RETURN=$?
-  rtrn=${RETURN} # deprecated
+	"$@" >"${STD_OUT}" 2>"${STD_ERR}"
+	RETURN=$?
+	rtrn=${RETURN} # deprecated
 }
 
-resetCapture()
-{
-  if [ -f ${STD_OUT} ]; then
-    rm ${STD_OUT}
-  fi
+resetCapture() {
+	if [[ -f "${STD_OUT}" ]]; then
+		rm "${STD_OUT}"
+	fi
 
-  if [ -f ${STD_ERR} ]; then
-    rm ${STD_ERR}
-  fi
+	if [[ -f "${STD_ERR}" ]]; then
+		rm "${STD_ERR}"
+	fi
 
-  unset LAST_COMMAND
-  unset RETURN
-  unset rtrn # deprecated
+	unset LAST_COMMAND
+	unset RETURN
+	unset rtrn # deprecated
 }
 
-detect()
-{
-  capture ${BUILDPACK_HOME}/bin/detect ${BUILD_DIR}
+detect() {
+	capture "${BUILDPACK_HOME}"/bin/detect "${BUILD_DIR}"
 }
 
-compile()
-{
-  capture ${BUILDPACK_HOME}/bin/compile ${BUILD_DIR} ${CACHE_DIR}
+compile() {
+	capture "${BUILDPACK_HOME}"/bin/compile "${BUILD_DIR}" "${CACHE_DIR}"
 }
 
-release()
-{
-  capture ${BUILDPACK_HOME}/bin/release ${BUILD_DIR}
+release() {
+	capture "${BUILDPACK_HOME}"/bin/release "${BUILD_DIR}"
 }
 
-assertCapturedEquals()
-{
-  assertEquals "$@" "$(cat ${STD_OUT})"
+assertCapturedEquals() {
+	assertEquals "$@" "$(cat "${STD_OUT}")"
 }
 
-assertCapturedNotEquals()
-{
-  assertNotEquals "$@" "$(cat ${STD_OUT})"
+assertCapturedNotEquals() {
+	assertNotEquals "$@" "$(cat "${STD_OUT}")"
 }
 
-assertCaptured()
-{
-  assertFileContains "$@" "${STD_OUT}"
+assertCaptured() {
+	assertFileContains "$@" "${STD_OUT}"
 }
 
-assertNotCaptured()
-{
-  assertFileNotContains "$@" "${STD_OUT}"
+assertNotCaptured() {
+	assertFileNotContains "$@" "${STD_OUT}"
 }
 
-assertCapturedSuccess()
-{
-  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
-  assertEquals "Expected STD_ERR to be empty; was <$(cat ${STD_ERR})>" "" "$(cat ${STD_ERR})"
+assertCapturedSuccess() {
+	assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
+	assertEquals "Expected STD_ERR to be empty; was <$(cat "${STD_ERR}")>" "" "$(cat "${STD_ERR}")"
 }
 
-assertCapturedSuccessWithWarnings()
-{
-  assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
-  assertNotEquals "Expected STD_ERR to be non-empty (warnings should have been emitted)" "" "$(cat ${STD_ERR})"
+assertCapturedSuccessWithWarnings() {
+	assertEquals "Expected captured exit code to be 0; was <${RETURN}>" "0" "${RETURN}"
+	assertNotEquals "Expected STD_ERR to be non-empty (warnings should have been emitted)" "" "$(cat "${STD_ERR}")"
 }
 
-assertCapturedStderr()
-{
-  assertFileContains "$@" "${STD_ERR}"
+assertCapturedStderr() {
+	assertFileContains "$@" "${STD_ERR}"
 }
 
-assertNotCapturedStderr()
-{
-  assertFileNotContains "$@" "${STD_ERR}"
+assertNotCapturedStderr() {
+	assertFileNotContains "$@" "${STD_ERR}"
 }
 
 # assertCapturedError [[expectedErrorCode] expectedErrorMsg]
-assertCapturedError()
-{
-  if [ $# -gt 1 ]; then
-    local expectedErrorCode=${1}
-    shift
-  fi
+assertCapturedError() {
+	if [[ $# -gt 1 ]]; then
+		local expectedErrorCode=${1}
+		shift
+	fi
 
-  local expectedErrorMsg=${1:-""}
+	local expectedErrorMsg=${1:-""}
 
-  if [ -z ${expectedErrorCode} ]; then
-    assertTrue "Expected captured exit code to be greater than 0; was <${RETURN}>" "[ ${RETURN} -gt 0 ]"
-  else
-    assertTrue "Expected captured exit code to be <${expectedErrorCode}>; was <${RETURN}>" "[ ${RETURN} -eq ${expectedErrorCode} ]"
-  fi
+	if [[ -z "${expectedErrorCode}" ]]; then
+		assertTrue "Expected captured exit code to be greater than 0; was <${RETURN}>" "[ ${RETURN} -gt 0 ]"
+	else
+		assertTrue "Expected captured exit code to be <${expectedErrorCode}>; was <${RETURN}>" "[ ${RETURN} -eq ${expectedErrorCode} ]"
+	fi
 
-  if [ "${expectedErrorMsg}" != "" ]; then
-    assertFileContains "Expected STD_ERR to contain error <${expectedErrorMsg}>" "${expectedErrorMsg}" "${STD_ERR}"
-  fi
+	if [[ "${expectedErrorMsg}" != "" ]]; then
+		assertFileContains "Expected STD_ERR to contain error <${expectedErrorMsg}>" "${expectedErrorMsg}" "${STD_ERR}"
+	fi
 }
 
-_assertContains()
-{
-  if [ 5 -eq $# ]; then
-    local msg=$1
-    shift
-  elif [ ! 4 -eq $# ]; then
-    fail "Expected 4 or 5 parameters; Receieved $# parameters"
-  fi
+_assertContains() {
+	if [[ 5 -eq $# ]]; then
+		local msg=$1
+		shift
+	elif [[ ! 4 -eq $# ]]; then
+		fail "Expected 4 or 5 parameters; Receieved $# parameters"
+	fi
 
-  local needle=$1
-  local haystack=$2
-  local expectation=$3
-  local haystack_type=$4
+	local needle=$1
+	local haystack=$2
+	local expectation=$3
+	local haystack_type=$4
 
-  case "${haystack_type}" in
-    "file") grep -q -F -e "${needle}" ${haystack} ;;
-    "text") echo "${haystack}" | grep -q -F -e "${needle}" ;;
-  esac
+	case "${haystack_type}" in
+		"file") grep -q -F -e "${needle}" "${haystack}" ;;
+		"text") echo "${haystack}" | grep -q -F -e "${needle}" ;;
+	esac
 
-  if [ "${expectation}" != "$?" ]; then
-    case "${expectation}" in
-      0) default_msg="Expected <${haystack}> to contain <${needle}>" ;;
-      1) default_msg="Did not expect <${haystack}> to contain <${needle}>" ;;
-    esac
+	if [[ "${expectation}" != "$?" ]]; then
+		case "${expectation}" in
+			0) default_msg="Expected <${haystack}> to contain <${needle}>" ;;
+			1) default_msg="Did not expect <${haystack}> to contain <${needle}>" ;;
+		esac
 
-    fail "${msg:-${default_msg}}"
-  fi
+		fail "${msg:-${default_msg}}"
+	fi
 }
 
-assertFileContains()
-{
-  _assertContains "$@" 0 "file"
+assertFileContains() {
+	_assertContains "$@" 0 "file"
 }
 
-assertFileNotContains()
-{
-  _assertContains "$@" 1 "file"
+assertFileNotContains() {
+	_assertContains "$@" 1 "file"
 }
 
-assertFileContainsMatch()
-{
-  local needle=$1
-  local haystack=$2
+assertFileContainsMatch() {
+	local needle=$1
+	local haystack=$2
 
-  grep -q -E -e "${needle}" ${haystack}
-  if [ "$?" != 0 ]; then
-    fail "Expected <${haystack}> to contain <${needle}>"
-  fi
+	grep -q -E -e "${needle}" "${haystack}"
+	if [[ "$?" != 0 ]]; then
+		fail "Expected <${haystack}> to contain <${needle}>"
+	fi
 }
 
-command_exists () {
-    type "$1" > /dev/null 2>&1 ;
+command_exists() {
+	type "$1" >/dev/null 2>&1
 }
 
-assertFileMD5()
-{
-  expectedHash=$1
-  filename=$2
+assertFileMD5() {
+	expectedHash=$1
+	filename=$2
 
-  if command_exists "md5sum"; then
-    md5_cmd="md5sum ${filename}"
-    expected_md5_cmd_output="${expectedHash}  ${filename}"
-  elif command_exists "md5"; then
-    md5_cmd="md5 ${filename}"
-    expected_md5_cmd_output="MD5 (${filename}) = ${expectedHash}"
-  else
-    fail "no suitable MD5 hashing command found on this system"
-  fi
+	if command_exists "md5sum"; then
+		md5_cmd="md5sum ${filename}"
+		expected_md5_cmd_output="${expectedHash}  ${filename}"
+	elif command_exists "md5"; then
+		md5_cmd="md5 ${filename}"
+		expected_md5_cmd_output="MD5 (${filename}) = ${expectedHash}"
+	else
+		fail "no suitable MD5 hashing command found on this system"
+	fi
 
-  assertEquals "${expected_md5_cmd_output}" "$(${md5_cmd})"
+	assertEquals "${expected_md5_cmd_output}" "$(${md5_cmd})"
 }
 
 assertDirectoryExists() {
-  if [[ ! -e "$1" ]]; then
-    fail "$1 does not exist"
-  fi
-  if [[ ! -d $1 ]]; then
-    fail "$1 is not a directory"
-  fi
+	if [[ ! -e "$1" ]]; then
+		fail "$1 does not exist"
+	fi
+	if [[ ! -d $1 ]]; then
+		fail "$1 is not a directory"
+	fi
 }
 
-assertFileExists()
-{
-  filename=$1
-  assertTrue "$filename doesn't exist" "[[ -e $filename ]]"
+assertFileExists() {
+	filename=$1
+	assertTrue "${filename} doesn't exist" "[[ -e ${filename} ]]"
 }
 
-assertFileDoesNotExist()
-{
-  filename=$1
-  assertTrue "$filename exists" "[[ ! -e $filename ]]"
+assertFileDoesNotExist() {
+	filename=$1
+	assertTrue "${filename} exists" "[[ ! -e ${filename} ]]"
 }
 
 assertCapturedTimes() {
-  expected_times="$1"
-  capture_text="$2"
-  actual_times=$(grep --only-matching --regexp "$capture_text" "$STD_OUT" | wc -l)
-  assertEquals "Expected '$capture_text' text to appear $expected_times times; it appeared <$actual_times> times" "$expected_times" "$actual_times"
+	expected_times="$1"
+	capture_text="$2"
+	actual_times=$(grep --only-matching --regexp "${capture_text}" "${STD_OUT}" | wc -l)
+	assertEquals "Expected '${capture_text}' text to appear ${expected_times} times; it appeared <${actual_times}> times" "${expected_times}" "${actual_times}"
 }
 
 # Asserts that the metrics JSON file contains the expected values using jq queries
@@ -242,92 +219,95 @@ assertCapturedTimes() {
 #     select(.cache_status == "not-found")
 #   EOF
 assertMetrics() {
-  local cache_dir="$1"
-  local metrics_file="${cache_dir}/build-data/nodejs.json"
-  local expected_metrics=""
-  local checked_keys=()
-  
-  # Check if cache_dir is provided
-  if [ -z "$cache_dir" ]; then
-    fail "assertMetrics: cache_dir argument is required"
-  fi
-  
-  # Check if metrics file exists
-  if [ ! -f "$metrics_file" ]; then
-    fail "Metrics file not found: $metrics_file"
-  fi
-  
-  # Read expected_metrics from stdin (HEREDOC style)
-  if [ -t 0 ]; then
-    fail "assertMetrics: expected metrics must be provided via stdin (HEREDOC)"
-  fi
-  
-  expected_metrics=$(cat)
-  
-  # Process each line of expected_metrics
-  while IFS= read -r line; do
-    # Skip empty lines and lines with only whitespace
-    if [[ -z "$line" || "$line" =~ ^[[:space:]]*$ ]]; then
-      continue
-    fi
-    
-    # Execute the jq query
-    local query_result
-    query_result=$(jq -r "$line" "$metrics_file" 2>/dev/null)
-    
-    if [ $? -ne 0 ] || [ "$query_result" = "null" ] || [ "$query_result" = "" ]; then
-      fail "jq query failed: '$line' on file $metrics_file. File contents: $(jq --sort-keys '.' "${metrics_file}")"
-    fi
-    
-    # Extract the key from the jq query
-    local key=""
-    if [[ "$line" =~ select\(\.([a-zA-Z_][a-zA-Z0-9_]*)\s* ]]; then
-      key="${BASH_REMATCH[1]}"
-    else
-      fail "Unable to extract key from jq query: '$line'. Expected format: 'select(.field_name ...)'"
-    fi
-    
-    # Add key to checked_keys array if it's not already there
-    if [[ ! " ${checked_keys[@]} " =~ " ${key} " ]]; then
-      checked_keys+=("$key")
-    fi
-  done <<< "$expected_metrics"
-  
-  # Get all keys from the JSON file
-  local all_keys
-  all_keys=$(jq -r 'keys[]' "$metrics_file" 2>/dev/null | sort)
-  
-  if [ $? -ne 0 ]; then
-    fail "Failed to extract keys from metrics file: $metrics_file"
-  fi
-  
-  # Find keys that weren't checked
-  local unchecked_keys=()
-  while IFS= read -r key; do
-    if [[ ! " ${checked_keys[@]} " =~ " ${key} " ]]; then
-      unchecked_keys+=("$key")
-    fi
-  done <<< "$all_keys"
-  
-  # If there are unchecked keys, fail with details
-  if [ ${#unchecked_keys[@]} -gt 0 ]; then
-    local unchecked_list
-    mapfile -t unchecked_list < <(printf '%s\n' "${unchecked_keys[@]}" | sort)
-    fail "The following keys in the metrics file were not checked: [$(IFS=,; echo "${unchecked_list[*]}")]. File contents: $(jq --sort-keys '.' "${metrics_file}")"
-  fi
+	local cache_dir="$1"
+	local metrics_file="${cache_dir}/build-data/nodejs.json"
+	local expected_metrics=""
+	local checked_keys=()
+
+	# Check if cache_dir is provided
+	if [[ -z "${cache_dir}" ]]; then
+		fail "assertMetrics: cache_dir argument is required"
+	fi
+
+	# Check if metrics file exists
+	if [[ ! -f "${metrics_file}" ]]; then
+		fail "Metrics file not found: ${metrics_file}"
+	fi
+
+	# Read expected_metrics from stdin (HEREDOC style)
+	if [[ -t 0 ]]; then
+		fail "assertMetrics: expected metrics must be provided via stdin (HEREDOC)"
+	fi
+
+	expected_metrics=$(cat)
+
+	# Process each line of expected_metrics
+	while IFS= read -r line; do
+		# Skip empty lines and lines with only whitespace
+		if [[ -z "${line}" || "${line}" =~ ^[[:space:]]*$ ]]; then
+			continue
+		fi
+
+		# Execute the jq query
+		local query_result
+		query_result=$(jq -r "${line}" "${metrics_file}" 2>/dev/null)
+
+		if [[ $? -ne 0 ]] || [[ "${query_result}" = "null" ]] || [[ "${query_result}" = "" ]]; then
+			fail "jq query failed: '${line}' on file ${metrics_file}. File contents: $(jq --sort-keys '.' "${metrics_file}")"
+		fi
+
+		# Extract the key from the jq query
+		local key=""
+		if [[ "${line}" =~ select\(\.([a-zA-Z_][a-zA-Z0-9_]*)\s* ]]; then
+			key="${BASH_REMATCH[1]}"
+		else
+			fail "Unable to extract key from jq query: '${line}'. Expected format: 'select(.field_name ...)'"
+		fi
+
+		# Add key to checked_keys array if it's not already there
+		if [[ ! " ${checked_keys[@]} " =~ " ${key} " ]]; then
+			checked_keys+=("${key}")
+		fi
+	done <<<"${expected_metrics}"
+
+	# Get all keys from the JSON file
+	local all_keys
+	all_keys=$(jq -r 'keys[]' "${metrics_file}" 2>/dev/null | sort)
+
+	if [[ $? -ne 0 ]]; then
+		fail "Failed to extract keys from metrics file: ${metrics_file}"
+	fi
+
+	# Find keys that weren't checked
+	local unchecked_keys=()
+	while IFS= read -r key; do
+		if [[ ! " ${checked_keys[@]} " =~ " ${key} " ]]; then
+			unchecked_keys+=("${key}")
+		fi
+	done <<<"${all_keys}"
+
+	# If there are unchecked keys, fail with details
+	if [[ ${#unchecked_keys[@]} -gt 0 ]]; then
+		local unchecked_list
+		mapfile -t unchecked_list < <(printf '%s\n' "${unchecked_keys[@]}" | sort)
+		fail "The following keys in the metrics file were not checked: [$(
+			IFS=,
+			echo "${unchecked_list[*]}"
+		)]. File contents: $(jq --sort-keys '.' "${metrics_file}")"
+	fi
 }
 
 assertMetricEqualsString() {
-  assertMetricEqualsRaw "$1" "$2" "\"$3\""
+	assertMetricEqualsRaw "$1" "$2" "\"$3\""
 }
 
 assertMetricEqualsRaw() {
-  local cache_dir="$1"
-  local field="$2"
-  local value="$3"
-  local metrics_file="${cache_dir}/build-data/nodejs.json"
-  query_result=$(jq -r "select(.${field} == ${value})" "$metrics_file" 2>/dev/null)
-  if [ $? -ne 0 ] || [ "$query_result" = "null" ] || [ "$query_result" = "" ]; then
-    fail "expected metric '${field}' to equal '${value}' but was '$(jq -r ".${field}" "$metrics_file" 2>/dev/null)'"
-  fi
+	local cache_dir="$1"
+	local field="$2"
+	local value="$3"
+	local metrics_file="${cache_dir}/build-data/nodejs.json"
+	query_result=$(jq -r "select(.${field} == ${value})" "${metrics_file}" 2>/dev/null)
+	if [[ $? -ne 0 ]] || [[ "${query_result}" = "null" ]] || [[ "${query_result}" = "" ]]; then
+		fail "expected metric '${field}' to equal '${value}' but was '$(jq -r ".${field}" "${metrics_file}" 2>/dev/null)'"
+	fi
 }


### PR DESCRIPTION
This is the final step of the shell-linting migration. With the build-time and runtime scripts already migrated, the remaining support and test scripts (`ci-profile/`, `etc/`, and `test/`) are the last ones outside the framework. Bringing them in lets the migration retire the `MIGRATED_FILES` allowlist entirely — the makefile now discovers every shell script via `shfmt -f` and lints/formats the whole tree, so a new script is covered by CI automatically instead of only once someone remembers to add it to the list. The sole exclusion is the vendored upstream `test/shunit2`.

Like the profile scripts, these support/test files are lint/format-only — no namespace renaming, no strict-mode flags. Findings outside a mechanical migration (subshell-scope and test-fixture style nits) are suppressed with per-file `shellcheck disable` directives that document why, so the allowlist can be dropped without folding a large behavioral change into the same PR.

Stacked on #1776.
