### PR TITLE
Disable `testPnpmWithNoPackageManagerEntry` while `pnpm@latest` is broken

### DIFF
--- a/test/run-pnpm
+++ b/test/run-pnpm
@@ -260,7 +260,11 @@ testPnpm11StoreDirExport() {
 	assertCapturedSuccessWithWarnings
 }
 
-testPnpmWithNoPackageManagerEntry() {
+# Disabled while pnpm@latest is broken. pnpm 12 (currently `latest`) errors on
+# `pnpm install --prod=false`. Upstream fix at
+# https://github.com/pnpm/pnpm/issues/14553 has been merged but not released.
+# Rename back to the original once a fixed pnpm 12 ships.
+disabled_testPnpmWithNoPackageManagerEntry() {
 	compile "pnpm-unknown-version"
 	assertCaptured "Downloading and installing pnpm (latest)"
 	assertCaptured "Using pnpm"

--- a/test/run-pnpm
+++ b/test/run-pnpm
@@ -262,8 +262,8 @@ testPnpm11StoreDirExport() {
 
 # Disabled while pnpm@latest is broken. pnpm 12 (currently `latest`) errors on
 # `pnpm install --prod=false`. Upstream fix at
-# https://github.com/pnpm/pnpm/issues/14553 has been merged but not released.
-# Rename back to the original once a fixed pnpm 12 ships.
+# https://github.com/pnpm/pnpm/issues/14553 shipped in pnpm 12.4, but is not
+# yet the `latest` dist-tag. Rename back to the original once 12.4 is `latest`.
 disabled_testPnpmWithNoPackageManagerEntry() {
 	compile "pnpm-unknown-version"
 	assertCaptured "Downloading and installing pnpm (latest)"


### PR DESCRIPTION
`testPnpmWithNoPackageManagerEntry` uses the `pnpm-unknown-version` fixture, which the buildpack resolves to `pnpm@latest`. Since pnpm 12 became `latest`, `pnpm install --prod=false` errors and the test fails on every CI run.

The upstream fix (https://github.com/pnpm/pnpm/issues/14553) shipped in pnpm `12.4`, but that version is not yet the `latest` dist-tag. Renaming the test so shunit2 skips it keeps CI green until pnpm 12.4 is promoted to `latest`, at which point the rename can be reverted.

GUS-W-24136881