### PR TITLE
Fix pnpm install by using `--no-prod` instead of `--prod=false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed `pnpm install` failing under pnpm 12 by replacing the legacy `--prod=false` flag with `--no-prod`. ([#1796](https://github.com/heroku/heroku-buildpack-nodejs/pull/1796))
+
 
 ## [v365] - 2026-08-27
 

--- a/lib/package_managers/pnpm.sh
+++ b/lib/package_managers/pnpm.sh
@@ -18,7 +18,7 @@ package_managers::pnpm::install_dependencies() {
 	output::info "Running 'pnpm install' with pnpm-lock.yaml"
 	cd "${build_dir}" || return
 
-	pnpm_install_args=("install" "--prod=false" "--frozen-lockfile")
+	pnpm_install_args=("install" "--no-prod" "--frozen-lockfile")
 
 	if [[ -n "${PNPM_INSTALL_REPORTER}" ]]; then
 		case "${PNPM_INSTALL_REPORTER}" in

--- a/test/fixtures/pnpm-12/package.json
+++ b/test/fixtures/pnpm-12/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-12",
+  "packageManager": "pnpm@12.3.4+sha512.961aa41fb077da3a04a441d9f8e15ebc0c96da8ef710b2eb67bf9ee7cb0610eabd48f1fd85f51cffe73846785fa0f87c56a3a872a1d893f8446741b5cce45457"
+}

--- a/test/fixtures/pnpm-12/pnpm-lock.yaml
+++ b/test/fixtures/pnpm-12/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/test/run-pnpm
+++ b/test/run-pnpm
@@ -260,6 +260,22 @@ testPnpm11StoreDirExport() {
 	assertCapturedSuccessWithWarnings
 }
 
+testPnpm12StoreDirExport() {
+	cache_dir=$(mktmpdir)
+	env_dir=$(mktmpdir)
+	pnpm_config_cache="${cache_dir}/pnpm-store"
+	echo "${pnpm_config_cache}" >"${env_dir}/PNPM_CONFIG_CACHE"
+
+	compile "pnpm-12" "${cache_dir}" "${env_dir}"
+
+	assertFileContains "export pnpm_config_store_dir=\"${pnpm_config_cache}\"" "${bp_dir}/export"
+	assertFileNotContains "export npm_config_store_dir=" "${bp_dir}/export"
+	actual_store_dir=$(source "${bp_dir}/export" && cd "${compile_dir}" && pnpm config get store-dir)
+	assertEquals "${pnpm_config_cache}" "${actual_store_dir}"
+	assertNotCaptured "pnpm store cache may not work"
+	assertCapturedSuccessWithWarnings
+}
+
 testPnpmWithNoPackageManagerEntry() {
 	compile "pnpm-unknown-version"
 	assertCaptured "Downloading and installing pnpm (latest)"


### PR DESCRIPTION
pnpm 12 rewrote its CLI in Rust and no longer accepts `--prod=false`. `pnpm install --prod=false --frozen-lockfile` errors with `unexpected value 'false' for '--prod' found`, aborting the build.

Since pnpm 12's `latest` dist-tag promotion (on or around 2026-08-29), every pnpm functional-test job on `main` has been failing because the `pnpm-unknown-version` fixture resolves `pnpm@latest`.

Switching the flag to `--no-prod` fixes pnpm 12 install and remains accepted by all previously-tested pnpm versions.

Also adds an explicit pnpm 12 fixture and `testPnpm12StoreDirExport`, mirroring the existing pnpm-10 and pnpm-11 store-dir tests, so future pnpm 12 regressions get caught even when `latest` moves on.

| pnpm version | test fixture |
|---|---|
| `7.32.3` | `pnpm-7-pnp` |
| `8.4.0` | `pnpm-8-hoist`, `pnpm-with-corepack-and-engine` |
| `8.11.0` | `pnpm-8-nuxt` |
| `8.15.5` | `pnpm-8.15.5`, `pnpm-8.15.5-with-pre-post-install` |
| `8.15.6` | `pnpm-8.15.6-with-pre-post-install` |
| `9.5.0` | `pnpm-workspace-binaries` |
| `9.7.1` | `pnpm-empty-deps` |
| `10.5.0` | `pnpm-workspace-file-exists-but-not-configured-as-workspace` |
| `10.12.4` | `pnpm-custom-cache` |
| `10.28.2` | `pnpm-workspace-with-lifecycle-script-project`, `pnpm-workspace-with-lifecycle-script-root` |
| `10.33.3` | `pnpm-10` |
| `11.0.5` | `pnpm-11` |
| `12.3.4` | `pnpm-12`, `pnpm-unknown-version` (via `pnpm@latest`) |

GUS-W-24136881